### PR TITLE
docs(gh-pages): add GoatCounter cookieless analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage.xml
 htmlcov/
 .venv/
 .env
+secrets/
+*.db
+.code_reader/

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Intelligente Bewässerung für Home Assistant</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Intelligente Bewässerung für Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Riego Inteligente para Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Irrigation Intelligente pour Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Pametno Navodnjavanje za Home Assistant</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Intelligens Öntözés a Home Assistant-hez</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Smart Irrigation for Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Irrigazione Intelligente per Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
+    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
     <title>NeverDry — Irrigação Inteligente para Home Assistant</title>
     <style>
         :root {


### PR DESCRIPTION
## Summary
- Add GoatCounter analytics script to all 9 language landing pages (`index.html`, `it.html`, `de.html`, `at.html`, `fr.html`, `es.html`, `pt.html`, `hu.html`, `hr.html`)
- Cookieless, privacy-friendly: no cookies, no fingerprinting, no client-side identifiers
- No consent banner required under GDPR/ePrivacy for purely statistical aggregation
- Async script tag, ~3KB, no rendering impact

Site code: `neverdry.goatcounter.com` (registered separately).

## Test plan
- [ ] CI checks pass (gh-pages workflow, hassfest, lint, security, tests)
- [ ] After merge & gh-pages deploy: open the live page and verify a hit appears in the GoatCounter dashboard within ~1 minute