### PR TITLE
fix: hass-is-None crash and duplicate zone prevention

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -375,6 +375,15 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             new_data = dict(self._config_entry.data)
             zones = list(new_data.get(CONF_ZONES, []))
+            # Reject duplicate zone names
+            new_name = user_input[CONF_ZONE_NAME]
+            existing_names = {z[CONF_ZONE_NAME] for z in zones}
+            if new_name in existing_names:
+                return self.async_show_form(
+                    step_id="add_zone",
+                    data_schema=STEP_ZONE_SCHEMA,
+                    errors={"base": "zone_already_exists"},
+                )
             zones.append(user_input)
             new_data[CONF_ZONES] = zones
             self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -706,7 +706,8 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                 0.0,
                 min(self._zone_deficit + et_h * kc * dt_h - rain, self._d_max),
             )
-        self.async_write_ha_state()
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
 
     @property
     def zone_name(self) -> str:
@@ -861,7 +862,8 @@ class ZoneDeficitSensor(SensorEntity):
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
-        self.async_write_ha_state()
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> float:
@@ -896,7 +898,8 @@ class ZoneRainSensor(SensorEntity):
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
-        self.async_write_ha_state()
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> float:
@@ -934,7 +937,8 @@ class ZoneSessionWaterSensor(SensorEntity):
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
-        self.async_write_ha_state()
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> float:
@@ -972,7 +976,8 @@ class ZoneYearlyWaterSensor(SensorEntity):
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
-        self.async_write_ha_state()
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> float:

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -70,7 +70,8 @@
       "too_many_zones": "Maximum number of zones reached (50)",
       "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
       "flow_meter_required": "Flow meter sensor is required for flow_meter delivery mode",
-      "volume_entity_required": "Volume entity is required for volume_preset delivery mode"
+      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "zone_already_exists": "A zone with this name already exists"
     },
     "abort": {
       "already_configured": "NeverDry is already configured"


### PR DESCRIPTION
## Summary
- Fix `RuntimeError: Attribute hass is None` — all listener callbacks now guard `async_write_ha_state()` with `getattr(self, 'hass', None)` to avoid crash when listeners fire before entity registration
- Prevent duplicate zone names in options flow — shows error instead of creating duplicates that cause HA to ignore entities

## Test plan
- [x] All 257 tests pass
- [ ] No more `hass is None` errors in HA log after restart
- [ ] Adding a zone with an existing name shows error message