### PR TITLE
chore(codeql): close three open note-severity alerts

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -8,7 +8,6 @@ Provides a multi-step UI setup:
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import voluptuous as vol
@@ -67,8 +66,6 @@ from .const import (
     SYSTEM_TYPE_MICRO_SPRINKLER,
     SYSTEM_TYPE_SPRINKLER,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 STEP_SENSORS_SCHEMA = vol.Schema(
     {

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -278,6 +278,8 @@ class ETSensor(SensorEntity):
             t = float(new_state.state)
             self._value = max(0.0, self._alpha * (t - self._t_base) / 24)
         except (ValueError, TypeError):
+            # Temperature sensor not yet numeric (boot / unavailable):
+            # keep the previous self._value unchanged.
             pass
         self.async_write_ha_state()
 
@@ -398,6 +400,8 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             vwc = float(vwc_state.state)
             self._deficit = max(0.0, (self._field_cap - vwc) * self._root_depth * 1000)
         except (ValueError, TypeError):
+            # VWC sensor not yet numeric (boot / unavailable):
+            # keep the previous self._deficit unchanged.
             pass
 
     def _compute_rain_delta(self) -> float:


### PR DESCRIPTION
## Summary

Closes the three open CodeQL alerts on the repo, all severity `note` (lowest tier — *code quality nudges, not security vulnerabilities*).

| # | Rule | File | Fix |
|---|---|---|---|
| 2 | `py/unused-global-variable` | `config_flow.py` | Remove the unused module-level `_LOGGER` binding (and the now-unused `import logging`). |
| 4 | `py/empty-except` | `sensor.py` | Annotate the `except (ValueError, TypeError): pass` with a one-line comment explaining why the error is intentionally swallowed (HA sensor not yet numeric at boot / unavailable). |
| 5 | `py/empty-except` | `sensor.py` | Same as #4 on the second occurrence. |

No functional change. The `pass` semantics are preserved; CodeQL is happy as soon as the swallowed exception has a comment justifying it.

## Test plan
- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] `pytest` — 258 tests pass on the base branch (unchanged)
- [ ] CodeQL workflow re-runs and the three alerts move to `fixed`

## Notes
- This branch is **independent** of `feature/valve-robustness-cluster` (PR #44). Merge either first.
- Dependabot is still **disabled** for this repo (separate setting). Recommend enabling from Settings → Security & analysis when convenient.