### PR TITLE
feat(controller): notify when valve is unreachable at irrigation time

### DIFF
--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -44,7 +44,7 @@ from .const import (
     SERVICE_STOP,
 )
 from .valve_fsm import ValveState
-from .valve_notifier import ValveNotifier
+from .valve_notifier import NotificationKind, Severity, ValveNotifier
 from .valve_operator import OperationStatus, ValveOperator
 
 MONITORING_INTERVAL = 6 * 3600  # 6 hours in seconds
@@ -549,6 +549,22 @@ class IrrigationController:
             _LOGGER.error("Zone '%s' has no volume_entity configured", zone.zone_name)
             return 0.0
 
+        # Pre-check the switch entity. volume_preset bypasses ValveOperator,
+        # so it also bypasses the operator's pre-check. Do our own here so
+        # the user gets the same "unreachable at irrigation time"
+        # notification when the smart valve is offline.
+        switch_state = self._hass.states.get(zone.valve)
+        if switch_state is None or switch_state.state in ("unavailable", "unknown"):
+            reason = "switch_entity_not_found" if switch_state is None else "switch_unavailable"
+            _LOGGER.error(
+                "Zone '%s' valve '%s' %s, skipping volume_preset",
+                zone.zone_name,
+                zone.valve,
+                reason,
+            )
+            await self._notify_unreachable_at_irrigation(zone.valve, reason)
+            return 0.0
+
         # 1) Arm the dose
         await self._hass.services.async_call(
             "number",
@@ -777,6 +793,25 @@ class IrrigationController:
 
     # ── Valve helpers ─────────────────────────────────────
 
+    async def _notify_unreachable_at_irrigation(self, entity_id: str, reason: str) -> None:
+        """Surface a UNREACHABLE_AT_IRRIGATION notification.
+
+        Fired when the user (or scheduler) asked the integration to open a
+        valve but the pre-check failed: the switch entity is missing,
+        ``unavailable`` or ``unknown``. The notifier dedups on
+        ``(zone, kind, context)`` so repeated presses do not stack
+        identical notifications.
+        """
+        if self._notifier is None:
+            return
+        zone_name = self._valve_to_zone.get(entity_id, entity_id)
+        await self._notifier.notify(
+            zone_name,
+            NotificationKind.UNREACHABLE_AT_IRRIGATION,
+            Severity.WARNING,
+            context={"entity_id": entity_id, "reason": reason},
+        )
+
     async def _wait_with_stop_check(self, duration_s: int) -> None:
         """Wait for duration, checking for stop requests every second."""
         for _ in range(duration_s):
@@ -804,6 +839,8 @@ class IrrigationController:
                 result.status.value,
                 result.error_detail,
             )
+            if result.status == OperationStatus.PRECHECK_FAILED:
+                await self._notify_unreachable_at_irrigation(entity_id, result.error_detail or "unavailable")
             return False
         return True
 

--- a/custom_components/never_dry/valve_notifier.py
+++ b/custom_components/never_dry/valve_notifier.py
@@ -82,7 +82,10 @@ _TEMPLATES: dict[NotificationKind, _Template] = {
     ),
     NotificationKind.UNREACHABLE_AT_IRRIGATION: _Template(
         title="Valve unreachable at irrigation time",
-        body="Could not start scheduled irrigation for zone '{zone}': valve unavailable.",
+        body=(
+            "Could not start irrigation for zone '{zone}': valve unavailable "
+            "({reason}). Check the valve battery / Zigbee mesh before retrying."
+        ),
     ),
     NotificationKind.FLOW_METER_DEAD: _Template(
         title="Flow meter unavailable",

--- a/tests/test_controller_with_operator.py
+++ b/tests/test_controller_with_operator.py
@@ -314,6 +314,153 @@ async def test_partial_irrigation_updates_last_irrigated(hass_mock, di_sensor):
     assert zone._last_volume_delivered == round(partial, 1)
 
 
+# ── Unreachable-at-irrigation notification ───────────────────────────
+
+
+async def test_open_precheck_failed_fires_unreachable_notification(hass_mock, di_sensor):
+    """A PRECHECK_FAILED open result fires UNREACHABLE_AT_IRRIGATION."""
+    from never_dry.valve_notifier import NotificationKind, ValveNotifier
+
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+    notifier = ValveNotifier(hass_mock)
+    op = _fake_operator(
+        open_result=OperationResult(OperationStatus.PRECHECK_FAILED, "switch_unavailable"),
+    )
+    ctrl = IrrigationController(
+        hass_mock,
+        di_sensor,
+        [zone],
+        inter_zone_delay=0,
+        valve_operators={zone.valve: op},
+        notifier=notifier,
+    )
+
+    delivered = await ctrl._deliver_estimated_flow(zone)
+    assert delivered == 0.0
+    assert notifier.is_active("Orto", NotificationKind.UNREACHABLE_AT_IRRIGATION)
+
+
+async def test_open_failed_does_not_fire_unreachable_notification(hass_mock, di_sensor):
+    """A FAILED (not PRECHECK_FAILED) open does *not* fire the unreachable kind.
+
+    The operator already raises COMMAND_FAILED in that case; we must not
+    double-notify with UNREACHABLE_AT_IRRIGATION.
+    """
+    from never_dry.valve_notifier import NotificationKind, ValveNotifier
+
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+    notifier = ValveNotifier(hass_mock)
+    op = _fake_operator(
+        open_result=OperationResult(OperationStatus.FAILED, "open_failed"),
+    )
+    ctrl = IrrigationController(
+        hass_mock,
+        di_sensor,
+        [zone],
+        inter_zone_delay=0,
+        valve_operators={zone.valve: op},
+        notifier=notifier,
+    )
+
+    await ctrl._deliver_estimated_flow(zone)
+    assert not notifier.is_active("Orto", NotificationKind.UNREACHABLE_AT_IRRIGATION)
+
+
+async def test_volume_preset_unavailable_valve_notifies_and_aborts(hass_mock, di_sensor):
+    """volume_preset pre-checks the switch and notifies if unavailable."""
+    from never_dry.valve_notifier import NotificationKind, ValveNotifier
+
+    cfg = {
+        CONF_ZONE_NAME: "Orto",
+        CONF_ZONE_VALVE: "switch.valve_orto",
+        CONF_ZONE_AREA: 20.0,
+        CONF_ZONE_EFFICIENCY: 0.90,
+        CONF_ZONE_FLOW_RATE: 8.0,
+        CONF_ZONE_THRESHOLD: 15.0,
+        CONF_ZONE_DELIVERY_MODE: "volume_preset",
+        CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
+    }
+    zone = IrrigationZoneSensor(hass_mock, cfg, di_sensor)
+    zone._zone_deficit = 5.0
+
+    # Switch reports unavailable.
+    hass_mock.states.get = MagicMock(return_value=MagicMock(state="unavailable"))
+
+    notifier = ValveNotifier(hass_mock)
+    ctrl = IrrigationController(
+        hass_mock,
+        di_sensor,
+        [zone],
+        inter_zone_delay=0,
+        notifier=notifier,
+    )
+
+    delivered = await ctrl._deliver_volume_preset(zone)
+    assert delivered == 0.0
+    assert notifier.is_active("Orto", NotificationKind.UNREACHABLE_AT_IRRIGATION)
+    # No number.set_value should have been sent.
+    set_value_calls = [c for c in hass_mock.services.async_call.call_args_list if c.args[:2] == ("number", "set_value")]
+    assert set_value_calls == []
+
+
+async def test_volume_preset_missing_switch_entity_notifies(hass_mock, di_sensor):
+    """volume_preset reports switch_entity_not_found when state is None."""
+    from never_dry.valve_notifier import NotificationKind, ValveNotifier
+
+    cfg = {
+        CONF_ZONE_NAME: "Orto",
+        CONF_ZONE_VALVE: "switch.valve_orto",
+        CONF_ZONE_AREA: 20.0,
+        CONF_ZONE_EFFICIENCY: 0.90,
+        CONF_ZONE_FLOW_RATE: 8.0,
+        CONF_ZONE_THRESHOLD: 15.0,
+        CONF_ZONE_DELIVERY_MODE: "volume_preset",
+        CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
+    }
+    zone = IrrigationZoneSensor(hass_mock, cfg, di_sensor)
+    zone._zone_deficit = 5.0
+    hass_mock.states.get = MagicMock(return_value=None)
+
+    notifier = ValveNotifier(hass_mock)
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0, notifier=notifier)
+
+    delivered = await ctrl._deliver_volume_preset(zone)
+    assert delivered == 0.0
+    assert notifier.is_active("Orto", NotificationKind.UNREACHABLE_AT_IRRIGATION)
+    active = notifier._active[("Orto", NotificationKind.UNREACHABLE_AT_IRRIGATION)]
+    assert active.context["reason"] == "switch_entity_not_found"
+
+
+async def test_unreachable_notification_dedupes_across_retries(hass_mock, di_sensor):
+    """Multiple consecutive presses on an unavailable valve produce one notification."""
+    from never_dry.valve_notifier import ValveNotifier
+
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 5.0
+    notifier = ValveNotifier(hass_mock)
+    op = _fake_operator(
+        open_result=OperationResult(OperationStatus.PRECHECK_FAILED, "switch_unavailable"),
+    )
+    ctrl = IrrigationController(
+        hass_mock,
+        di_sensor,
+        [zone],
+        inter_zone_delay=0,
+        valve_operators={zone.valve: op},
+        notifier=notifier,
+    )
+
+    for _ in range(3):
+        await ctrl._deliver_estimated_flow(zone)
+
+    create_calls = [
+        c for c in hass_mock.services.async_call.call_args_list if c.args[:2] == ("persistent_notification", "create")
+    ]
+    assert len(create_calls) == 1
+
+
 async def test_volume_preset_stop_during_run(hass_mock, di_sensor):
     """A stop signal during volume_preset issues switch.turn_off and returns 0."""
     cfg = {


### PR DESCRIPTION
## Summary

Close the "no feedback when user presses Irrigate on an unavailable valve" gap by emitting a `UNREACHABLE_AT_IRRIGATION` WARNING persistent notification on every pre-check failure.

This is the **at-irrigation-time** half of AI-023. The passive >6h check is intentionally left out and remains TODO under AI-023 proper.

## What was broken

Before this PR, when the user pressed *Irrigate* (or a scheduled trigger fired) on a valve whose switch entity was `unavailable`, the integration:

1. Called `ValveOperator.open()` → pre-check failed → returned `PRECHECK_FAILED`.
2. Logged an error and aborted the delivery.
3. **Did nothing user-visible** — no notification, no entity state, no event.

Same for `volume_preset` mode (which bypasses the operator) — no pre-check at all, the `number.set_value` was sent into the void.

## What this PR does

- `_open_valve`: when the operator returns `PRECHECK_FAILED`, surface a WARNING `UNREACHABLE_AT_IRRIGATION` notification with the reason (`switch_entity_not_found` / `switch_unavailable`) before bailing out.
- `_deliver_volume_preset`: added an explicit switch pre-check before sending `number.set_value`. Same notification path on failure.
- `UNREACHABLE_AT_IRRIGATION` template updated to be generic (was hardcoded to "scheduled irrigation") and to include the `{reason}` from the context.
- Dedup: the notifier already keys on `(zone, kind, context)`, so repeated presses on the same unavailable valve produce **one** notification, not a stack.

## What it does NOT do

- No retries are added — pre-check failures fail fast on purpose.
- No periodic >6h passive unavailable check (that's still AI-023 proper).
- `FAILED` (non-precheck) and `MAINTENANCE` results keep their existing notifications (`COMMAND_FAILED` from the operator and `ZONE_DISABLED` on entry to maintenance respectively). No double-notify.

## Test plan
- [x] +5 unit tests in `test_controller_with_operator.py` (precheck fires, failed does not fire, volume_preset unavailable + missing-entity, dedup across retries).
- [x] Full suite: **364 passed**.
- [x] `ruff format --check` and `ruff check` clean.
- [ ] Field test: press Irrigate on a powered-down Sonoff SWV → see a "Valve unreachable at irrigation time" persistent notification appear.

## Notes

Independent of PR #46 (real-time deficit update). Either can land first; they touch the same files but the diffs don't overlap.