### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0 for new release

After merge, tag `v0.3.0` will trigger the release workflow.