### PR TITLE
feat: per-zone rain and water delivered sensors

### DIFF
--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -180,6 +180,8 @@ def _create_entities(
         zone_sensors.append(zone_sensor)
         entities.append(zone_sensor)
         entities.append(ZoneDeficitSensor(zone_sensor, zone_device))
+        entities.append(ZoneRainSensor(zone_sensor, zone_device))
+        entities.append(ZoneWaterDeliveredSensor(zone_sensor, zone_device))
 
     return entities, di_sensor, zone_sensors
 
@@ -613,6 +615,8 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._irrigating = False
         self._last_irrigated: datetime | None = None
         self._last_volume_delivered: float = 0.0
+        self._total_rain: float = 0.0
+        self._total_water_delivered: float = 0.0
 
         # Kc: manual override > plant family seasonal profile > 1.0
         self._plant_family = zone_config.get(CONF_ZONE_PLANT_FAMILY)
@@ -655,6 +659,10 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                 if ts:
                     self._last_irrigated = datetime.fromisoformat(ts)
                     self._last_volume_delivered = float(last.attributes.get("last_volume_delivered", 0.0))
+            with contextlib.suppress(ValueError, TypeError):
+                self._total_rain = float(last.attributes.get("total_rain_mm", 0.0))
+            with contextlib.suppress(ValueError, TypeError):
+                self._total_water_delivered = float(last.attributes.get("total_water_delivered_l", 0.0))
         else:
             # New zone: seed deficit from global Dryness Index * Kc
             kc = self._get_current_kc()
@@ -680,6 +688,8 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             self._zone_deficit = self._dryness.deficit * kc
         else:
             kc = self._get_current_kc()
+            if rain > 0:
+                self._total_rain += rain
             self._zone_deficit = max(
                 0.0,
                 min(self._zone_deficit + et_h * kc * dt_h - rain, self._d_max),
@@ -733,6 +743,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     def reset_deficit(self) -> None:
         """Reset this zone's deficit to zero (called after irrigation)."""
         self._last_volume_delivered = round(self.volume_liters, 1)
+        self._total_water_delivered += self._last_volume_delivered
         self._last_irrigated = datetime.now()
         self._zone_deficit = 0.0
 
@@ -779,6 +790,8 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             "deficit_mm": round(self._zone_deficit, 2),
             "irrigating": self._irrigating,
         }
+        attrs["total_rain_mm"] = round(self._total_rain, 2)
+        attrs["total_water_delivered_l"] = round(self._total_water_delivered, 1)
         if self._last_irrigated:
             attrs["last_irrigated"] = self._last_irrigated.isoformat()
             attrs["last_volume_delivered"] = self._last_volume_delivered
@@ -828,3 +841,73 @@ class ZoneDeficitSensor(SensorEntity):
     @property
     def native_value(self) -> float:
         return round(self._zone_sensor._zone_deficit, 2)
+
+
+# ══════════════════════════════════════════════════════════
+#  ZoneRainSensor (cumulative rain per zone in mm)
+# ══════════════════════════════════════════════════════════
+
+
+class ZoneRainSensor(SensorEntity):
+    """Cumulative rain received by this zone [mm]."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Rain"
+    _attr_native_unit_of_measurement = "mm"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_icon = "mdi:weather-rainy"
+
+    def __init__(
+        self,
+        zone_sensor: IrrigationZoneSensor,
+        device_info: DeviceInfo | None = None,
+    ) -> None:
+        self._zone_sensor = zone_sensor
+        slug = zone_sensor.zone_name.lower().replace(" ", "_")
+        self._attr_unique_id = f"rain_zone_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
+        zone_sensor._dryness.register_zone_listener(self._on_update)
+
+    def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
+        """Update when the dryness sensor broadcasts."""
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        return round(self._zone_sensor._total_rain, 2)
+
+
+# ══════════════════════════════════════════════════════════
+#  ZoneWaterDeliveredSensor (cumulative irrigation per zone in L)
+# ══════════════════════════════════════════════════════════
+
+
+class ZoneWaterDeliveredSensor(SensorEntity):
+    """Cumulative water delivered by irrigation to this zone [L]."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Water delivered"
+    _attr_native_unit_of_measurement = "L"
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_icon = "mdi:water-pump"
+
+    def __init__(
+        self,
+        zone_sensor: IrrigationZoneSensor,
+        device_info: DeviceInfo | None = None,
+    ) -> None:
+        self._zone_sensor = zone_sensor
+        slug = zone_sensor.zone_name.lower().replace(" ", "_")
+        self._attr_unique_id = f"water_delivered_zone_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
+        zone_sensor._dryness.register_zone_listener(self._on_update)
+
+    def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
+        """Update when the dryness sensor broadcasts."""
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        return round(self._zone_sensor._total_water_delivered, 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def _create_ha_stubs():
 
     class SensorStateClass:
         MEASUREMENT = "measurement"
+        TOTAL_INCREASING = "total_increasing"
 
     sensor_mod.SensorStateClass = SensorStateClass
 


### PR DESCRIPTION
## Summary
- Add `ZoneRainSensor` (mm, total_increasing) — cumulative rain per zone
- Add `ZoneWaterDeliveredSensor` (L, total_increasing) — cumulative irrigation per zone
- Both persisted via attributes and restored on restart
- Each zone device now shows: Deficit, Volume, Rain, Water delivered, Irrigate, Mark irrigated

## Test plan
- [x] All 257 tests pass
- [ ] Verify Rain sensor increases when rain event occurs
- [ ] Verify Water delivered increases after irrigation