### PR TITLE
fix: per-zone throttling

### DIFF
--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -71,7 +71,7 @@ class IrrigationController:
         self._irrigation_task: asyncio.Task | None = None
         self._monitoring_mode = not any(zs.valve for zs in zone_sensors)
         self._unsub_monitor = None
-        self._last_service_call: float = 0.0
+        self._last_service_call: dict[str, float] = {}
         # Manual valve tracking: valve_entity_id → flow meter reading at valve open
         self._manual_valve_open: dict[str, float | None] = {}
         # Reverse map: valve_entity_id → zone_name
@@ -141,19 +141,25 @@ class IrrigationController:
 
     # ── Rate limiting ──────────────────────────────────────
 
-    def _is_throttled(self, service_name: str) -> bool:
-        """Return True if a service call should be rejected (rate limit)."""
+    def _is_throttled(self, service_name: str, zone_name: str | None = None) -> bool:
+        """Return True if a service call should be rejected (rate limit).
+
+        Throttling is per service+zone so that calling irrigate on
+        different zones in quick succession is allowed.
+        """
+        key = f"{service_name}:{zone_name}" if zone_name else service_name
         now = time.monotonic()
-        elapsed = now - self._last_service_call
+        last = self._last_service_call.get(key, 0.0)
+        elapsed = now - last
         if elapsed < MIN_SERVICE_INTERVAL_S:
             _LOGGER.warning(
                 "Service %s throttled — %0.1fs since last call (min %ds)",
-                service_name,
+                key,
                 elapsed,
                 MIN_SERVICE_INTERVAL_S,
             )
             return True
-        self._last_service_call = now
+        self._last_service_call[key] = now
         return False
 
     # ── Service handlers ─────────────────────────────────
@@ -170,9 +176,9 @@ class IrrigationController:
 
     async def _handle_irrigate_zone(self, call: ServiceCall) -> None:
         """Irrigate a single zone by name."""
-        if self._is_throttled("irrigate_zone"):
-            return
         zone_name = call.data.get(ATTR_ZONE_NAME)
+        if self._is_throttled("irrigate_zone", zone_name):
+            return
         if zone_name not in self._zones:
             _LOGGER.error(
                 "Zone '%s' not found. Available: %s",
@@ -216,9 +222,9 @@ class IrrigationController:
 
     async def _handle_mark_irrigated(self, call: ServiceCall) -> None:
         """Mark one or all zones as manually irrigated (reset deficit, no valve)."""
-        if self._is_throttled("mark_irrigated"):
-            return
         zone_name = call.data.get(ATTR_ZONE_NAME)
+        if self._is_throttled("mark_irrigated", zone_name):
+            return
         if zone_name is not None:
             if zone_name not in self._zones:
                 _LOGGER.error(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -369,23 +369,28 @@ class TestRateLimiting:
         """First service call should never be throttled."""
         assert controller._is_throttled("test") is False
 
-    def test_rapid_second_call_is_throttled(self, controller):
-        """A call within MIN_SERVICE_INTERVAL_S should be throttled."""
-        controller._is_throttled("first")
-        assert controller._is_throttled("second") is True
+    def test_rapid_second_call_same_key_is_throttled(self, controller):
+        """A call with the same key within MIN_SERVICE_INTERVAL_S should be throttled."""
+        controller._is_throttled("irrigate_zone", "Orto")
+        assert controller._is_throttled("irrigate_zone", "Orto") is True
+
+    def test_rapid_call_different_zone_not_throttled(self, controller):
+        """A call on a different zone should not be throttled."""
+        controller._is_throttled("irrigate_zone", "Orto")
+        assert controller._is_throttled("irrigate_zone", "Prato") is False
 
     def test_call_after_interval_not_throttled(self, controller):
         """A call after the minimum interval should not be throttled."""
-        controller._is_throttled("first")
+        controller._is_throttled("irrigate_zone", "Orto")
         # Simulate time passing beyond the throttle window
-        controller._last_service_call = time.monotonic() - MIN_SERVICE_INTERVAL_S - 1
-        assert controller._is_throttled("second") is False
+        controller._last_service_call["irrigate_zone:Orto"] = time.monotonic() - MIN_SERVICE_INTERVAL_S - 1
+        assert controller._is_throttled("irrigate_zone", "Orto") is False
 
     @pytest.mark.asyncio
     async def test_reset_throttled_does_nothing(self, controller, di_sensor):
         """Throttled reset should not modify deficit."""
         di_sensor._deficit = 15.0
-        controller._is_throttled("warmup")  # set the timestamp
+        controller._is_throttled("reset")  # set the timestamp
 
         call_mock = MagicMock()
         call_mock.data = {}
@@ -397,7 +402,7 @@ class TestRateLimiting:
     async def test_irrigate_zone_throttled_does_nothing(self, controller, zone_orto):
         """Throttled irrigate_zone should not start irrigation."""
         zone_orto._zone_deficit = 10.0
-        controller._is_throttled("warmup")
+        controller._is_throttled("irrigate_zone", "Orto")
 
         call_mock = MagicMock()
         call_mock.data = {"zone_name": "Orto"}
@@ -408,7 +413,7 @@ class TestRateLimiting:
     @pytest.mark.asyncio
     async def test_irrigate_all_throttled_does_nothing(self, controller):
         """Throttled irrigate_all should not start irrigation."""
-        controller._is_throttled("warmup")
+        controller._is_throttled("irrigate_all")
 
         call_mock = MagicMock()
         call_mock.data = {}
@@ -488,7 +493,7 @@ class TestMarkIrrigated:
     async def test_mark_irrigated_throttled(self, controller, zone_orto):
         """Throttled mark_irrigated should not modify deficit."""
         zone_orto._zone_deficit = 15.0
-        controller._is_throttled("warmup")  # set the timestamp
+        controller._is_throttled("mark_irrigated", "Orto")
 
         call_mock = MagicMock()
         call_mock.data = {"zone_name": "Orto"}


### PR DESCRIPTION
## Summary
- Throttle is now per service+zone (e.g. `irrigate_zone:Orto`)
- Irrigating different zones in quick succession is now allowed
- Same zone still throttled within 10s to prevent accidental double-press

## Test plan
- [x] All 258 tests pass
- [ ] Can irrigate two different zones within 10s