### PR TITLE
feat: per-zone scheduled irrigation time

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_ZONE_EFFICIENCY,
     CONF_ZONE_FLOW_METER_SENSOR,
     CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_IRRIGATION_TIME,
     CONF_ZONE_KC,
     CONF_ZONE_NAME,
     CONF_ZONE_PLANT_FAMILY,
@@ -43,6 +44,7 @@ from .const import (
     DEFAULT_D_MAX,
     DEFAULT_DELIVERY_MODE,
     DEFAULT_DELIVERY_TIMEOUT_S,
+    DEFAULT_IRRIGATION_TIME,
     DEFAULT_RAIN_SENSOR_TYPE,
     DEFAULT_T_BASE,
     DEFAULT_THRESHOLD,
@@ -213,6 +215,10 @@ STEP_ZONE_SCHEMA = vol.Schema(
                 unit_of_measurement="mm",
             )
         ),
+        vol.Optional(
+            CONF_ZONE_IRRIGATION_TIME,
+            default=DEFAULT_IRRIGATION_TIME,
+        ): selector.TimeSelector(),
     }
 )
 
@@ -601,6 +607,13 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                         unit_of_measurement="mm",
                     )
                 ),
+                vol.Optional(
+                    CONF_ZONE_IRRIGATION_TIME,
+                    default=_d(
+                        CONF_ZONE_IRRIGATION_TIME,
+                        DEFAULT_IRRIGATION_TIME,
+                    ),
+                ): selector.TimeSelector(),
             }
         )
 

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -36,6 +36,7 @@ CONF_ZONE_VOLUME_ENTITY = "volume_entity"
 CONF_ZONE_FLOW_METER_SENSOR = "flow_meter_sensor"
 CONF_ZONE_DELIVERY_TIMEOUT = "delivery_timeout"
 CONF_ZONE_BATTERY_SENSOR = "battery_sensor"
+CONF_ZONE_IRRIGATION_TIME = "irrigation_time"
 
 # ── Controller parameters ────────────────────────────────
 CONF_INTER_ZONE_DELAY = "inter_zone_delay"
@@ -111,6 +112,7 @@ DEFAULT_INTER_ZONE_DELAY = 30
 DEFAULT_KC = 1.0
 DEFAULT_RAIN_SENSOR_TYPE = RAIN_TYPE_EVENT
 DEFAULT_BACKFILL_DAYS = 90
+DEFAULT_IRRIGATION_TIME = "06:00"  # default daily irrigation check time
 DEFAULT_BATTERY_LOW_THRESHOLD = 15  # percent
 ANOMALY_DEFICIT_MULTIPLIER = 2  # alert when deficit > threshold * this
 CONF_BACKFILL_DAYS = "backfill_days"

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -19,6 +19,7 @@ import time
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.event import (
     async_track_state_change_event,
+    async_track_time_change,
     async_track_time_interval,
 )
 
@@ -127,6 +128,32 @@ class IrrigationController:
             timedelta(hours=6),
         )
 
+        # Schedule daily irrigation per zone
+        for zs in self._zones.values():
+            irr_time = zs.irrigation_time
+            if irr_time and zs.valve:
+                try:
+                    parts = irr_time.split(":")
+                    hour, minute = int(parts[0]), int(parts[1])
+                    async_track_time_change(
+                        self._hass,
+                        self._make_scheduled_handler(zs.zone_name),
+                        hour=hour,
+                        minute=minute,
+                        second=0,
+                    )
+                    _LOGGER.info(
+                        "Scheduled daily irrigation: zone='%s' at %s",
+                        zs.zone_name,
+                        irr_time,
+                    )
+                except (ValueError, IndexError):
+                    _LOGGER.error(
+                        "Invalid irrigation_time '%s' for zone '%s'",
+                        irr_time,
+                        zs.zone_name,
+                    )
+
         # Start monitoring mode if no valves are configured
         if self._monitoring_mode:
             _LOGGER.info(
@@ -138,6 +165,46 @@ class IrrigationController:
                 self._check_and_notify,
                 timedelta(hours=6),
             )
+
+    # ── Scheduled irrigation ────────────────────────────────
+
+    def _make_scheduled_handler(self, zone_name: str):
+        """Create a time-triggered handler for a specific zone."""
+
+        @callback
+        def _handler(now) -> None:
+            zone = self._zones.get(zone_name)
+            if zone is None:
+                return
+            threshold = zone.extra_state_attributes.get(
+                "threshold_mm",
+                DEFAULT_THRESHOLD,
+            )
+            if zone._zone_deficit < threshold:
+                _LOGGER.debug(
+                    "Scheduled check: zone='%s' deficit=%.1fmm < threshold=%.1fmm, skipping",
+                    zone_name,
+                    zone._zone_deficit,
+                    threshold,
+                )
+                return
+            if self._running:
+                _LOGGER.warning(
+                    "Scheduled irrigation for '%s' skipped — another irrigation is in progress",
+                    zone_name,
+                )
+                return
+            _LOGGER.info(
+                "Scheduled irrigation triggered: zone='%s', deficit=%.1fmm, threshold=%.1fmm",
+                zone_name,
+                zone._zone_deficit,
+                threshold,
+            )
+            self._irrigation_task = self._hass.async_create_task(
+                self._irrigate_zones([zone_name]),
+            )
+
+        return _handler
 
     # ── Rate limiting ──────────────────────────────────────
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_ZONE_EFFICIENCY,
     CONF_ZONE_FLOW_METER_SENSOR,
     CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_IRRIGATION_TIME,
     CONF_ZONE_KC,
     CONF_ZONE_NAME,
     CONF_ZONE_PLANT_FAMILY,
@@ -613,6 +614,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._flow_meter_sensor = zone_config.get(CONF_ZONE_FLOW_METER_SENSOR)
         self._delivery_timeout = zone_config.get(CONF_ZONE_DELIVERY_TIMEOUT, DEFAULT_DELIVERY_TIMEOUT_S)
         self._battery_sensor = zone_config.get(CONF_ZONE_BATTERY_SENSOR)
+        self._irrigation_time = zone_config.get(CONF_ZONE_IRRIGATION_TIME)
         self._irrigating = False
         self._last_irrigated: datetime | None = None
         self._last_volume_delivered: float = 0.0
@@ -720,6 +722,11 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         return self._valve
 
     @property
+    def irrigation_time(self) -> str | None:
+        """Configured daily irrigation time (HH:MM) or None."""
+        return self._irrigation_time
+
+    @property
     def delivery_mode(self) -> str:
         """Configured delivery mode for this zone."""
         return self._delivery_mode
@@ -800,6 +807,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             "zone_name": self._zone_name,
             "valve": self._valve,
             "delivery_mode": self._delivery_mode,
+            "irrigation_time": self._irrigation_time,
             "system_type": self._system_type,
             "plant_family": self._plant_family,
             "kc": round(kc, 3),

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -39,7 +39,8 @@
           "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
           "volume_entity": "Volume target entity (volume_preset only)",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         },
         "data_description": {
           "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)",
@@ -54,7 +55,8 @@
           "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
           "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level that triggers Mode A irrigation for this zone"
+          "threshold": "Deficit level (mm) that triggers automatic irrigation for this zone",
+          "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },
       "add_another": {
@@ -113,7 +115,8 @@
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         }
       },
       "edit_zone": {
@@ -137,7 +140,8 @@
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         }
       },
       "remove_zone": {

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -39,7 +39,8 @@
           "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
           "volume_entity": "Volume target entity (volume_preset only)",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         },
         "data_description": {
           "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)",
@@ -51,10 +52,11 @@
           "plant_family": "Select the type of plants in this zone. Sets a seasonal crop coefficient (Kc) that adjusts water demand throughout the year",
           "kc": "Leave empty to use the plant family seasonal profile. Set to override with a fixed Kc value (0.1–2.0)",
           "flow_rate_lpm": "Water flow rate of the valve in liters per minute. Required for estimated_flow mode. Measure with a bucket and stopwatch",
-          "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
+          "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered or flow rate (L/h, L/min). Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
           "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level that triggers Mode A irrigation for this zone"
+          "threshold": "Deficit level (mm) that triggers automatic irrigation for this zone",
+          "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },
       "add_another": {
@@ -112,7 +114,8 @@
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         }
       },
       "edit_zone": {
@@ -136,7 +139,8 @@
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
           "delivery_timeout": "Safety timeout",
-          "threshold": "Threshold for Mode A"
+          "threshold": "Irrigation threshold",
+          "irrigation_time": "Daily irrigation time"
         }
       },
       "remove_zone": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def _create_ha_stubs():
     # homeassistant.helpers.event
     event_mod = ModuleType("homeassistant.helpers.event")
     event_mod.async_track_state_change_event = MagicMock()
+    event_mod.async_track_time_change = MagicMock()
     event_mod.async_track_time_interval = MagicMock()
 
     # homeassistant.helpers.restore_state


### PR DESCRIPTION
## Summary
- New per-zone config field: **irrigation_time** (HH:MM)
- At configured time, NeverDry checks deficit vs threshold and irrigates if needed
- Each zone can have a different schedule (e.g. Melino at 06:00, Ortensia at 06:30)
- Leave empty to disable automatic scheduling (manual/button only)
- Visible in zone attributes and editable via Edit Zone

## Test plan
- [x] All 258 tests pass
- [ ] Verify time selector appears in add/edit zone forms
- [ ] Verify irrigation triggers at configured time when deficit > threshold
- [ ] Verify no irrigation when deficit < threshold