### PR TITLE
feat: alert on anomalous deficit (possible malfunction)

### DIFF
--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -112,6 +112,7 @@ DEFAULT_KC = 1.0
 DEFAULT_RAIN_SENSOR_TYPE = RAIN_TYPE_EVENT
 DEFAULT_BACKFILL_DAYS = 90
 DEFAULT_BATTERY_LOW_THRESHOLD = 15  # percent
+ANOMALY_DEFICIT_MULTIPLIER = 2  # alert when deficit > threshold * this
 CONF_BACKFILL_DAYS = "backfill_days"
 
 # ── Runtime safety limits ────────────────────────────────

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.event import (
 )
 
 from .const import (
+    ANOMALY_DEFICIT_MULTIPLIER,
     ATTR_ZONE_NAME,
     DEFAULT_BATTERY_LOW_THRESHOLD,
     DEFAULT_INTER_ZONE_DELAY,
@@ -81,6 +82,8 @@ class IrrigationController:
         }
         # Track which zones have already been alerted for low battery
         self._battery_alerted: set[str] = set()
+        # Track which zones have already been alerted for anomalous deficit
+        self._deficit_anomaly_alerted: set[str] = set()
 
     @property
     def is_monitoring_mode(self) -> bool:
@@ -115,10 +118,17 @@ class IrrigationController:
         if battery_entities:
             async_track_state_change_event(self._hass, battery_entities, self._on_battery_change)
 
+        # Periodic deficit anomaly check (all modes, every 6h)
+        from datetime import timedelta
+
+        async_track_time_interval(
+            self._hass,
+            self._check_deficit_anomaly,
+            timedelta(hours=6),
+        )
+
         # Start monitoring mode if no valves are configured
         if self._monitoring_mode:
-            from datetime import timedelta
-
             _LOGGER.info(
                 "No valves configured — running in monitoring mode. "
                 "Irrigation alerts will be sent every 6 hours when needed."
@@ -613,6 +623,46 @@ class IrrigationController:
         else:
             # Battery recovered (e.g. replaced) — reset alert
             self._battery_alerted.discard(zone_name)
+
+    # ── Deficit anomaly detection ─────────────────────────
+
+    async def _check_deficit_anomaly(self, now=None) -> None:
+        """Alert when a zone's deficit is anomalously high (possible malfunction).
+
+        Called every 6 hours in all modes. Alerts once per zone until
+        the deficit drops back below the anomaly threshold.
+        """
+        for zs in self._zones.values():
+            threshold = zs.extra_state_attributes.get("threshold_mm", DEFAULT_THRESHOLD)
+            anomaly_limit = threshold * ANOMALY_DEFICIT_MULTIPLIER
+            zone_deficit = zs._zone_deficit
+
+            if zone_deficit >= anomaly_limit:
+                if zs.zone_name not in self._deficit_anomaly_alerted:
+                    self._deficit_anomaly_alerted.add(zs.zone_name)
+                    await self._hass.services.async_call(
+                        "persistent_notification",
+                        "create",
+                        {
+                            "title": "Anomalous deficit — possible malfunction",
+                            "message": (
+                                f"Zone **{zs.zone_name}**: deficit {zone_deficit:.1f} mm "
+                                f"exceeds {anomaly_limit:.0f} mm "
+                                f"({ANOMALY_DEFICIT_MULTIPLIER}\u00d7 threshold). "
+                                f"Irrigation may not be working correctly. "
+                                f"Check valve, schedule, and HA logs."
+                            ),
+                            "notification_id": f"{DOMAIN}_anomaly_{zs.zone_name}",
+                        },
+                    )
+                    _LOGGER.warning(
+                        "Deficit anomaly: zone='%s', deficit=%.1fmm, limit=%.0fmm",
+                        zs.zone_name,
+                        zone_deficit,
+                        anomaly_limit,
+                    )
+            else:
+                self._deficit_anomaly_alerted.discard(zs.zone_name)
 
     # ── Monitoring mode (no valves) ──────────────────────
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -861,7 +861,7 @@ class TestDeficitAnomaly:
 
     @pytest.mark.asyncio
     async def test_alerts_when_deficit_exceeds_2x_threshold(self, hass_mock, di_sensor):
-        """Should alert when deficit > 2× threshold."""
+        """Should alert when deficit > 2x threshold."""
         ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=35.0, threshold=15.0)
         await ctrl._check_deficit_anomaly()
 
@@ -873,7 +873,7 @@ class TestDeficitAnomaly:
 
     @pytest.mark.asyncio
     async def test_no_alert_below_2x_threshold(self, hass_mock, di_sensor):
-        """Should not alert when deficit < 2× threshold."""
+        """Should not alert when deficit < 2x threshold."""
         ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=25.0, threshold=15.0)
         await ctrl._check_deficit_anomaly()
 
@@ -907,7 +907,7 @@ class TestDeficitAnomaly:
 
     @pytest.mark.asyncio
     async def test_exactly_at_2x_threshold_alerts(self, hass_mock, di_sensor):
-        """Deficit exactly at 2× threshold should trigger alert."""
+        """Deficit exactly at 2x threshold should trigger alert."""
         ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=30.0, threshold=15.0)
         await ctrl._check_deficit_anomaly()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -9,6 +9,7 @@ from never_dry.const import (
     CONF_ZONE_EFFICIENCY,
     CONF_ZONE_FLOW_RATE,
     CONF_ZONE_NAME,
+    CONF_ZONE_THRESHOLD,
     MIN_SERVICE_INTERVAL_S,
 )
 from never_dry.controller import IrrigationController
@@ -311,20 +312,23 @@ class TestMonitoringMode:
         assert controller.is_monitoring_mode is False
 
     def test_register_services_starts_monitor(self, hass_mock, di_sensor):
-        """In monitoring mode, register_services should start the periodic check."""
+        """In monitoring mode, register_services should start monitoring + anomaly timers."""
         from homeassistant.helpers.event import async_track_time_interval
 
+        async_track_time_interval.reset_mock()
         ctrl, _ = self._make_no_valve_controller(hass_mock, di_sensor)
         ctrl.register_services()
-        async_track_time_interval.assert_called_once()
+        # 2 calls: anomaly check (all modes) + monitoring check (monitoring mode only)
+        assert async_track_time_interval.call_count == 2
 
-    def test_register_services_no_monitor_with_valves(self, controller, hass_mock):
-        """With valves, register_services should NOT start the periodic check."""
+    def test_register_services_anomaly_only_with_valves(self, controller, hass_mock):
+        """With valves, register_services should start only the anomaly timer."""
         from homeassistant.helpers.event import async_track_time_interval
 
         async_track_time_interval.reset_mock()
         controller.register_services()
-        async_track_time_interval.assert_not_called()
+        # Only anomaly check, no monitoring check
+        async_track_time_interval.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_notify_when_deficit_above_threshold(self, hass_mock, di_sensor):
@@ -831,6 +835,83 @@ class TestValveMonitoringEdgeCases:
         assert "volume_liters" not in event_data
         assert "duration_s" not in event_data
         assert event_data["source"] == "manual"
+
+
+class TestDeficitAnomaly:
+    """Test anomalous deficit detection."""
+
+    def _make_controller(self, hass_mock, di_sensor, zone_deficit=0.0, threshold=15.0):
+        from never_dry.sensor import IrrigationZoneSensor
+
+        zone = IrrigationZoneSensor(
+            hass_mock,
+            {
+                CONF_ZONE_NAME: "Garden",
+                "valve": "switch.valve_garden",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_EFFICIENCY: 0.85,
+                CONF_ZONE_FLOW_RATE: 8.0,
+                CONF_ZONE_THRESHOLD: threshold,
+            },
+            di_sensor,
+        )
+        zone._zone_deficit = zone_deficit
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        return ctrl, zone
+
+    @pytest.mark.asyncio
+    async def test_alerts_when_deficit_exceeds_2x_threshold(self, hass_mock, di_sensor):
+        """Should alert when deficit > 2× threshold."""
+        ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=35.0, threshold=15.0)
+        await ctrl._check_deficit_anomaly()
+
+        hass_mock.services.async_call.assert_called_once()
+        call_args = hass_mock.services.async_call.call_args
+        assert call_args.args[0] == "persistent_notification"
+        assert "35.0 mm" in call_args.args[2]["message"]
+        assert "Garden" in ctrl._deficit_anomaly_alerted
+
+    @pytest.mark.asyncio
+    async def test_no_alert_below_2x_threshold(self, hass_mock, di_sensor):
+        """Should not alert when deficit < 2× threshold."""
+        ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=25.0, threshold=15.0)
+        await ctrl._check_deficit_anomaly()
+
+        hass_mock.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_alert_only_once(self, hass_mock, di_sensor):
+        """Should not re-alert for same zone."""
+        ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=40.0, threshold=15.0)
+        await ctrl._check_deficit_anomaly()
+        await ctrl._check_deficit_anomaly()
+
+        assert hass_mock.services.async_call.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_re_alerts_after_recovery(self, hass_mock, di_sensor):
+        """Should re-alert if deficit drops and rises again."""
+        ctrl, zone = self._make_controller(hass_mock, di_sensor, zone_deficit=40.0, threshold=15.0)
+        await ctrl._check_deficit_anomaly()
+        assert "Garden" in ctrl._deficit_anomaly_alerted
+
+        # Deficit recovers
+        zone._zone_deficit = 10.0
+        await ctrl._check_deficit_anomaly()
+        assert "Garden" not in ctrl._deficit_anomaly_alerted
+
+        # Deficit rises again
+        zone._zone_deficit = 35.0
+        await ctrl._check_deficit_anomaly()
+        assert hass_mock.services.async_call.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_2x_threshold_alerts(self, hass_mock, di_sensor):
+        """Deficit exactly at 2× threshold should trigger alert."""
+        ctrl, _ = self._make_controller(hass_mock, di_sensor, zone_deficit=30.0, threshold=15.0)
+        await ctrl._check_deficit_anomaly()
+
+        assert "Garden" in ctrl._deficit_anomaly_alerted
 
 
 class TestBatteryMonitoringEdgeCases:


### PR DESCRIPTION
## Summary
- Periodic check every 6h (all modes): alerts when zone deficit > 2× threshold
- Signals possible irrigation malfunction (valve failure, HA offline, schedule broken)
- Alert fires once per zone, resets when deficit recovers
- `ANOMALY_DEFICIT_MULTIPLIER = 2` in const.py (configurable)

## Test plan
- [x] Alert fires when deficit exceeds 2× threshold (35mm with 15mm threshold)
- [x] No alert when deficit below 2× threshold
- [x] Alert fires only once per zone
- [x] Re-alerts after deficit recovery and new rise
- [x] Exactly at 2× threshold triggers alert
- [x] Timer registered in both monitoring and valve modes