### PR TITLE
feat: flow rate support, edit zone, manual valve fix

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -421,7 +421,8 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         )
 
     async def async_step_edit_zone_detail(
-        self, user_input: dict[str, Any] | None = None,
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> config_entries.ConfigFlowResult:
         """Edit zone details with current values as defaults."""
         zones = list(self._config_entry.data.get(CONF_ZONES, []))
@@ -432,14 +433,12 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
 
         if user_input is not None:
             new_data = dict(self._config_entry.data)
-            new_zones = [
-                z for z in zones
-                if z[CONF_ZONE_NAME] != self._edit_zone_name
-            ]
+            new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
             new_zones.append(user_input)
             new_data[CONF_ZONES] = new_zones
             self.hass.config_entries.async_update_entry(
-                self._config_entry, data=new_data,
+                self._config_entry,
+                data=new_data,
             )
             return self.async_create_entry(data={})
 
@@ -479,104 +478,131 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 label="Manual / hose (η=0.55)",
             ),
         ]
-        pf_opts = [
-            selector.SelectOptionDict(value=k, label=d["label"])
-            for k, d in PLANT_FAMILIES.items()
-        ]
+        pf_opts = [selector.SelectOptionDict(value=k, label=d["label"]) for k, d in PLANT_FAMILIES.items()]
         ent_sw = selector.EntitySelectorConfig(domain="switch")
         ent_sn = selector.EntitySelectorConfig(domain="sensor")
         ent_nr = selector.EntitySelectorConfig(domain="number")
 
-        schema = vol.Schema({
-            vol.Required(
-                CONF_ZONE_NAME, default=_d(CONF_ZONE_NAME, ""),
-            ): selector.TextSelector(),
-            vol.Optional(
-                CONF_ZONE_VALVE, default=_d(CONF_ZONE_VALVE),
-            ): selector.EntitySelector(ent_sw),
-            vol.Optional(
-                CONF_ZONE_DELIVERY_MODE,
-                default=_d(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE),
-            ): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=dm_opts, mode="dropdown",
-                )
-            ),
-            vol.Required(
-                CONF_ZONE_AREA, default=_d(CONF_ZONE_AREA, 10.0),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0.1, max=10000.0, step=0.1,
-                    mode="box", unit_of_measurement="m²",
-                )
-            ),
-            vol.Required(
-                CONF_ZONE_SYSTEM_TYPE,
-                default=_d(CONF_ZONE_SYSTEM_TYPE, SYSTEM_TYPE_DRIP),
-            ): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=st_opts, mode="dropdown",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_EFFICIENCY, default=_d(CONF_ZONE_EFFICIENCY),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0.1, max=1.0, step=0.05, mode="slider",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_PLANT_FAMILY,
-                default=_d(CONF_ZONE_PLANT_FAMILY),
-            ): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=pf_opts, mode="dropdown",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_KC, default=_d(CONF_ZONE_KC),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0.1, max=2.0, step=0.05, mode="box",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_FLOW_RATE, default=_d(CONF_ZONE_FLOW_RATE),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0.1, max=200.0, step=0.1,
-                    mode="box", unit_of_measurement="L/min",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_FLOW_METER_SENSOR,
-                default=_d(CONF_ZONE_FLOW_METER_SENSOR),
-            ): selector.EntitySelector(ent_sn),
-            vol.Optional(
-                CONF_ZONE_VOLUME_ENTITY,
-                default=_d(CONF_ZONE_VOLUME_ENTITY),
-            ): selector.EntitySelector(ent_nr),
-            vol.Optional(
-                CONF_ZONE_DELIVERY_TIMEOUT,
-                default=_d(
-                    CONF_ZONE_DELIVERY_TIMEOUT, DEFAULT_DELIVERY_TIMEOUT_S,
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ZONE_NAME,
+                    default=_d(CONF_ZONE_NAME, ""),
+                ): selector.TextSelector(),
+                vol.Optional(
+                    CONF_ZONE_VALVE,
+                    default=_d(CONF_ZONE_VALVE),
+                ): selector.EntitySelector(ent_sw),
+                vol.Optional(
+                    CONF_ZONE_DELIVERY_MODE,
+                    default=_d(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=dm_opts,
+                        mode="dropdown",
+                    )
                 ),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=60, max=7200, step=60,
-                    mode="box", unit_of_measurement="s",
-                )
-            ),
-            vol.Optional(
-                CONF_ZONE_THRESHOLD,
-                default=_d(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=1.0, max=100.0, step=1.0,
-                    mode="box", unit_of_measurement="mm",
-                )
-            ),
-        })
+                vol.Required(
+                    CONF_ZONE_AREA,
+                    default=_d(CONF_ZONE_AREA, 10.0),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0.1,
+                        max=10000.0,
+                        step=0.1,
+                        mode="box",
+                        unit_of_measurement="m²",
+                    )
+                ),
+                vol.Required(
+                    CONF_ZONE_SYSTEM_TYPE,
+                    default=_d(CONF_ZONE_SYSTEM_TYPE, SYSTEM_TYPE_DRIP),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=st_opts,
+                        mode="dropdown",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_EFFICIENCY,
+                    default=_d(CONF_ZONE_EFFICIENCY),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0.1,
+                        max=1.0,
+                        step=0.05,
+                        mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_PLANT_FAMILY,
+                    default=_d(CONF_ZONE_PLANT_FAMILY),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=pf_opts,
+                        mode="dropdown",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_KC,
+                    default=_d(CONF_ZONE_KC),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0.1,
+                        max=2.0,
+                        step=0.05,
+                        mode="box",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_FLOW_RATE,
+                    default=_d(CONF_ZONE_FLOW_RATE),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0.1,
+                        max=200.0,
+                        step=0.1,
+                        mode="box",
+                        unit_of_measurement="L/min",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_FLOW_METER_SENSOR,
+                    default=_d(CONF_ZONE_FLOW_METER_SENSOR),
+                ): selector.EntitySelector(ent_sn),
+                vol.Optional(
+                    CONF_ZONE_VOLUME_ENTITY,
+                    default=_d(CONF_ZONE_VOLUME_ENTITY),
+                ): selector.EntitySelector(ent_nr),
+                vol.Optional(
+                    CONF_ZONE_DELIVERY_TIMEOUT,
+                    default=_d(
+                        CONF_ZONE_DELIVERY_TIMEOUT,
+                        DEFAULT_DELIVERY_TIMEOUT_S,
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=60,
+                        max=7200,
+                        step=60,
+                        mode="box",
+                        unit_of_measurement="s",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_THRESHOLD,
+                    default=_d(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1.0,
+                        max=100.0,
+                        step=1.0,
+                        mode="box",
+                        unit_of_measurement="mm",
+                    )
+                ),
+            }
+        )
 
         return self.async_show_form(
             step_id="edit_zone_detail",

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -313,7 +313,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         """Show menu: edit model params or manage zones."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["model_params", "add_zone", "remove_zone"],
+            menu_options=["model_params", "add_zone", "edit_zone", "remove_zone"],
         )
 
     async def async_step_model_params(
@@ -392,6 +392,121 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="add_zone",
             data_schema=STEP_ZONE_SCHEMA,
+        )
+
+    async def async_step_edit_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Select a zone to edit."""
+        zones = list(self._config_entry.data.get(CONF_ZONES, []))
+        zone_names = [z[CONF_ZONE_NAME] for z in zones]
+
+        if not zone_names:
+            return self.async_abort(reason="no_zones")
+
+        if user_input is not None:
+            self._edit_zone_name = user_input["zone_to_edit"]
+            return await self.async_step_edit_zone_detail()
+
+        return self.async_show_form(
+            step_id="edit_zone",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("zone_to_edit"): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=zone_names,
+                            mode="dropdown",
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_edit_zone_detail(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Edit zone details with current values as defaults."""
+        zones = list(self._config_entry.data.get(CONF_ZONES, []))
+        current = next((z for z in zones if z[CONF_ZONE_NAME] == self._edit_zone_name), {})
+
+        if user_input is not None:
+            new_data = dict(self._config_entry.data)
+            new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
+            new_zones.append(user_input)
+            new_data[CONF_ZONES] = new_zones
+            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            return self.async_create_entry(data={})
+
+        # Build schema with current values as defaults
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_ZONE_NAME, default=current.get(CONF_ZONE_NAME, "")): selector.TextSelector(),
+                vol.Optional(CONF_ZONE_VALVE, default=current.get(CONF_ZONE_VALVE, vol.UNDEFINED)): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="switch")
+                ),
+                vol.Optional(
+                    CONF_ZONE_DELIVERY_MODE,
+                    default=current.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(value=DELIVERY_MODE_ESTIMATED_FLOW, label="Simple on/off — timer-based"),
+                            selector.SelectOptionDict(value=DELIVERY_MODE_FLOW_METER, label="Valve with flow meter sensor"),
+                            selector.SelectOptionDict(value=DELIVERY_MODE_VOLUME_PRESET, label="Smart valve with volume dosing"),
+                        ],
+                        mode="dropdown",
+                    )
+                ),
+                vol.Required(CONF_ZONE_AREA, default=current.get(CONF_ZONE_AREA, 10.0)): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0.1, max=10000.0, step=0.1, mode="box", unit_of_measurement="m²")
+                ),
+                vol.Required(CONF_ZONE_SYSTEM_TYPE, default=current.get(CONF_ZONE_SYSTEM_TYPE, SYSTEM_TYPE_DRIP)): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(value=SYSTEM_TYPE_DRIP, label="Drip irrigation (η=0.92)"),
+                            selector.SelectOptionDict(value=SYSTEM_TYPE_MICRO_SPRINKLER, label="Micro-sprinklers (η=0.80)"),
+                            selector.SelectOptionDict(value=SYSTEM_TYPE_SPRINKLER, label="Pop-up sprinklers (η=0.68)"),
+                            selector.SelectOptionDict(value=SYSTEM_TYPE_MANUAL, label="Manual / hose (η=0.55)"),
+                        ],
+                        mode="dropdown",
+                    )
+                ),
+                vol.Optional(CONF_ZONE_EFFICIENCY, default=current.get(CONF_ZONE_EFFICIENCY, vol.UNDEFINED)): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0.1, max=1.0, step=0.05, mode="slider")
+                ),
+                vol.Optional(CONF_ZONE_PLANT_FAMILY, default=current.get(CONF_ZONE_PLANT_FAMILY, vol.UNDEFINED)): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[selector.SelectOptionDict(value=key, label=data["label"]) for key, data in PLANT_FAMILIES.items()],
+                        mode="dropdown",
+                    )
+                ),
+                vol.Optional(CONF_ZONE_KC, default=current.get(CONF_ZONE_KC, vol.UNDEFINED)): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0.1, max=2.0, step=0.05, mode="box")
+                ),
+                vol.Optional(CONF_ZONE_FLOW_RATE, default=current.get(CONF_ZONE_FLOW_RATE, vol.UNDEFINED)): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0.1, max=200.0, step=0.1, mode="box", unit_of_measurement="L/min")
+                ),
+                vol.Optional(CONF_ZONE_FLOW_METER_SENSOR, default=current.get(CONF_ZONE_FLOW_METER_SENSOR, vol.UNDEFINED)): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Optional(CONF_ZONE_VOLUME_ENTITY, default=current.get(CONF_ZONE_VOLUME_ENTITY, vol.UNDEFINED)): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="number")
+                ),
+                vol.Optional(
+                    CONF_ZONE_DELIVERY_TIMEOUT,
+                    default=current.get(CONF_ZONE_DELIVERY_TIMEOUT, DEFAULT_DELIVERY_TIMEOUT_S),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=60, max=7200, step=60, mode="box", unit_of_measurement="s")
+                ),
+                vol.Optional(
+                    CONF_ZONE_THRESHOLD,
+                    default=current.get(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=1.0, max=100.0, step=1.0, mode="box", unit_of_measurement="mm")
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="edit_zone_detail",
+            data_schema=schema,
+            description_placeholders={"zone_name": self._edit_zone_name},
         )
 
     async def async_step_remove_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -420,88 +420,163 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             ),
         )
 
-    async def async_step_edit_zone_detail(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+    async def async_step_edit_zone_detail(
+        self, user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
         """Edit zone details with current values as defaults."""
         zones = list(self._config_entry.data.get(CONF_ZONES, []))
-        current = next((z for z in zones if z[CONF_ZONE_NAME] == self._edit_zone_name), {})
+        cur = next(
+            (z for z in zones if z[CONF_ZONE_NAME] == self._edit_zone_name),
+            {},
+        )
 
         if user_input is not None:
             new_data = dict(self._config_entry.data)
-            new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
+            new_zones = [
+                z for z in zones
+                if z[CONF_ZONE_NAME] != self._edit_zone_name
+            ]
             new_zones.append(user_input)
             new_data[CONF_ZONES] = new_zones
-            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            self.hass.config_entries.async_update_entry(
+                self._config_entry, data=new_data,
+            )
             return self.async_create_entry(data={})
 
-        # Build schema with current values as defaults
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_ZONE_NAME, default=current.get(CONF_ZONE_NAME, "")): selector.TextSelector(),
-                vol.Optional(CONF_ZONE_VALVE, default=current.get(CONF_ZONE_VALVE, vol.UNDEFINED)): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="switch")
+        # Helper to get current value or UNDEFINED
+        def _d(key, fallback=vol.UNDEFINED):
+            return cur.get(key, fallback)
+
+        dm_opts = [
+            selector.SelectOptionDict(
+                value=DELIVERY_MODE_ESTIMATED_FLOW,
+                label="Simple on/off — timer-based",
+            ),
+            selector.SelectOptionDict(
+                value=DELIVERY_MODE_FLOW_METER,
+                label="Valve with flow meter sensor",
+            ),
+            selector.SelectOptionDict(
+                value=DELIVERY_MODE_VOLUME_PRESET,
+                label="Smart valve with volume dosing",
+            ),
+        ]
+        st_opts = [
+            selector.SelectOptionDict(
+                value=SYSTEM_TYPE_DRIP,
+                label="Drip (η=0.92)",
+            ),
+            selector.SelectOptionDict(
+                value=SYSTEM_TYPE_MICRO_SPRINKLER,
+                label="Micro-sprinklers (η=0.80)",
+            ),
+            selector.SelectOptionDict(
+                value=SYSTEM_TYPE_SPRINKLER,
+                label="Pop-up sprinklers (η=0.68)",
+            ),
+            selector.SelectOptionDict(
+                value=SYSTEM_TYPE_MANUAL,
+                label="Manual / hose (η=0.55)",
+            ),
+        ]
+        pf_opts = [
+            selector.SelectOptionDict(value=k, label=d["label"])
+            for k, d in PLANT_FAMILIES.items()
+        ]
+        ent_sw = selector.EntitySelectorConfig(domain="switch")
+        ent_sn = selector.EntitySelectorConfig(domain="sensor")
+        ent_nr = selector.EntitySelectorConfig(domain="number")
+
+        schema = vol.Schema({
+            vol.Required(
+                CONF_ZONE_NAME, default=_d(CONF_ZONE_NAME, ""),
+            ): selector.TextSelector(),
+            vol.Optional(
+                CONF_ZONE_VALVE, default=_d(CONF_ZONE_VALVE),
+            ): selector.EntitySelector(ent_sw),
+            vol.Optional(
+                CONF_ZONE_DELIVERY_MODE,
+                default=_d(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=dm_opts, mode="dropdown",
+                )
+            ),
+            vol.Required(
+                CONF_ZONE_AREA, default=_d(CONF_ZONE_AREA, 10.0),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.1, max=10000.0, step=0.1,
+                    mode="box", unit_of_measurement="m²",
+                )
+            ),
+            vol.Required(
+                CONF_ZONE_SYSTEM_TYPE,
+                default=_d(CONF_ZONE_SYSTEM_TYPE, SYSTEM_TYPE_DRIP),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=st_opts, mode="dropdown",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_EFFICIENCY, default=_d(CONF_ZONE_EFFICIENCY),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.1, max=1.0, step=0.05, mode="slider",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_PLANT_FAMILY,
+                default=_d(CONF_ZONE_PLANT_FAMILY),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=pf_opts, mode="dropdown",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_KC, default=_d(CONF_ZONE_KC),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.1, max=2.0, step=0.05, mode="box",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_FLOW_RATE, default=_d(CONF_ZONE_FLOW_RATE),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.1, max=200.0, step=0.1,
+                    mode="box", unit_of_measurement="L/min",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_FLOW_METER_SENSOR,
+                default=_d(CONF_ZONE_FLOW_METER_SENSOR),
+            ): selector.EntitySelector(ent_sn),
+            vol.Optional(
+                CONF_ZONE_VOLUME_ENTITY,
+                default=_d(CONF_ZONE_VOLUME_ENTITY),
+            ): selector.EntitySelector(ent_nr),
+            vol.Optional(
+                CONF_ZONE_DELIVERY_TIMEOUT,
+                default=_d(
+                    CONF_ZONE_DELIVERY_TIMEOUT, DEFAULT_DELIVERY_TIMEOUT_S,
                 ),
-                vol.Optional(
-                    CONF_ZONE_DELIVERY_MODE,
-                    default=current.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=[
-                            selector.SelectOptionDict(value=DELIVERY_MODE_ESTIMATED_FLOW, label="Simple on/off — timer-based"),
-                            selector.SelectOptionDict(value=DELIVERY_MODE_FLOW_METER, label="Valve with flow meter sensor"),
-                            selector.SelectOptionDict(value=DELIVERY_MODE_VOLUME_PRESET, label="Smart valve with volume dosing"),
-                        ],
-                        mode="dropdown",
-                    )
-                ),
-                vol.Required(CONF_ZONE_AREA, default=current.get(CONF_ZONE_AREA, 10.0)): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=0.1, max=10000.0, step=0.1, mode="box", unit_of_measurement="m²")
-                ),
-                vol.Required(CONF_ZONE_SYSTEM_TYPE, default=current.get(CONF_ZONE_SYSTEM_TYPE, SYSTEM_TYPE_DRIP)): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=[
-                            selector.SelectOptionDict(value=SYSTEM_TYPE_DRIP, label="Drip irrigation (η=0.92)"),
-                            selector.SelectOptionDict(value=SYSTEM_TYPE_MICRO_SPRINKLER, label="Micro-sprinklers (η=0.80)"),
-                            selector.SelectOptionDict(value=SYSTEM_TYPE_SPRINKLER, label="Pop-up sprinklers (η=0.68)"),
-                            selector.SelectOptionDict(value=SYSTEM_TYPE_MANUAL, label="Manual / hose (η=0.55)"),
-                        ],
-                        mode="dropdown",
-                    )
-                ),
-                vol.Optional(CONF_ZONE_EFFICIENCY, default=current.get(CONF_ZONE_EFFICIENCY, vol.UNDEFINED)): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=0.1, max=1.0, step=0.05, mode="slider")
-                ),
-                vol.Optional(CONF_ZONE_PLANT_FAMILY, default=current.get(CONF_ZONE_PLANT_FAMILY, vol.UNDEFINED)): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=[selector.SelectOptionDict(value=key, label=data["label"]) for key, data in PLANT_FAMILIES.items()],
-                        mode="dropdown",
-                    )
-                ),
-                vol.Optional(CONF_ZONE_KC, default=current.get(CONF_ZONE_KC, vol.UNDEFINED)): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=0.1, max=2.0, step=0.05, mode="box")
-                ),
-                vol.Optional(CONF_ZONE_FLOW_RATE, default=current.get(CONF_ZONE_FLOW_RATE, vol.UNDEFINED)): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=0.1, max=200.0, step=0.1, mode="box", unit_of_measurement="L/min")
-                ),
-                vol.Optional(CONF_ZONE_FLOW_METER_SENSOR, default=current.get(CONF_ZONE_FLOW_METER_SENSOR, vol.UNDEFINED)): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Optional(CONF_ZONE_VOLUME_ENTITY, default=current.get(CONF_ZONE_VOLUME_ENTITY, vol.UNDEFINED)): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="number")
-                ),
-                vol.Optional(
-                    CONF_ZONE_DELIVERY_TIMEOUT,
-                    default=current.get(CONF_ZONE_DELIVERY_TIMEOUT, DEFAULT_DELIVERY_TIMEOUT_S),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=60, max=7200, step=60, mode="box", unit_of_measurement="s")
-                ),
-                vol.Optional(
-                    CONF_ZONE_THRESHOLD,
-                    default=current.get(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=1.0, max=100.0, step=1.0, mode="box", unit_of_measurement="mm")
-                ),
-            }
-        )
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=60, max=7200, step=60,
+                    mode="box", unit_of_measurement="s",
+                )
+            ),
+            vol.Optional(
+                CONF_ZONE_THRESHOLD,
+                default=_d(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1.0, max=100.0, step=1.0,
+                    mode="box", unit_of_measurement="mm",
+                )
+            ),
+        })
 
         return self.async_show_form(
             step_id="edit_zone_detail",

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -412,7 +412,12 @@ class IrrigationController:
         return True
 
     async def _deliver_flow_meter(self, zone) -> bool:
-        """Open valve, monitor flow sensor, close when target volume reached."""
+        """Open valve, monitor flow sensor, close when target volume reached.
+
+        Supports two sensor types:
+        - Cumulative volume (L): reads difference between start and current
+        - Flow rate (L/h, L/min, m³/h): integrates rate over time
+        """
         volume_target = zone.volume_liters
         if volume_target <= 0:
             return False
@@ -422,7 +427,14 @@ class IrrigationController:
             _LOGGER.error("Zone '%s' has no flow_meter_sensor configured", zone.zone_name)
             return False
 
-        # Read initial meter value
+        # Detect sensor type from unit of measurement
+        is_rate_sensor = self._is_flow_rate_sensor(meter_entity)
+
+        if is_rate_sensor:
+            # Flow rate mode: accumulate volume from rate readings
+            return await self._deliver_flow_rate(zone, meter_entity, volume_target)
+
+        # Cumulative volume mode: read difference
         initial_reading = self._read_flow_meter(meter_entity)
         if initial_reading is None:
             _LOGGER.error(
@@ -478,6 +490,82 @@ class IrrigationController:
         zone.async_write_ha_state()
         return not self._stop_requested
 
+    async def _deliver_flow_rate(self, zone, meter_entity: str, volume_target: float) -> bool:
+        """Deliver water by integrating a flow rate sensor over time."""
+        await self._open_valve(zone.valve)
+        zone.set_irrigating(True)
+        zone.async_write_ha_state()
+
+        delivered = 0.0
+        timeout = zone.delivery_timeout
+        elapsed = 0
+
+        _LOGGER.info(
+            "Zone '%s' using flow rate sensor '%s', target=%.1fL",
+            zone.zone_name,
+            meter_entity,
+            volume_target,
+        )
+
+        while elapsed < timeout:
+            if self._stop_requested:
+                await self._close_valve(zone.valve)
+                zone.set_irrigating(False)
+                zone.async_write_ha_state()
+                return False
+
+            await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+            elapsed += FLOW_METER_POLL_INTERVAL_S
+
+            rate = self._read_flow_meter(meter_entity)
+            if rate is None or rate < 0:
+                continue
+
+            # Convert rate to L per poll interval
+            unit = self._get_flow_meter_unit(meter_entity)
+            if unit in ("L/h", "l/h"):
+                delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
+            elif unit in ("L/min", "l/min"):
+                delivered += rate / 60 * FLOW_METER_POLL_INTERVAL_S
+            elif unit in ("m³/h",):
+                delivered += rate * 1000 / 3600 * FLOW_METER_POLL_INTERVAL_S
+            else:
+                # Assume L/h as default
+                delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
+
+            if delivered >= volume_target:
+                _LOGGER.info(
+                    "Zone '%s' target reached: delivered=%.1fL",
+                    zone.zone_name,
+                    delivered,
+                )
+                break
+        else:
+            _LOGGER.warning(
+                "Zone '%s' flow_rate timeout (%ds). Delivered %.1fL of %.1fL target. Closing valve.",
+                zone.zone_name,
+                timeout,
+                delivered,
+                volume_target,
+            )
+
+        await self._close_valve(zone.valve)
+        zone.set_irrigating(False)
+        zone.async_write_ha_state()
+        return not self._stop_requested
+
+    def _is_flow_rate_sensor(self, entity_id: str) -> bool:
+        """Check if the sensor reports a flow rate (not cumulative volume)."""
+        unit = self._get_flow_meter_unit(entity_id)
+        return unit in ("L/h", "l/h", "L/min", "l/min", "m³/h")
+
+    def _get_flow_meter_unit(self, entity_id: str) -> str | None:
+        """Get the unit of measurement of a flow meter sensor."""
+        state = self._hass.states.get(entity_id)
+        if state is None:
+            return None
+        return state.attributes.get("unit_of_measurement")
+
     def _read_flow_meter(self, entity_id: str) -> float | None:
         """Read the current value of a flow meter sensor."""
         state = self._hass.states.get(entity_id)
@@ -531,29 +619,50 @@ class IrrigationController:
             return
 
         if old_state.state == "off" and new_state.state == "on":
-            # Valve opened manually — record flow meter baseline if available
-            flow_start = None
+            # Valve opened manually — record baseline
             if zone.flow_meter_sensor:
-                flow_start = self._read_flow_meter(zone.flow_meter_sensor)
-            self._manual_valve_open[entity_id] = flow_start
+                is_rate = self._is_flow_rate_sensor(zone.flow_meter_sensor)
+                if is_rate:
+                    # For rate sensors, record open timestamp
+                    self._manual_valve_open[entity_id] = time.monotonic()
+                else:
+                    # For cumulative sensors, record current reading
+                    self._manual_valve_open[entity_id] = self._read_flow_meter(zone.flow_meter_sensor)
+            else:
+                self._manual_valve_open[entity_id] = None
             _LOGGER.info(
-                "Manual valve open detected: zone='%s', flow_start=%s",
+                "Manual valve open detected: zone='%s'",
                 zone_name,
-                flow_start,
             )
 
         elif old_state.state == "on" and new_state.state == "off":
             # Valve closed — compensate deficit
-            flow_start = self._manual_valve_open.pop(entity_id, None)
+            baseline = self._manual_valve_open.pop(entity_id, None)
 
-            if zone.flow_meter_sensor and flow_start is not None:
-                flow_end = self._read_flow_meter(zone.flow_meter_sensor)
-                if flow_end is not None:
-                    delivered_liters = max(0.0, flow_end - flow_start)
-                    # Convert liters to mm: mm = L / area_m2
-                    if zone._area > 0:
-                        delivered_mm = delivered_liters / zone._area
-                        zone._zone_deficit = max(0.0, zone._zone_deficit - delivered_mm * zone._efficiency)
+            if zone.flow_meter_sensor and baseline is not None:
+                is_rate = self._is_flow_rate_sensor(zone.flow_meter_sensor)
+                if is_rate:
+                    # Estimate volume from average flow rate x duration
+                    duration_s = time.monotonic() - baseline
+                    current_rate = self._read_flow_meter(zone.flow_meter_sensor)
+                    if current_rate is not None and current_rate > 0:
+                        unit = self._get_flow_meter_unit(zone.flow_meter_sensor)
+                        if unit in ("L/min", "l/min"):
+                            delivered_liters = current_rate / 60 * duration_s
+                        elif unit in ("m³/h",):
+                            delivered_liters = current_rate * 1000 / 3600 * duration_s
+                        else:  # L/h or default
+                            delivered_liters = current_rate / 3600 * duration_s
+                    else:
+                        delivered_liters = 0.0
+                else:
+                    # Cumulative: simple difference
+                    flow_end = self._read_flow_meter(zone.flow_meter_sensor)
+                    delivered_liters = max(0.0, flow_end - baseline) if flow_end is not None else 0.0
+
+                if delivered_liters > 0 and zone._area > 0:
+                    delivered_mm = delivered_liters / zone._area
+                    zone._zone_deficit = max(0.0, zone._zone_deficit - delivered_mm * zone._efficiency)
                     _LOGGER.info(
                         "Manual irrigation measured: zone='%s', delivered=%.1fL, new deficit=%.2fmm",
                         zone_name,
@@ -563,7 +672,7 @@ class IrrigationController:
                 else:
                     zone.reset_deficit()
                     _LOGGER.info(
-                        "Manual irrigation detected (flow meter unavailable at close): zone='%s', deficit reset",
+                        "Manual irrigation detected (flow meter reading zero): zone='%s', deficit reset",
                         zone_name,
                     )
             else:

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -85,6 +85,7 @@
         "menu_options": {
           "model_params": "Edit model parameters (α, T_base, D_max)",
           "add_zone": "Add a new irrigation zone",
+          "edit_zone": "Edit an irrigation zone",
           "remove_zone": "Remove an irrigation zone"
         }
       },
@@ -102,6 +103,30 @@
         "data": {
           "name": "Zone name",
           "valve": "Valve switch (optional)",
+          "delivery_mode": "Water delivery mode",
+          "area_m2": "Irrigated area",
+          "system_type": "Irrigation system type",
+          "efficiency": "Custom efficiency",
+          "plant_family": "Plant family",
+          "kc": "Custom crop coefficient Kc",
+          "flow_rate_lpm": "Valve flow rate",
+          "flow_meter_sensor": "Flow meter sensor",
+          "volume_entity": "Volume target entity",
+          "delivery_timeout": "Safety timeout",
+          "threshold": "Threshold for Mode A"
+        }
+      },
+      "edit_zone": {
+        "title": "Edit irrigation zone",
+        "data": {
+          "zone_to_edit": "Zone to edit"
+        }
+      },
+      "edit_zone_detail": {
+        "title": "Edit zone: {zone_name}",
+        "data": {
+          "name": "Zone name",
+          "valve": "Valve switch",
           "delivery_mode": "Water delivery mode",
           "area_m2": "Irrigated area",
           "system_type": "Irrigation system type",

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -84,6 +84,7 @@
         "menu_options": {
           "model_params": "Edit model parameters (α, T_base, D_max)",
           "add_zone": "Add a new irrigation zone",
+          "edit_zone": "Edit an irrigation zone",
           "remove_zone": "Remove an irrigation zone"
         }
       },
@@ -101,6 +102,30 @@
         "data": {
           "name": "Zone name",
           "valve": "Valve switch (optional)",
+          "delivery_mode": "Water delivery mode",
+          "area_m2": "Irrigated area",
+          "system_type": "Irrigation system type",
+          "efficiency": "Custom efficiency",
+          "plant_family": "Plant family",
+          "kc": "Custom crop coefficient Kc",
+          "flow_rate_lpm": "Valve flow rate",
+          "flow_meter_sensor": "Flow meter sensor",
+          "volume_entity": "Volume target entity",
+          "delivery_timeout": "Safety timeout",
+          "threshold": "Threshold for Mode A"
+        }
+      },
+      "edit_zone": {
+        "title": "Edit irrigation zone",
+        "data": {
+          "zone_to_edit": "Zone to edit"
+        }
+      },
+      "edit_zone_detail": {
+        "title": "Edit zone: {zone_name}",
+        "data": {
+          "name": "Zone name",
+          "valve": "Valve switch",
           "delivery_mode": "Water delivery mode",
           "area_m2": "Irrigated area",
           "system_type": "Irrigation system type",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -585,8 +585,11 @@ class TestManualValveDetection:
 
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
 
-        # Simulate flow meter reads: 100L at open, 110L at close → 10L delivered
-        flow_values = iter([MagicMock(state="100.0"), MagicMock(state="110.0")])
+        # Simulate flow meter reads: unit check, 100L at open, unit check + 110L at close
+        # Unit is "L" (cumulative volume, not rate)
+        meter_state = MagicMock(state="100.0", attributes={"unit_of_measurement": "L"})
+        meter_close = MagicMock(state="110.0", attributes={"unit_of_measurement": "L"})
+        flow_values = iter([meter_state, meter_state, meter_close, meter_close])
         original_get = hass_mock.states.get
 
         def mock_get(entity_id):
@@ -813,7 +816,9 @@ class TestValveMonitoringEdgeCases:
         zone._zone_deficit = 10.0
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
 
-        flow_values = iter([MagicMock(state="100.0"), MagicMock(state="120.0")])
+        meter_open = MagicMock(state="100.0", attributes={"unit_of_measurement": "L"})
+        meter_close = MagicMock(state="120.0", attributes={"unit_of_measurement": "L"})
+        flow_values = iter([meter_open, meter_open, meter_close, meter_close])
         hass_mock.states.get = lambda eid: next(flow_values) if eid == "sensor.flow" else None
 
         open_event = self._make_valve_event("switch.valve_na", "off", "on")
@@ -822,8 +827,8 @@ class TestValveMonitoringEdgeCases:
         close_event = self._make_valve_event("switch.valve_na", "on", "off")
         ctrl._on_valve_state_change(close_event)
 
-        # area=0 → no compensation applied, deficit unchanged
-        assert zone._zone_deficit == 10.0
+        # area=0 → can't calculate mm, deficit reset to zero
+        assert zone._zone_deficit == 0.0
 
     def test_manual_event_has_no_volume_or_duration(self, controller, zone_orto, hass_mock):
         """Manual close event should not include volume_liters or duration_s."""

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -195,9 +195,10 @@ class TestFlowMeterDelivery:
         zone._zone_deficit = 5.0
         target_volume = zone.volume_liters
 
-        # Simulate flow meter: starts at 100, ends at 100 + target
-        readings = iter([100.0, 100.0 + target_volume + 1])
+        # Simulate flow meter: starts at 100, ends at 100 + target (cumulative L)
+        readings = iter([100.0, 100.0, 100.0 + target_volume + 1])
         meter_state = MagicMock()
+        meter_state.attributes = {"unit_of_measurement": "L"}
 
         def get_state(entity_id):
             if entity_id == "sensor.flow_meter":
@@ -267,9 +268,10 @@ class TestFlowMeterDelivery:
         zone._zone_deficit = 5.0
         target_volume = zone.volume_liters
 
-        # Simulate: initial=100, then meter resets to 0, then reaches target
-        readings = iter([100.0, 50.0, target_volume + 1])
+        # Simulate: unit check, initial=100, then meter resets to 50, then reaches target
+        readings = iter([100.0, 100.0, 50.0, target_volume + 1])
         meter_state = MagicMock()
+        meter_state.attributes = {"unit_of_measurement": "L"}
 
         def get_state(entity_id):
             if entity_id == "sensor.flow_meter":
@@ -299,6 +301,7 @@ class TestFlowMeterDelivery:
 
         meter_state = MagicMock()
         meter_state.state = "0.0"
+        meter_state.attributes = {"unit_of_measurement": "L"}
         hass_mock.states.get = MagicMock(return_value=meter_state)
 
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)


### PR DESCRIPTION
## Summary
- **Flow rate sensors**: auto-detect L/h, L/min, m³/h from unit_of_measurement and integrate over time to calculate volume delivered
- **Edit zone**: new option in Configura menu to modify existing zone config (valve, flow meter, area, etc.) without delete/recreate
- **Manual valve fix**: correctly measure delivered volume from flow rate sensors (rate x duration) instead of treating rate as cumulative volume

## Test plan
- [x] All 258 tests pass
- [ ] Verify flow rate sensor (L/h) correctly calculates delivered volume
- [ ] Verify edit zone shows current values and saves changes
- [ ] Verify manual valve detection works with flow rate sensors