### PR TITLE
fix(ui): devices visible in integration page

### DIFF
--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -63,13 +63,14 @@ def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -
 class MarkIrrigatedButton(ButtonEntity):
     """Button to mark a zone as manually irrigated."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:water-check"
 
     def __init__(self, hass: HomeAssistant, zone_name: str, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._zone_name = zone_name
         slug = zone_name.lower().replace(" ", "_")
-        self._attr_name = f"Mark {zone_name} irrigated"
+        self._attr_name = "Mark irrigated"
         self._attr_unique_id = f"mark_irrigated_{slug}"
         if device_info:
             self._attr_device_info = device_info
@@ -86,13 +87,14 @@ class MarkIrrigatedButton(ButtonEntity):
 class IrrigateButton(ButtonEntity):
     """Button to trigger irrigation for a zone based on current deficit."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:sprinkler"
 
     def __init__(self, hass: HomeAssistant, zone_name: str, device_info: DeviceInfo | None = None) -> None:
         self._hass = hass
         self._zone_name = zone_name
         slug = zone_name.lower().replace(" ", "_")
-        self._attr_name = f"Irrigate {zone_name}"
+        self._attr_name = "Irrigate"
         self._attr_unique_id = f"irrigate_{slug}"
         if device_info:
             self._attr_device_info = device_info

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -231,6 +231,7 @@ class ETSensor(SensorEntity):
     Uses a simplified linear model: ET_h = max(0, alpha * (T - T_base) / 24)
     """
 
+    _attr_has_entity_name = True
     _attr_name = "ET Hourly Estimate"
     _attr_unique_id = "et_hourly_estimate"
     _attr_native_unit_of_measurement = "mm/h"
@@ -282,7 +283,8 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
     their own per-zone deficit scaled by Kc.
     """
 
-    _attr_name = "NeverDry"
+    _attr_has_entity_name = True
+    _attr_name = "Dryness Index"
     _attr_unique_id = "never_dry"
     _attr_native_unit_of_measurement = "mm"
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -582,6 +584,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     and is auto-adjusted for hemisphere via hass.config.latitude.
     """
 
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "L"
     _attr_icon = "mdi:sprinkler-variant"
@@ -627,7 +630,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             self._efficiency = DEFAULT_EFFICIENCY
 
         slug = self._zone_name.lower().replace(" ", "_")
-        self._attr_name = f"Irrigation {self._zone_name}"
+        self._attr_name = "Volume"
         self._attr_unique_id = f"irrigation_zone_{slug}"
         if device_info:
             self._attr_device_info = device_info

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -47,7 +47,7 @@ class TestButtonProperties:
 
     def test_name(self, hass_mock):
         btn = MarkIrrigatedButton(hass_mock, "Orto")
-        assert btn._attr_name == "Mark Orto irrigated"
+        assert btn._attr_name == "Mark irrigated"
 
     def test_unique_id(self, hass_mock):
         btn = MarkIrrigatedButton(hass_mock, "Orto")
@@ -112,7 +112,7 @@ class TestIrrigateButton:
 
     def test_name(self, hass_mock):
         btn = IrrigateButton(hass_mock, "Orto")
-        assert btn._attr_name == "Irrigate Orto"
+        assert btn._attr_name == "Irrigate"
 
     def test_unique_id(self, hass_mock):
         btn = IrrigateButton(hass_mock, "Orto")

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -252,7 +252,7 @@ class TestSensorAttributes:
         assert di_sensor._attr_native_unit_of_measurement == "mm"
 
     def test_name(self, di_sensor):
-        assert di_sensor._attr_name == "NeverDry"
+        assert di_sensor._attr_name == "Dryness Index"
 
     def test_icon(self, di_sensor):
         assert di_sensor._attr_icon == "mdi:water-percent-alert"

--- a/tests/test_volume_duration.py
+++ b/tests/test_volume_duration.py
@@ -169,7 +169,7 @@ class TestZoneMetadata:
 
     def test_name(self, di_sensor):
         zone = _make_zone(di_sensor, name="Orto")
-        assert zone._attr_name == "Irrigation Orto"
+        assert zone._attr_name == "Volume"
 
     def test_unique_id(self, di_sensor):
         zone = _make_zone(di_sensor, name="Orto")


### PR DESCRIPTION
## Summary
- Add `has_entity_name = True` to all entity classes (ETSensor, DrynessIndexSensor, IrrigationZoneSensor, MarkIrrigatedButton, IrrigateButton)
- Entity names are now suffixes of the device name (e.g. "Volume" under "NeverDry Orto")
- Without this flag, HA does not show devices in the integration page

## Test plan
- [x] All 243 tests pass
- [ ] Verify devices appear in Settings > Devices & Services > NeverDry after restart
- [ ] Verify entity names display correctly under each device