### PR TITLE
feat: group entities under HA devices

### DIFF
--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -1,7 +1,6 @@
 """Button platform for the NeverDry integration.
 
-Provides a "Mark as irrigated" button for each configured irrigation zone.
-When pressed, resets the zone's deficit to zero via the mark_irrigated service.
+Provides per-zone buttons: "Irrigate" and "Mark as irrigated".
 """
 
 from __future__ import annotations
@@ -9,6 +8,7 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
@@ -20,6 +20,14 @@ from .const import (
     SERVICE_IRRIGATE_ZONE,
     SERVICE_MARK_IRRIGATED,
 )
+
+
+def _zone_device_info(entry_id: str, zone_name: str) -> DeviceInfo:
+    """Device info matching the zone device created in sensor.py."""
+    slug = zone_name.lower().replace(" ", "_")
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{entry_id}_{slug}")},
+    )
 
 
 async def async_setup_platform(
@@ -38,16 +46,17 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the NeverDry buttons from a config entry (UI)."""
-    async_add_entities(_create_buttons(hass, dict(entry.data)), True)
+    async_add_entities(_create_buttons(hass, dict(entry.data), entry.entry_id), True)
 
 
-def _create_buttons(hass: HomeAssistant, config: dict) -> list[ButtonEntity]:
+def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -> list[ButtonEntity]:
     """Create button entities for each configured zone."""
     buttons: list[ButtonEntity] = []
     for zone_conf in config.get(CONF_ZONES, []):
         zone_name = zone_conf[CONF_ZONE_NAME]
-        buttons.append(MarkIrrigatedButton(hass, zone_name))
-        buttons.append(IrrigateButton(hass, zone_name))
+        device_info = _zone_device_info(entry_id, zone_name)
+        buttons.append(MarkIrrigatedButton(hass, zone_name, device_info))
+        buttons.append(IrrigateButton(hass, zone_name, device_info))
     return buttons
 
 
@@ -56,12 +65,14 @@ class MarkIrrigatedButton(ButtonEntity):
 
     _attr_icon = "mdi:water-check"
 
-    def __init__(self, hass: HomeAssistant, zone_name: str) -> None:
+    def __init__(self, hass: HomeAssistant, zone_name: str, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._zone_name = zone_name
         slug = zone_name.lower().replace(" ", "_")
         self._attr_name = f"Mark {zone_name} irrigated"
         self._attr_unique_id = f"mark_irrigated_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
 
     async def async_press(self) -> None:
         """Handle the button press — reset zone deficit."""
@@ -77,12 +88,14 @@ class IrrigateButton(ButtonEntity):
 
     _attr_icon = "mdi:sprinkler"
 
-    def __init__(self, hass: HomeAssistant, zone_name: str) -> None:
+    def __init__(self, hass: HomeAssistant, zone_name: str, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._zone_name = zone_name
         slug = zone_name.lower().replace(" ", "_")
         self._attr_name = f"Irrigate {zone_name}"
         self._attr_unique_id = f"irrigate_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
 
     async def async_press(self) -> None:
         """Handle the button press — start irrigation for this zone."""

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -67,6 +68,7 @@ from .const import (
     DEFAULT_T_BASE,
     DEFAULT_THRESHOLD,
     DELIVERY_MODE_ESTIMATED_FLOW,
+    DOMAIN,
     KC_ANCHOR_DAYS,
     PLANT_FAMILIES,
     RAIN_TYPE_EVENT,
@@ -140,17 +142,41 @@ def compute_kc(
 # ══════════════════════════════════════════════════════════
 
 
+def _hub_device_info(entry_id: str) -> DeviceInfo:
+    """Device info for the main NeverDry hub (ET + deficit sensors)."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry_id)},
+        name="NeverDry",
+        manufacturer="NeverDry",
+        model="Smart Watering Controller",
+    )
+
+
+def _zone_device_info(entry_id: str, zone_name: str) -> DeviceInfo:
+    """Device info for a zone (sensor + buttons grouped together)."""
+    slug = zone_name.lower().replace(" ", "_")
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{entry_id}_{slug}")},
+        name=f"NeverDry {zone_name}",
+        manufacturer="NeverDry",
+        model="Irrigation Zone",
+        via_device=(DOMAIN, entry_id),
+    )
+
+
 def _create_entities(
-    hass: HomeAssistant, config: dict
+    hass: HomeAssistant, config: dict, entry_id: str = "yaml"
 ) -> tuple[list[SensorEntity], DrynessIndexSensor, list[IrrigationZoneSensor]]:
     """Create sensor entities from a config dict (shared by YAML and UI)."""
-    et_sensor = ETSensor(hass, config)
-    di_sensor = DrynessIndexSensor(hass, config)
+    hub_device = _hub_device_info(entry_id)
+    et_sensor = ETSensor(hass, config, hub_device)
+    di_sensor = DrynessIndexSensor(hass, config, hub_device)
     entities: list[SensorEntity] = [et_sensor, di_sensor]
 
     zone_sensors: list[IrrigationZoneSensor] = []
     for zone_conf in config.get(CONF_ZONES, []):
-        zone_sensor = IrrigationZoneSensor(hass, zone_conf, di_sensor)
+        zone_device = _zone_device_info(entry_id, zone_conf[CONF_ZONE_NAME])
+        zone_sensor = IrrigationZoneSensor(hass, zone_conf, di_sensor, zone_device)
         zone_sensors.append(zone_sensor)
         entities.append(zone_sensor)
 
@@ -189,7 +215,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the NeverDry sensors from a config entry (UI)."""
     config = dict(entry.data)
-    entities, di_sensor, zone_sensors = _create_entities(hass, config)
+    entities, di_sensor, zone_sensors = _create_entities(hass, config, entry.entry_id)
     async_add_entities(entities, True)
     _setup_controller(hass, config, di_sensor, zone_sensors)
 
@@ -211,12 +237,14 @@ class ETSensor(SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:sun-thermometer"
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, config: ConfigType, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._temp_sensor = config[CONF_TEMP_SENSOR]
         self._alpha = config.get(CONF_ALPHA, DEFAULT_ALPHA)
         self._t_base = config.get(CONF_T_BASE, DEFAULT_T_BASE)
         self._value = 0.0
+        if device_info:
+            self._attr_device_info = device_info
 
     async def async_added_to_hass(self) -> None:
         """Register state change listener on temperature sensor."""
@@ -260,7 +288,7 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-percent-alert"
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, config: ConfigType, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._temp_sensor = config[CONF_TEMP_SENSOR]
         self._rain_sensor = config[CONF_RAIN_SENSOR]
@@ -276,6 +304,8 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         self._last_rain = 0.0  # tracks last rain reading for delta computation
         self._last_update = datetime.now()
         self._zone_listeners: list[Callable] = []
+        if device_info:
+            self._attr_device_info = device_info
 
     def register_zone_listener(self, listener: Callable) -> None:
         """Register a zone sensor callback for ET/rain broadcasts."""
@@ -561,6 +591,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         hass: HomeAssistant,
         zone_config: dict,
         dryness_sensor: DrynessIndexSensor,
+        device_info: DeviceInfo | None = None,
     ) -> None:
         self._hass = hass
         self._dryness = dryness_sensor
@@ -598,6 +629,8 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         slug = self._zone_name.lower().replace(" ", "_")
         self._attr_name = f"Irrigation {self._zone_name}"
         self._attr_unique_id = f"irrigation_zone_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
 
         # Register as listener on the dryness sensor
         dryness_sensor.register_zone_listener(self._on_et_update)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,9 +86,20 @@ def _create_ha_stubs():
     recorder_history_mod = ModuleType("homeassistant.components.recorder.history")
     recorder_history_mod.get_significant_states = MagicMock(return_value={})
 
+    # homeassistant.helpers.device_registry
+    device_registry_mod = ModuleType("homeassistant.helpers.device_registry")
+
+    class DeviceInfo(dict):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.__dict__.update(kwargs)
+
+    device_registry_mod.DeviceInfo = DeviceInfo
+
     # Register all stubs
     helpers_mod = ModuleType("homeassistant.helpers")
     helpers_mod.config_validation = cv_mod
+    helpers_mod.device_registry = device_registry_mod
     mods = {
         "homeassistant": ModuleType("homeassistant"),
         "homeassistant.components": ModuleType("homeassistant.components"),
@@ -101,6 +112,7 @@ def _create_ha_stubs():
         "homeassistant.helpers.entity_platform": entity_platform_mod,
         "homeassistant.helpers.event": event_mod,
         "homeassistant.helpers.restore_state": restore_mod,
+        "homeassistant.helpers.device_registry": device_registry_mod,
         "homeassistant.helpers.typing": typing_mod,
         "homeassistant.components.recorder": recorder_mod,
         "homeassistant.components.recorder.history": recorder_history_mod,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -89,6 +89,24 @@ class TestButtonPress:
         assert call_args.args[2][ATTR_ZONE_NAME] == "Vegetable Garden"
 
 
+class TestButtonDeviceInfo:
+    """Test device_info grouping."""
+
+    def test_buttons_have_device_info_from_create(self, hass_mock):
+        config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
+        buttons = _create_buttons(hass_mock, config, entry_id="test_entry")
+        for btn in buttons:
+            assert hasattr(btn, "_attr_device_info")
+            assert (DOMAIN, "test_entry_orto") in btn._attr_device_info["identifiers"]
+
+    def test_buttons_without_entry_id_have_yaml_device(self, hass_mock):
+        config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
+        buttons = _create_buttons(hass_mock, config)
+        for btn in buttons:
+            assert hasattr(btn, "_attr_device_info")
+            assert (DOMAIN, "yaml_orto") in btn._attr_device_info["identifiers"]
+
+
 class TestIrrigateButton:
     """Test irrigate button entity."""
 


### PR DESCRIPTION
## Summary
- Hub device **NeverDry** groups ET sensor + DrynessIndex sensor
- Per-zone device **NeverDry {zone}** groups zone sensor + Irrigate/Mark irrigated buttons
- Zone devices linked to hub via `via_device`
- All entities now visible with controls in **Devices** panel

## Result
User navigates to Settings → Devices → NeverDry {zone} and sees:
- Zone sensor with deficit/volume
- "Irrigate" button with Press action
- "Mark as irrigated" button with Press action

## Test plan
- [x] Buttons created with device_info (test_button.py)
- [x] All 243 tests passing
- [x] Ruff lint clean