### PR TITLE
fix: hassfest validation and ruff formatting

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -9,6 +9,7 @@ Supports both YAML configuration and UI-based config flow.
 
 import logging
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
@@ -19,9 +20,11 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor"]
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the NeverDry integration from YAML."""
+    """Set up the NeverDry integration."""
     hass.data.setdefault(DOMAIN, {})
     return True
 

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -194,9 +194,7 @@ STEP_ZONE_SCHEMA = vol.Schema(
         vol.Optional(CONF_ZONE_FLOW_METER_SENSOR): selector.EntitySelector(
             selector.EntitySelectorConfig(domain="sensor")
         ),
-        vol.Optional(CONF_ZONE_VOLUME_ENTITY): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain="number")
-        ),
+        vol.Optional(CONF_ZONE_VOLUME_ENTITY): selector.EntitySelector(selector.EntitySelectorConfig(domain="number")),
         vol.Optional(CONF_ZONE_DELIVERY_TIMEOUT, default=DEFAULT_DELIVERY_TIMEOUT_S): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=60,

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -323,7 +323,8 @@ class IrrigationController:
 
         # Send volume target to the number entity
         await self._hass.services.async_call(
-            "number", "set_value",
+            "number",
+            "set_value",
             {"entity_id": volume_entity, "value": round(volume, 1)},
         )
         zone.set_irrigating(True)
@@ -348,7 +349,8 @@ class IrrigationController:
         else:
             _LOGGER.warning(
                 "Zone '%s' volume_preset timeout (%ds). Forcing valve close.",
-                zone.zone_name, timeout,
+                zone.zone_name,
+                timeout,
             )
             await self._close_valve(zone.valve)
 
@@ -372,7 +374,8 @@ class IrrigationController:
         if initial_reading is None:
             _LOGGER.error(
                 "Flow meter '%s' unavailable for zone '%s', skipping",
-                meter_entity, zone.zone_name,
+                meter_entity,
+                zone.zone_name,
             )
             return False
 
@@ -396,7 +399,8 @@ class IrrigationController:
             if current_reading is None:
                 _LOGGER.warning(
                     "Flow meter '%s' became unavailable during irrigation of zone '%s'",
-                    meter_entity, zone.zone_name,
+                    meter_entity,
+                    zone.zone_name,
                 )
                 continue
 
@@ -412,7 +416,8 @@ class IrrigationController:
         else:
             _LOGGER.warning(
                 "Zone '%s' flow_meter timeout (%ds). Closing valve.",
-                zone.zone_name, timeout,
+                zone.zone_name,
+                timeout,
             )
 
         await self._close_valve(zone.valve)

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "never_dry",
   "name": "NeverDry",
-  "version": "0.2.0",
-  "documentation": "https://github.com/drake69/NeverDry",
-  "requirements": [],
-  "dependencies": [],
   "codeowners": ["@drake69"],
-  "iot_class": "local_push",
   "config_flow": true,
-  "issue_tracker": "https://github.com/drake69/NeverDry/issues"
+  "dependencies": [],
+  "documentation": "https://github.com/drake69/NeverDry",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/drake69/NeverDry/issues",
+  "requirements": [],
+  "version": "0.2.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,14 +64,21 @@ def _create_ha_stubs():
     entity_platform_mod = ModuleType("homeassistant.helpers.entity_platform")
     entity_platform_mod.AddEntitiesCallback = MagicMock
 
+    # homeassistant.helpers.config_validation
+    cv_mod = ModuleType("homeassistant.helpers.config_validation")
+    cv_mod.config_entry_only_config_schema = lambda domain: {}
+
     # Register all stubs
+    helpers_mod = ModuleType("homeassistant.helpers")
+    helpers_mod.config_validation = cv_mod
     mods = {
         "homeassistant": ModuleType("homeassistant"),
         "homeassistant.components": ModuleType("homeassistant.components"),
         "homeassistant.components.sensor": sensor_mod,
         "homeassistant.config_entries": config_entries_mod,
         "homeassistant.core": core_mod,
-        "homeassistant.helpers": ModuleType("homeassistant.helpers"),
+        "homeassistant.helpers": helpers_mod,
+        "homeassistant.helpers.config_validation": cv_mod,
         "homeassistant.helpers.entity_platform": entity_platform_mod,
         "homeassistant.helpers.event": event_mod,
         "homeassistant.helpers.restore_state": restore_mod,

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -85,7 +85,8 @@ class TestVolumePresetDelivery:
     @pytest.mark.asyncio
     async def test_sends_volume_to_number_entity(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
                 CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
@@ -105,7 +106,8 @@ class TestVolumePresetDelivery:
         assert result is True
         # Check number.set_value was called
         set_value_calls = [
-            c for c in hass_mock.services.async_call.call_args_list
+            c
+            for c in hass_mock.services.async_call.call_args_list
             if c.args[0] == "number" and c.args[1] == "set_value"
         ]
         assert len(set_value_calls) == 1
@@ -114,7 +116,8 @@ class TestVolumePresetDelivery:
     @pytest.mark.asyncio
     async def test_timeout_forces_close(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
                 CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
@@ -139,7 +142,8 @@ class TestVolumePresetDelivery:
     @pytest.mark.asyncio
     async def test_no_volume_entity_returns_false(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET},
         )
         zone._zone_deficit = 5.0
@@ -152,7 +156,8 @@ class TestVolumePresetDelivery:
     @pytest.mark.asyncio
     async def test_stop_during_preset(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
                 CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
@@ -179,7 +184,8 @@ class TestFlowMeterDelivery:
     @pytest.mark.asyncio
     async def test_closes_at_target_volume(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
                 CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
@@ -212,7 +218,8 @@ class TestFlowMeterDelivery:
     @pytest.mark.asyncio
     async def test_unavailable_sensor_skips(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
                 CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
@@ -235,7 +242,8 @@ class TestFlowMeterDelivery:
     @pytest.mark.asyncio
     async def test_no_flow_meter_entity_returns_false(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER},
         )
         zone._zone_deficit = 5.0
@@ -248,7 +256,8 @@ class TestFlowMeterDelivery:
     @pytest.mark.asyncio
     async def test_meter_reset_adjusts_baseline(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
                 CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
@@ -278,7 +287,8 @@ class TestFlowMeterDelivery:
     @pytest.mark.asyncio
     async def test_stop_during_flow_meter(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
                 CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
@@ -335,7 +345,8 @@ class TestDurationByMode:
 
     def test_flow_meter_zero_duration(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER},
         )
         zone._zone_deficit = 5.0
@@ -343,7 +354,8 @@ class TestDurationByMode:
 
     def test_volume_preset_zero_duration(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET},
         )
         zone._zone_deficit = 5.0
@@ -359,7 +371,8 @@ class TestDeliveryModeAttributes:
 
     def test_volume_entity_in_attributes(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
                 CONF_ZONE_VOLUME_ENTITY: "number.valve_vol",
@@ -371,7 +384,8 @@ class TestDeliveryModeAttributes:
 
     def test_flow_meter_in_attributes(self, hass_mock, di_sensor):
         zone = _make_zone(
-            hass_mock, di_sensor,
+            hass_mock,
+            di_sensor,
             **{
                 CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
                 CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow",


### PR DESCRIPTION
## Summary
- Sort manifest.json keys per hassfest requirements (domain, name, then alphabetical)
- Add `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` to satisfy hassfest
- Add `config_validation` stub to test conftest
- Ruff auto-format for 3 files from delivery modes feature

## Test plan
- [x] 170 tests pass locally
- [ ] Hassfest workflow passes
- [ ] Lint workflow passes