### PR TITLE
feat(controller): real-time deficit update during flow-metered delivery

### DIFF
--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -407,6 +407,13 @@ class IrrigationController:
                 )
 
                 volume_target = zone.volume_liters
+                # Snapshot the deficit BEFORE delivery starts. Flow-metered
+                # delivery modes use this snapshot for real-time deficit
+                # updates so that partial progress is preserved on crashes
+                # mid-cycle (a network glitch in the flow sensor used to
+                # lose every mm we had already delivered).
+                deficit_at_start = zone._zone_deficit
+                zone._deficit_at_irrigation_start = deficit_at_start
                 delivered = await self._deliver_water(zone)
 
                 if self._stop_requested:
@@ -414,7 +421,7 @@ class IrrigationController:
 
                 if delivered > 0:
                     irrigated_zones.append(
-                        (zone_name, delivered, volume_target),
+                        (zone_name, delivered, volume_target, deficit_at_start),
                     )
                     self._hass.bus.async_fire(
                         EVENT_IRRIGATION_COMPLETE,
@@ -438,22 +445,22 @@ class IrrigationController:
                     _LOGGER.debug("Inter-zone delay: %ds", self._inter_zone_delay)
                     await asyncio.sleep(self._inter_zone_delay)
 
-            # Adjust deficits for irrigated zones
+            # Adjust deficits for irrigated zones using the snapshot taken
+            # before each delivery. The settle here is **idempotent** with
+            # any real-time updates that ran inside the delivery modes:
+            # both write ``max(0, deficit_at_start - delivered_mm)``.
             if irrigated_zones and not self._stop_requested:
                 all_complete = True
-                for zone_name, delivered, target in irrigated_zones:
+                for zone_name, delivered, target, deficit_at_start in irrigated_zones:
                     zone = self._zones[zone_name]
                     if delivered >= target:
                         # Full irrigation — reset deficit to zero
                         zone.reset_deficit(self._current_source or "automatic")
                     else:
-                        # Partial irrigation — reduce deficit proportionally
+                        # Partial irrigation — authoritative recompute from snapshot
                         all_complete = False
                         delivered_mm = delivered * zone._efficiency / zone._area if zone._area > 0 else 0.0
-                        zone._zone_deficit = max(
-                            0.0,
-                            zone._zone_deficit - delivered_mm,
-                        )
+                        zone._zone_deficit = max(0.0, deficit_at_start - delivered_mm)
                         zone._last_volume_delivered = round(delivered, 1)
                         zone._session_water_delivered = round(delivered, 1)
                         zone._total_water_delivered += delivered
@@ -467,6 +474,7 @@ class IrrigationController:
                             target,
                             zone._zone_deficit,
                         )
+                    zone._deficit_at_irrigation_start = None
                     zone.async_write_ha_state()
                 # Reset reference sensor only if ALL zones fully irrigated
                 zone_names_irrigated = {z[0] for z in irrigated_zones}
@@ -488,6 +496,11 @@ class IrrigationController:
         finally:
             self._running = False
             self._active_valve = None
+            # Clear any leftover irrigation-start snapshot so a subsequent
+            # cycle does not see stale state if this one was aborted before
+            # the settle step ran.
+            for zs in self._zones.values():
+                zs._deficit_at_irrigation_start = None
 
     # ── Delivery mode dispatch ────────────────────────────
 
@@ -666,6 +679,9 @@ class IrrigationController:
                 initial_reading = 0.0
                 delivered = current_reading
 
+            # Real-time deficit update (snapshot-based — idempotent with settle).
+            self._update_deficit_realtime(zone, delivered)
+
             if delivered >= volume_target:
                 break
         else:
@@ -732,6 +748,9 @@ class IrrigationController:
                 # L/h or default
                 delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
 
+            # Real-time deficit update (snapshot-based — idempotent with settle).
+            self._update_deficit_realtime(zone, delivered)
+
             if delivered >= volume_target:
                 _LOGGER.info(
                     "Zone '%s' target reached: delivered=%.1fL",
@@ -774,6 +793,27 @@ class IrrigationController:
             return float(state.state)
         except (ValueError, TypeError):
             return None
+
+    # ── Deficit live-update helper ────────────────────────
+
+    def _update_deficit_realtime(self, zone, delivered_liters: float) -> None:
+        """Apply a snapshot-based incremental deficit update.
+
+        Writes ``zone._zone_deficit = max(0, deficit_at_start -
+        delivered_liters * efficiency / area)`` and pushes the new state
+        to Home Assistant. Skipped when ``_deficit_at_irrigation_start``
+        is ``None`` (no active cycle) or the zone has no area.
+
+        Idempotency: every call writes an absolute value derived from the
+        snapshot, so multiple intermediate calls plus the end-of-cycle
+        settle never double-count.
+        """
+        snapshot = zone._deficit_at_irrigation_start
+        if snapshot is None or zone._area <= 0:
+            return
+        delivered_mm = delivered_liters * zone._efficiency / zone._area
+        zone._zone_deficit = max(0.0, snapshot - delivered_mm)
+        zone.async_write_ha_state()
 
     # ── Valve helpers ─────────────────────────────────────
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -669,6 +669,13 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._last_irrigated: datetime | None = None
         self._last_volume_delivered: float = 0.0
         self._last_irrigation_source: str | None = None
+        # Snapshot of zone_deficit captured by the controller at the start
+        # of an irrigation cycle. Used by flow-metered delivery modes for
+        # real-time deficit updates: every update is computed as
+        # ``max(0, snapshot - delivered_mm)`` so intermediate writes are
+        # idempotent and the end-of-cycle settle never double-counts.
+        # ``None`` outside an active cycle.
+        self._deficit_at_irrigation_start: float | None = None
         self._total_rain: float = 0.0
         self._total_water_delivered: float = 0.0
         self._yearly_water_delivered: float = 0.0

--- a/tests/test_controller_with_operator.py
+++ b/tests/test_controller_with_operator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from never_dry.const import (
     CONF_ZONE_AREA,
     CONF_ZONE_DELIVERY_MODE,
@@ -270,6 +271,111 @@ async def test_volume_preset_no_turn_on_when_auto_opened(hass_mock, di_sensor):
 
     turn_on_calls = [c for c in hass_mock.services.async_call.call_args_list if c.args[:2] == ("switch", "turn_on")]
     assert turn_on_calls == [], "no fallback turn_on when the valve auto-opened"
+
+
+# ── Real-time deficit update (snapshot-based) ────────────────────────
+
+
+def test_update_deficit_realtime_is_idempotent(hass_mock, di_sensor):
+    """Multiple calls with growing delivered always recompute from the snapshot.
+
+    Regression: previously the partial-irrigation settle subtracted
+    delivered_mm from the *current* deficit, which double-counted any
+    intermediate update. The new path uses an absolute snapshot-based
+    formula so intermediate writes converge cleanly.
+    """
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 12.0
+    zone._deficit_at_irrigation_start = 12.0
+
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+    # 5 L delivered → 5 * 0.9 / 20 = 0.225 mm consumed → 11.775 mm left.
+    ctrl._update_deficit_realtime(zone, 5.0)
+    assert zone._zone_deficit == pytest.approx(11.775, rel=1e-3)
+
+    # 50 L delivered → 50 * 0.9 / 20 = 2.25 mm consumed → 9.75 mm left.
+    ctrl._update_deficit_realtime(zone, 50.0)
+    assert zone._zone_deficit == pytest.approx(9.75, rel=1e-3)
+
+    # Over-shooting target clamps at 0.
+    ctrl._update_deficit_realtime(zone, 10_000.0)
+    assert zone._zone_deficit == 0.0
+
+
+def test_update_deficit_realtime_skipped_when_no_active_cycle(hass_mock, di_sensor):
+    """Without a snapshot the helper must leave the deficit untouched."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 7.5
+    zone._deficit_at_irrigation_start = None
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+    ctrl._update_deficit_realtime(zone, 100.0)
+    assert zone._zone_deficit == 7.5
+
+
+def test_update_deficit_realtime_skipped_for_zero_area(hass_mock, di_sensor):
+    """A misconfigured zone with area=0 must not divide by zero."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+    zone._deficit_at_irrigation_start = 5.0
+    zone._area = 0.0
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+    ctrl._update_deficit_realtime(zone, 10.0)
+    assert zone._zone_deficit == 5.0
+
+
+async def test_irrigate_zones_clears_snapshot_after_cycle(hass_mock, di_sensor):
+    """The snapshot attribute must be cleared at the end of a clean cycle."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+    async def _fake_deliver(z):
+        # Intermediate real-time write to exercise the path.
+        ctrl._update_deficit_realtime(z, z.volume_liters / 2)
+        return z.volume_liters
+
+    ctrl._deliver_water = _fake_deliver  # type: ignore[assignment]
+    await ctrl._irrigate_zones(["Orto"])
+    assert zone._deficit_at_irrigation_start is None
+
+
+async def test_irrigate_zones_clears_snapshot_on_abort(hass_mock, di_sensor):
+    """Even when the cycle aborts mid-delivery, the snapshot is cleared."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+    async def _exploding_deliver(_z):
+        raise RuntimeError("simulated crash")
+
+    ctrl._deliver_water = _exploding_deliver  # type: ignore[assignment]
+    await ctrl._irrigate_zones(["Orto"])
+    assert zone._deficit_at_irrigation_start is None
+
+
+async def test_settle_is_idempotent_with_realtime_updates(hass_mock, di_sensor):
+    """End-of-cycle settle yields the same deficit as the last real-time write."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 10.0  # mm
+
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+    async def _fake_deliver(z):
+        # Snapshot was set by _irrigate_zones before this call. Simulate
+        # a flow-meter loop writing real-time updates per poll.
+        for litres in (5.0, 10.0, 25.0):
+            ctrl._update_deficit_realtime(z, litres)
+        # Return a partial delivery so the settle exercises the partial branch.
+        return 25.0
+
+    ctrl._deliver_water = _fake_deliver  # type: ignore[assignment]
+    await ctrl._irrigate_zones(["Orto"])
+
+    # 25 L * 0.9 / 20 m² = 1.125 mm consumed → 10 - 1.125 = 8.875 mm.
+    assert zone._zone_deficit == pytest.approx(8.875, rel=1e-3)
 
 
 # ── _last_irrigated regression coverage ──────────────────────────────


### PR DESCRIPTION
## Summary

Flow-metered delivery modes (`flow_meter` cumulative + `flow_rate`) now write a real-time deficit update on every 2 s poll, computed as `max(0, deficit_at_start - delivered_liters * efficiency / area)`.

The snapshot is taken by `_irrigate_zones` right before delivery and stored on the zone as `_deficit_at_irrigation_start`.

## Why

Before this change the deficit was only updated at end-of-cycle. A network glitch on the flow sensor, an unclean HA restart, or any exception that escaped the delivery mode caused us to lose every millimetre we had already irrigated — the deficit stayed at its pre-cycle value even though the valve had been open for minutes.

With the snapshot-based formula every write is **absolute** (derived from the snapshot, not from the current deficit), so:

- Intermediate writes during delivery propagate progress live to HA (every 2 s).
- The end-of-cycle settle uses the same formula → idempotent → no double-counting.
- A crash mid-cycle preserves the last real-time value.

## What changed

- `controller.py`
  - `_irrigate_zones` snapshots `deficit_at_start` per zone and stores it on `zone._deficit_at_irrigation_start` before calling `_deliver_water`.
  - `_deliver_flow_meter` (cumulative) and `_deliver_flow_rate` call the new helper on every poll.
  - End-of-cycle settle switched from `deficit -= delivered_mm` to `deficit = max(0, snapshot - delivered_mm)`.
  - `finally` clears the snapshot attribute on every zone (even on abort).
- `sensor.py`
  - `IrrigationZoneSensor` exposes `_deficit_at_irrigation_start: float | None = None`.

## Test plan

- [x] +6 unit tests in `test_controller_with_operator.py` (idempotency, guards, cleanup, snapshot-based settle).
- [x] Full suite: **365 passed** (was 359).
- [x] `ruff format --check` and `ruff check` clean.
- [ ] Field test on real installation — see Test I in `documents/04_software_engineering/03_field_test_checklist.md`.

## Notes

- `estimated_flow` and `volume_preset` modes do **not** call the helper (they have no real-time metering). For them the end-of-cycle update is the only one, identical in result to the previous behaviour.
- Independent of PR #44 (cluster) and #45 (CodeQL) which are already merged.