### PR TITLE
feat: per-zone Mark as irrigated button entity

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -18,7 +18,7 @@ from .const import CONFIG_VERSION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "button"]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -1,0 +1,70 @@
+"""Button platform for the NeverDry integration.
+
+Provides a "Mark as irrigated" button for each configured irrigation zone.
+When pressed, resets the zone's deficit to zero via the mark_irrigated service.
+"""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    ATTR_ZONE_NAME,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+    DOMAIN,
+    SERVICE_MARK_IRRIGATED,
+)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities,
+    discovery_info=None,
+) -> None:
+    """Set up the NeverDry buttons from YAML configuration."""
+    async_add_entities(_create_buttons(hass, config), True)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the NeverDry buttons from a config entry (UI)."""
+    async_add_entities(_create_buttons(hass, dict(entry.data)), True)
+
+
+def _create_buttons(hass: HomeAssistant, config: dict) -> list[ButtonEntity]:
+    """Create button entities for each configured zone."""
+    buttons: list[ButtonEntity] = []
+    for zone_conf in config.get(CONF_ZONES, []):
+        zone_name = zone_conf[CONF_ZONE_NAME]
+        buttons.append(MarkIrrigatedButton(hass, zone_name))
+    return buttons
+
+
+class MarkIrrigatedButton(ButtonEntity):
+    """Button to mark a zone as manually irrigated."""
+
+    _attr_icon = "mdi:water-check"
+
+    def __init__(self, hass: HomeAssistant, zone_name: str) -> None:
+        self._hass = hass
+        self._zone_name = zone_name
+        slug = zone_name.lower().replace(" ", "_")
+        self._attr_name = f"Mark {zone_name} irrigated"
+        self._attr_unique_id = f"mark_irrigated_{slug}"
+
+    async def async_press(self) -> None:
+        """Handle the button press — reset zone deficit."""
+        await self._hass.services.async_call(
+            DOMAIN,
+            SERVICE_MARK_IRRIGATED,
+            {ATTR_ZONE_NAME: self._zone_name},
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,12 +68,23 @@ def _create_ha_stubs():
     cv_mod = ModuleType("homeassistant.helpers.config_validation")
     cv_mod.config_entry_only_config_schema = lambda domain: {}
 
+    # homeassistant.components.button
+    button_mod = ModuleType("homeassistant.components.button")
+    button_mod.ButtonEntity = type(
+        "ButtonEntity",
+        (),
+        {
+            "async_press": lambda self: None,
+        },
+    )
+
     # Register all stubs
     helpers_mod = ModuleType("homeassistant.helpers")
     helpers_mod.config_validation = cv_mod
     mods = {
         "homeassistant": ModuleType("homeassistant"),
         "homeassistant.components": ModuleType("homeassistant.components"),
+        "homeassistant.components.button": button_mod,
         "homeassistant.components.sensor": sensor_mod,
         "homeassistant.config_entries": config_entries_mod,
         "homeassistant.core": core_mod,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,6 +1,6 @@
 """Tests for MarkIrrigatedButton entities."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from never_dry.button import MarkIrrigatedButton, _create_buttons

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,82 @@
+"""Tests for MarkIrrigatedButton entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from never_dry.button import MarkIrrigatedButton, _create_buttons
+from never_dry.const import (
+    ATTR_ZONE_NAME,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+    DOMAIN,
+    SERVICE_MARK_IRRIGATED,
+)
+
+
+class TestButtonCreation:
+    """Test button entity creation."""
+
+    def test_creates_one_button_per_zone(self, hass_mock):
+        config = {
+            CONF_ZONES: [
+                {CONF_ZONE_NAME: "Orto"},
+                {CONF_ZONE_NAME: "Prato"},
+            ]
+        }
+        buttons = _create_buttons(hass_mock, config)
+        assert len(buttons) == 2
+
+    def test_no_buttons_without_zones(self, hass_mock):
+        buttons = _create_buttons(hass_mock, {})
+        assert len(buttons) == 0
+
+    def test_no_buttons_empty_zones(self, hass_mock):
+        buttons = _create_buttons(hass_mock, {CONF_ZONES: []})
+        assert len(buttons) == 0
+
+
+class TestButtonProperties:
+    """Test button entity attributes."""
+
+    def test_name(self, hass_mock):
+        btn = MarkIrrigatedButton(hass_mock, "Orto")
+        assert btn._attr_name == "Mark Orto irrigated"
+
+    def test_unique_id(self, hass_mock):
+        btn = MarkIrrigatedButton(hass_mock, "Orto")
+        assert btn._attr_unique_id == "mark_irrigated_orto"
+
+    def test_unique_id_with_spaces(self, hass_mock):
+        btn = MarkIrrigatedButton(hass_mock, "Vegetable Garden")
+        assert btn._attr_unique_id == "mark_irrigated_vegetable_garden"
+
+    def test_icon(self, hass_mock):
+        btn = MarkIrrigatedButton(hass_mock, "Orto")
+        assert btn._attr_icon == "mdi:water-check"
+
+
+class TestButtonPress:
+    """Test button press behavior."""
+
+    @pytest.mark.asyncio
+    async def test_press_calls_mark_irrigated_service(self, hass_mock):
+        hass_mock.services.async_call = AsyncMock()
+        btn = MarkIrrigatedButton(hass_mock, "Orto")
+
+        await btn.async_press()
+
+        hass_mock.services.async_call.assert_called_once_with(
+            DOMAIN,
+            SERVICE_MARK_IRRIGATED,
+            {ATTR_ZONE_NAME: "Orto"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_press_passes_correct_zone_name(self, hass_mock):
+        hass_mock.services.async_call = AsyncMock()
+        btn = MarkIrrigatedButton(hass_mock, "Vegetable Garden")
+
+        await btn.async_press()
+
+        call_args = hass_mock.services.async_call.call_args
+        assert call_args.args[2][ATTR_ZONE_NAME] == "Vegetable Garden"


### PR DESCRIPTION
## Summary
- New `ButtonEntity` per irrigation zone: "Mark {zone} irrigated"
- When pressed, calls `mark_irrigated` service to reset zone deficit
- No valve operation, just deficit reset — for manual irrigation signaling
- Icon: `mdi:water-check`
- 9 new tests (179 total)

## Test plan
- [x] 179 tests pass locally
- [ ] CI passes (tests, lint, hassfest, HACS)
- [ ] Button appears in HA dashboard per zone after restart
- [ ] Pressing button resets zone deficit to 0