### PR TITLE
feat: track is_irrigating + auto-close on external valve open

### DIFF
--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -422,7 +422,7 @@ class IrrigationController:
                         EVENT_IRRIGATION_COMPLETE,
                         {
                             "zone": zone_name,
-                            "source": "automatic",
+                            "source": self._current_source or "automatic",
                             "volume_liters": round(delivered, 1),
                             "volume_target": round(volume_target, 1),
                             "deficit_mm": round(zone._zone_deficit, 2),

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -95,6 +95,8 @@ class IrrigationController:
         self._current_source: str | None = None
         # Manual valve tracking: valve_entity_id → flow meter reading at valve open
         self._manual_valve_open: dict[str, float | None] = {}
+        # Per-valve safety-close watchdog for external (non-commanded) opens
+        self._manual_safety_tasks: dict[str, asyncio.Task] = {}
         # Reverse map: valve_entity_id → zone_name
         self._valve_to_zone: dict[str, str] = {zs.valve: zs.zone_name for zs in zone_sensors if zs.valve}
         # Battery sensor → zone_name map
@@ -890,14 +892,32 @@ class IrrigationController:
                     self._manual_valve_open[entity_id] = self._read_flow_meter(zone.flow_meter_sensor)
             else:
                 self._manual_valve_open[entity_id] = None
+            # Reflect "currently irrigating" in zone state so UI/automations
+            # see the same flag they would during a commanded cycle.
+            zone.set_irrigating(True)
+            zone.async_write_ha_state()
+            # Active monitor: closes the valve at the minimum between
+            # volume-needed (if we can measure or estimate it) and the
+            # safety delivery_timeout.
+            self._manual_safety_tasks[entity_id] = self._hass.async_create_task(
+                self._external_session_monitor(entity_id, zone_name),
+            )
             _LOGGER.info(
-                "Manual valve open detected: zone='%s'",
+                "Manual valve open detected: zone='%s' (target=%.1fL, timeout=%ds)",
                 zone_name,
+                zone.volume_liters,
+                zone.delivery_timeout,
             )
 
         elif old_state.state == "on" and new_state.state == "off":
+            # Cancel the safety watchdog: the user (or the watchdog itself)
+            # already closed the valve.
+            task = self._manual_safety_tasks.pop(entity_id, None)
+            if task and not task.done():
+                task.cancel()
             # Valve closed — compensate deficit
             baseline = self._manual_valve_open.pop(entity_id, None)
+            zone.set_irrigating(False)
 
             if zone.flow_meter_sensor and baseline is not None:
                 is_rate = self._is_flow_rate_sensor(zone.flow_meter_sensor)
@@ -955,6 +975,170 @@ class IrrigationController:
                     "deficit_mm": round(zone._zone_deficit, 2),
                 },
             )
+
+    async def _external_session_monitor(self, entity_id: str, zone_name: str) -> None:
+        """Auto-close a manually-opened valve at min(volume_needed, timeout).
+
+        Started when the user opens the valve from the physical button on
+        the device, the Zigbee app, or the HA switch UI (i.e. anything
+        outside NeverDry's commanded path). Three exit conditions:
+
+        1. **Volume target reached** — if the zone has a flow meter we
+           poll it and close as soon as the delivered amount covers the
+           current ``volume_liters`` (deficit-driven target).
+        2. **Estimated duration elapsed** — without a flow meter but
+           with a configured ``flow_rate``, we sleep for
+           ``volume_liters / flow_rate`` and close.
+        3. **Safety timeout** — ``delivery_timeout`` is always honoured
+           as the upper bound, so a forgotten-open valve cannot run
+           indefinitely.
+
+        The final ``switch.turn_off`` triggers the OFF transition that
+        :meth:`_on_valve_state_change` uses to finalise the session
+        (deficit, ``last_irrigated``, ``is_irrigating``). If the user
+        closes the valve first, the OFF transition cancels this task
+        before it gets a chance to send the service call.
+        """
+        zone = self._zones.get(zone_name)
+        if zone is None:
+            return
+        timeout_s = max(1, zone.delivery_timeout)
+        volume_target = zone.volume_liters
+
+        try:
+            if volume_target > 0 and zone.flow_meter_sensor:
+                await self._monitor_via_flow_meter(
+                    entity_id,
+                    zone_name,
+                    zone,
+                    volume_target,
+                    timeout_s,
+                )
+            elif volume_target > 0 and zone._flow_rate > 0:
+                # Estimated duration: volume / flow_rate (L/min) → seconds
+                estimated_s = int(volume_target / zone._flow_rate * 60)
+                wait_s = min(estimated_s, timeout_s)
+                _LOGGER.info(
+                    "Manual valve '%s': estimated %ds for %.1fL (timeout=%ds, waiting %ds)",
+                    zone_name,
+                    estimated_s,
+                    volume_target,
+                    timeout_s,
+                    wait_s,
+                )
+                await asyncio.sleep(wait_s)
+            else:
+                # No way to measure or estimate — fall back to safety
+                # timeout only. The valve will be force-closed when the
+                # timeout expires.
+                _LOGGER.info(
+                    "Manual valve '%s': no measurable target, safety timeout=%ds",
+                    zone_name,
+                    timeout_s,
+                )
+                await asyncio.sleep(timeout_s)
+        except asyncio.CancelledError:
+            return
+
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state != "on":
+            return
+        _LOGGER.info(
+            "Manual valve '%s' auto-close: target reached or timeout — sending switch.turn_off",
+            zone_name,
+        )
+        await self._hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=False,
+        )
+
+    async def _monitor_via_flow_meter(
+        self,
+        entity_id: str,
+        zone_name: str,
+        zone,
+        volume_target: float,
+        timeout_s: int,
+    ) -> None:
+        """Poll the flow meter until ``volume_target`` is delivered or timeout.
+
+        Supports both cumulative-volume sensors (L) and rate sensors
+        (L/h, L/min, m³/h) — mirroring the logic used by the commanded
+        delivery paths in :meth:`_deliver_flow_meter` /
+        :meth:`_deliver_flow_rate`.
+        """
+        meter = zone.flow_meter_sensor
+        is_rate = self._is_flow_rate_sensor(meter)
+        elapsed = 0
+        delivered = 0.0
+
+        if is_rate:
+            unit = self._get_flow_meter_unit(meter)
+            while elapsed < timeout_s:
+                await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+                elapsed += FLOW_METER_POLL_INTERVAL_S
+                rate = self._read_flow_meter(meter)
+                if rate is None or rate < 0:
+                    continue
+                if unit in ("L/min", "l/min"):
+                    delivered += rate / 60 * FLOW_METER_POLL_INTERVAL_S
+                elif unit in ("m³/h",):
+                    delivered += rate * 1000 / 3600 * FLOW_METER_POLL_INTERVAL_S
+                else:
+                    delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
+                if delivered >= volume_target:
+                    _LOGGER.info(
+                        "Manual valve '%s' reached target (%.1fL of %.1fL) via flow rate",
+                        zone_name,
+                        delivered,
+                        volume_target,
+                    )
+                    return
+            _LOGGER.warning(
+                "Manual valve '%s' rate-monitor timeout (%ds): %.1fL of %.1fL target",
+                zone_name,
+                timeout_s,
+                delivered,
+                volume_target,
+            )
+            return
+
+        initial = self._read_flow_meter(meter)
+        if initial is None:
+            _LOGGER.warning(
+                "Manual valve '%s': flow meter unavailable at open, falling back to timeout=%ds",
+                zone_name,
+                timeout_s,
+            )
+            await asyncio.sleep(timeout_s)
+            return
+        while elapsed < timeout_s:
+            await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+            elapsed += FLOW_METER_POLL_INTERVAL_S
+            current = self._read_flow_meter(meter)
+            if current is None:
+                continue
+            delivered = current - initial
+            if delivered < 0:
+                initial = 0.0
+                delivered = current
+            if delivered >= volume_target:
+                _LOGGER.info(
+                    "Manual valve '%s' reached target (%.1fL of %.1fL) via cumulative meter",
+                    zone_name,
+                    delivered,
+                    volume_target,
+                )
+                return
+        _LOGGER.warning(
+            "Manual valve '%s' meter-monitor timeout (%ds): %.1fL of %.1fL target",
+            zone_name,
+            timeout_s,
+            delivered,
+            volume_target,
+        )
 
     # ── Battery monitoring ────────────────────────────────
 

--- a/custom_components/never_dry/hacs.json
+++ b/custom_components/never_dry/hacs.json
@@ -1,5 +1,0 @@
-{
-  "name": "NeverDry",
-  "render_readme": true,
-  "homeassistant": "2024.1.0"
-}

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -1,13 +1,17 @@
 {
   "domain": "never_dry",
   "name": "NeverDry",
-  "after_dependencies": ["recorder"],
-  "codeowners": ["@drake69"],
+  "after_dependencies": [
+    "recorder"
+  ],
+  "codeowners": [
+    "@drake69"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/drake69/NeverDry",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -235,14 +235,14 @@ All configuration keys (`CONF_*`), service names (`SERVICE_*`), system types, pl
 
 `IrrigationZoneSensor.is_irrigating`, `_last_irrigated`, `_last_volume_delivered`, and `_zone_deficit` can be mutated through **four** entry points. Three of them share the commanded path (`_irrigate_zones` → `_deliver_water`); the fourth (manual valve open) goes through a dedicated reactive monitor.
 
-| # | Trigger | Entry point | Zone `last_irrigation_source` | `never_dry_irrigation_complete` event `source` | `is_irrigating` toggled | Flow meter integrated |
-|---|---|---|---|---|---|---|
-| 1 | External switch open (physical button on the valve, ZHA, HA switch) | `_on_valve_state_change` (callback on `switch` state changes) + `_external_session_monitor` (asyncio task) | `"manual"` | `"manual"` | yes (on open / on close) | yes (cumulative or rate) |
-| 2 | "Irrigate" button / `irrigate_zone` service / `irrigate_all` service | `_handle_irrigate_zone` / `_handle_irrigate_all` → `_irrigate_zones` → `_deliver_water` | `"button"` | `"automatic"` | yes (inside `_deliver_*` modes) | yes (in `flow_meter` and `flow_rate` modes) |
-| 3 | Scheduler (Mode A reactive, Mode B scheduled) | `_make_reactive_handler` / `_make_scheduled_handler` → `_irrigate_zones` → `_deliver_water` | `"reactive"` / `"scheduled"` | `"automatic"` | yes | yes |
-| 4 | `mark_irrigated` service / "Mark irrigated" button | `_handle_mark_irrigated` → `reset_deficit("mark_irrigated")` | `"mark_irrigated"` | *(no event fired)* | **no** (no physical irrigation through the tracked valve) | no |
+| # | Trigger | Entry point | Source string | `is_irrigating` toggled | Flow meter integrated |
+|---|---|---|---|---|---|
+| 1 | External switch open (physical button on the valve, ZHA, HA switch) | `_on_valve_state_change` (callback on `switch` state changes) + `_external_session_monitor` (asyncio task) | `"manual"` | yes (on open / on close) | yes (cumulative or rate) |
+| 2 | "Irrigate" button / `irrigate_zone` service / `irrigate_all` service | `_handle_irrigate_zone` / `_handle_irrigate_all` → `_irrigate_zones` → `_deliver_water` | `"button"` | yes (inside `_deliver_*` modes) | yes (in `flow_meter` and `flow_rate` modes) |
+| 3 | Scheduler (Mode A reactive, Mode B scheduled) | `_make_reactive_handler` / `_make_scheduled_handler` → `_irrigate_zones` → `_deliver_water` | `"reactive"` / `"scheduled"` | yes | yes |
+| 4 | `mark_irrigated` service / "Mark irrigated" button | `_handle_mark_irrigated` → `reset_deficit("mark_irrigated")` | `"mark_irrigated"` | **no** (no physical irrigation through the tracked valve) | no |
 
-> **Two different "source" fields.** The zone's `last_irrigation_source` attribute carries the *specific* origin (`"button"`, `"reactive"`, `"scheduled"`, `"manual"`, `"mark_irrigated"`). The `never_dry_irrigation_complete` HA event collapses commanded cycles into a single `"automatic"` value and uses `"manual"` only for external-open sessions; trigger 4 emits no event at all. When writing automations that need to distinguish reactive from scheduled, listen for the event and then read the zone's `last_irrigation_source` attribute.
+The source string column applies to both the zone's `last_irrigation_source` attribute and the `source` field of the `never_dry_irrigation_complete` HA event — they are kept in sync so an automation can filter on either. Trigger 4 sets the attribute but emits no event. The legacy fallback string `"automatic"` is only used if `_irrigate_zones` is called without a preceding `_current_source` assignment (defensive default; not reachable from production paths).
 
 **External-vs-commanded discrimination** lives in `_on_valve_state_change`. The callback fires for every state change on a tracked valve entity; the gating is:
 

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -231,6 +231,44 @@ All configuration keys (`CONF_*`), service names (`SERVICE_*`), system types, pl
 - Monitoring mode: 6-hour periodic check with per-zone deficit thresholds
 - Error safety: all valves closed on any exception
 
+#### Irrigation triggers and the External Session Monitor
+
+`IrrigationZoneSensor.is_irrigating`, `_last_irrigated`, `_last_volume_delivered`, and `_zone_deficit` can be mutated through **four** entry points. Three of them share the commanded path (`_irrigate_zones` → `_deliver_water`); the fourth (manual valve open) goes through a dedicated reactive monitor.
+
+| # | Trigger | Entry point | Source string | `is_irrigating` toggled | Flow meter integrated |
+|---|---|---|---|---|---|
+| 1 | External switch open (physical button on the valve, ZHA, HA switch) | `_on_valve_state_change` (callback on `switch` state changes) + `_external_session_monitor` (asyncio task) | `"manual"` | yes (on open / on close) | yes (cumulative or rate) |
+| 2 | "Irrigate" button / `irrigate_zone` service / `irrigate_all` service | `_handle_irrigate_zone` / `_handle_irrigate_all` → `_irrigate_zones` → `_deliver_water` | `"button"` | yes (inside `_deliver_*` modes) | yes (in `flow_meter` and `flow_rate` modes) |
+| 3 | Scheduler (Mode A reactive, Mode B scheduled) | `_make_reactive_handler` / `_make_scheduled_handler` → `_irrigate_zones` → `_deliver_water` | `"reactive"` / `"scheduled"` | yes | yes |
+| 4 | `mark_irrigated` service / "Mark irrigated" button | `_handle_mark_irrigated` → `reset_deficit("mark_irrigated")` | `"mark_irrigated"` | **no** (no physical irrigation through the tracked valve) | no |
+
+**External-vs-commanded discrimination** lives in `_on_valve_state_change`. The callback fires for every state change on a tracked valve entity; the gating is:
+
+1. If a `ValveOperator` is registered for the valve and its FSM state is **not** `IDLE`, the controller is driving the valve — return.
+2. Otherwise, if there is no operator and the legacy `_running` flag is `True`, another commanded cycle is in progress — return.
+3. Otherwise, the transition is external.
+
+For an external `off → on` transition:
+- Record the flow meter baseline (cumulative reading or `time.monotonic()` for rate sensors) in `_manual_valve_open`.
+- Call `zone.set_irrigating(True)` and `zone.async_write_ha_state()` so UI and automations see the same "currently irrigating" attribute they would during a commanded cycle.
+- Schedule the auto-close monitor task and store it in `_manual_safety_tasks`.
+
+For an external `on → off` transition:
+- Cancel the monitor task (the OFF transition is either the user closing or the monitor's own `switch.turn_off` completing).
+- Call `zone.set_irrigating(False)`.
+- Compute the delivered volume from the flow meter (cumulative diff or rate × duration). Reduce the deficit proportionally; if no flow meter is present, the deficit is fully reset (same semantics as `mark_irrigated`, since the user did open the valve and we have no evidence to estimate otherwise).
+- Stamp `_last_irrigated`, `_last_volume_delivered`, `_last_irrigation_source = "manual"`, and fire `never_dry_irrigation_complete` with `source: "manual"`.
+
+**`_external_session_monitor(entity_id, zone_name)`** is the auto-close brain. Started from the open detection, it must terminate the manual session at the **minimum** of:
+
+1. **Volume target reached.** When the zone has a `flow_meter_sensor`, the monitor polls every `FLOW_METER_POLL_INTERVAL_S` seconds. For cumulative sensors it tracks `current - initial`; for rate sensors it integrates `rate × dt` (units L/min, L/h, m³/h handled explicitly). It exits as soon as `delivered >= volume_target`.
+2. **Estimated duration elapsed.** Without a flow meter but with a configured `flow_rate` (L/min), the monitor sleeps for `min(volume_liters / flow_rate × 60, delivery_timeout)`.
+3. **Safety timeout.** `delivery_timeout` is always honoured as the upper bound. No measurement, no estimate, no target → fall back to a pure sleep.
+
+After waking up, the monitor checks the switch is still `"on"` and sends `switch.turn_off`. The resulting `on → off` state change is picked up by `_on_valve_state_change`, which finalises the session. If the user closes the valve first the monitor task is cancelled and never sends the service call.
+
+**Why two layers instead of one.** Keeping detection (`_on_valve_state_change`, a sync `@callback`) separate from the auto-close (an async task) avoids re-entrancy: the callback returns immediately so HA's event loop is not blocked, and the monitor can `await asyncio.sleep` safely. The same shape is used by `_deliver_flow_meter` / `_deliver_flow_rate` for commanded cycles.
+
 ### config_flow.py
 
 | Class | Purpose |
@@ -248,6 +286,7 @@ Services are registered in `IrrigationController.register_services()`.
 | `never_dry.irrigate_zone` | `_handle_irrigate_zone` | Single zone: open → wait → close → reset zone deficit |
 | `never_dry.irrigate_all` | `_handle_irrigate_all` | All zones sequentially, then reset all deficits |
 | `never_dry.stop` | `_handle_stop` | Close all valves, abort cycle (no deficit reset) |
+| `never_dry.mark_irrigated` | `_handle_mark_irrigated` | Resets deficit without opening any valve (used when the user watered with a different tool — hose, separate sprinkler, unmetered rain) |
 
 ## 6. Config flow
 

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -235,12 +235,14 @@ All configuration keys (`CONF_*`), service names (`SERVICE_*`), system types, pl
 
 `IrrigationZoneSensor.is_irrigating`, `_last_irrigated`, `_last_volume_delivered`, and `_zone_deficit` can be mutated through **four** entry points. Three of them share the commanded path (`_irrigate_zones` → `_deliver_water`); the fourth (manual valve open) goes through a dedicated reactive monitor.
 
-| # | Trigger | Entry point | Source string | `is_irrigating` toggled | Flow meter integrated |
-|---|---|---|---|---|---|
-| 1 | External switch open (physical button on the valve, ZHA, HA switch) | `_on_valve_state_change` (callback on `switch` state changes) + `_external_session_monitor` (asyncio task) | `"manual"` | yes (on open / on close) | yes (cumulative or rate) |
-| 2 | "Irrigate" button / `irrigate_zone` service / `irrigate_all` service | `_handle_irrigate_zone` / `_handle_irrigate_all` → `_irrigate_zones` → `_deliver_water` | `"button"` | yes (inside `_deliver_*` modes) | yes (in `flow_meter` and `flow_rate` modes) |
-| 3 | Scheduler (Mode A reactive, Mode B scheduled) | `_make_reactive_handler` / `_make_scheduled_handler` → `_irrigate_zones` → `_deliver_water` | `"reactive"` / `"scheduled"` | yes | yes |
-| 4 | `mark_irrigated` service / "Mark irrigated" button | `_handle_mark_irrigated` → `reset_deficit("mark_irrigated")` | `"mark_irrigated"` | **no** (no physical irrigation through the tracked valve) | no |
+| # | Trigger | Entry point | Zone `last_irrigation_source` | `never_dry_irrigation_complete` event `source` | `is_irrigating` toggled | Flow meter integrated |
+|---|---|---|---|---|---|---|
+| 1 | External switch open (physical button on the valve, ZHA, HA switch) | `_on_valve_state_change` (callback on `switch` state changes) + `_external_session_monitor` (asyncio task) | `"manual"` | `"manual"` | yes (on open / on close) | yes (cumulative or rate) |
+| 2 | "Irrigate" button / `irrigate_zone` service / `irrigate_all` service | `_handle_irrigate_zone` / `_handle_irrigate_all` → `_irrigate_zones` → `_deliver_water` | `"button"` | `"automatic"` | yes (inside `_deliver_*` modes) | yes (in `flow_meter` and `flow_rate` modes) |
+| 3 | Scheduler (Mode A reactive, Mode B scheduled) | `_make_reactive_handler` / `_make_scheduled_handler` → `_irrigate_zones` → `_deliver_water` | `"reactive"` / `"scheduled"` | `"automatic"` | yes | yes |
+| 4 | `mark_irrigated` service / "Mark irrigated" button | `_handle_mark_irrigated` → `reset_deficit("mark_irrigated")` | `"mark_irrigated"` | *(no event fired)* | **no** (no physical irrigation through the tracked valve) | no |
+
+> **Two different "source" fields.** The zone's `last_irrigation_source` attribute carries the *specific* origin (`"button"`, `"reactive"`, `"scheduled"`, `"manual"`, `"mark_irrigated"`). The `never_dry_irrigation_complete` HA event collapses commanded cycles into a single `"automatic"` value and uses `"manual"` only for external-open sessions; trigger 4 emits no event at all. When writing automations that need to distinguish reactive from scheduled, listen for the event and then read the zone's `last_irrigation_source` attribute.
 
 **External-vs-commanded discrimination** lives in `_on_valve_state_change`. The callback fires for every state change on a tracked valve entity; the gating is:
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -121,6 +121,16 @@
                 <h3>Nahtlose Updates</h3>
                 <p>Automatisierte Releases &uuml;ber GitHub Actions. Konfigurationsmigration bewahrt Ihre Einstellungen &uuml;ber Versionen hinweg. Ein-Klick-Update in HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Manuelles Ventil erkannt</h3>
+                <p>&Ouml;ffnen Sie das Ventil per Knopf, Zigbee-App oder HA — NeverDry verfolgt die Sitzung, aktualisiert das Defizit und schlie&szlig;t automatisch beim Minimum aus ben&ouml;tigter Wassermenge und Sicherheits-Timeout.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Alle Ausl&ouml;ser abgedeckt</h3>
+                <p>Bew&auml;sserung per Scheduler, Lovelace-Button, Automation, Ventilknopf oder &raquo;Mit dem Schlauch gegossen&laquo; — NeverDry h&auml;lt das Defizit in allen vier F&auml;llen aktuell.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -134,6 +134,16 @@
                 <h3>Nahtlose Updates</h3>
                 <p>Automatisierte Releases &uuml;ber GitHub Actions. Konfigurationsmigration bewahrt Ihre Einstellungen &uuml;ber Versionen hinweg. Ein-Klick-Update in HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Manuelles Ventil erkannt</h3>
+                <p>&Ouml;ffnen Sie das Ventil per Knopf, Zigbee-App oder HA — NeverDry verfolgt die Sitzung, aktualisiert das Defizit und schlie&szlig;t automatisch beim Minimum aus ben&ouml;tigter Wassermenge und Sicherheits-Timeout.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Alle Ausl&ouml;ser abgedeckt</h3>
+                <p>Bew&auml;sserung per Scheduler, Lovelace-Button, Automation, Ventilknopf oder &raquo;Mit dem Schlauch gegossen&laquo; — NeverDry h&auml;lt das Defizit in allen vier F&auml;llen aktuell.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -129,6 +129,16 @@
                 <h3>Actualizaciones Transparentes</h3>
                 <p>Releases automatizadas v&iacute;a GitHub Actions. La migraci&oacute;n de configuraci&oacute;n preserva tus ajustes entre versiones. Actualizaci&oacute;n con un clic en HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>V&aacute;lvula manual reconocida</h3>
+                <p>Abre la v&aacute;lvula desde el bot&oacute;n f&iacute;sico, la app Zigbee o HA — NeverDry rastrea la sesi&oacute;n, actualiza el d&eacute;ficit y cierra autom&aacute;ticamente al m&iacute;nimo entre agua necesaria y timeout de seguridad.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Todos los disparadores cubiertos</h3>
+                <p>Riego desde el programador, bot&oacute;n Lovelace, automatizaciones, bot&oacute;n de la v&aacute;lvula, o registra &laquo;regu&eacute; con la manguera&raquo; — NeverDry mantiene el d&eacute;ficit honesto en los cuatro casos.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -134,6 +134,16 @@
                 <h3>Mises &agrave; Jour Transparentes</h3>
                 <p>Releases automatis&eacute;es via GitHub Actions. La migration de configuration pr&eacute;serve vos param&egrave;tres entre les versions. Mise &agrave; jour en un clic dans HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Vanne manuelle reconnue</h3>
+                <p>Ouvrez la vanne depuis le bouton physique, l'app Zigbee ou HA — NeverDry suit la session, met &agrave; jour le d&eacute;ficit et ferme automatiquement au minimum entre eau n&eacute;cessaire et timeout de s&eacute;curit&eacute;.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Tous les d&eacute;clencheurs couverts</h3>
+                <p>Arrosage depuis le planificateur, bouton Lovelace, automatisations, bouton de la vanne, ou enregistrez &laquo;j'ai arros&eacute; au tuyau&raquo; — NeverDry garde le d&eacute;ficit &agrave; jour dans les quatre cas.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -121,6 +121,16 @@
                 <h3>Be&scaron;avna A&zcaron;uriranja</h3>
                 <p>Automatizirana izdanja putem GitHub Actions. Migracija konfiguracije &ccaron;uva va&scaron;e postavke između verzija. A&zcaron;uriranje jednim klikom u HACS-u.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Ru&ccaron;ni ventil prepoznat</h3>
+                <p>Otvorite ventil fizi&ccaron;kim gumbom, Zigbee aplikacijom ili iz HA — NeverDry prati sesiju, a&zcaron;urira deficit i automatski zatvara pri manjem od potrebne vode i sigurnosnog timeouta.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Svi okida&ccaron;i pokriveni</h3>
+                <p>Navodnjavanje iz rasporeda, Lovelace gumba, automatizacija, gumba na ventilu, ili zabilje&zcaron;ite &laquo;zalio sam crijevom&raquo; — NeverDry odr&zcaron;ava deficit to&ccaron;nim u sva &ccaron;etiri slu&ccaron;aja.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -121,6 +121,16 @@
                 <h3>Z&ouml;kken&odblac;mentes Friss&iacute;t&eacute;sek</h3>
                 <p>Automatiz&aacute;lt kiad&aacute;sok GitHub Actions-&ouml;n kereszt&uuml;l. A konfigur&aacute;ci&oacute;-migr&aacute;ci&oacute; meg&odblac;rzi a be&aacute;ll&iacute;t&aacute;sait verzi&oacute;k k&ouml;z&ouml;tt. Egyetlen kattint&aacute;ssal friss&iacute;thet&odblac; HACS-ban.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Manu&aacute;lis szelep felismer&eacute;se</h3>
+                <p>Nyisd ki a szelepet fizikai gombbal, Zigbee alkalmaz&aacute;sb&oacute;l vagy HA-b&oacute;l — a NeverDry k&ouml;veti a foly&aacute;st, friss&iacute;ti a hi&aacute;nyt &eacute;s automatikusan z&aacute;r a sz&uuml;ks&eacute;ges v&iacute;z &eacute;s a biztons&aacute;gi timeout k&ouml;z&uuml;l a kisebbn&eacute;l.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Minden trigger lefedve</h3>
+                <p>&Ouml;nt&ouml;z&eacute;s &uuml;temez&eacute;sb&odblac;l, Lovelace gombr&oacute;l, automatiz&aacute;ci&oacute;b&oacute;l, szelep gombr&oacute;l, vagy r&ouml;gz&iacute;tsd hogy &laquo;locsoltam tuk&aacute;val&raquo; — a NeverDry n&eacute;gy esetb&odblac;l mind n&eacute;gyben pontosan tartja a hi&aacute;nyt.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -302,6 +302,16 @@
                 <h3>Seamless Updates</h3>
                 <p>Automated releases via GitHub Actions. Config migration preserves your settings across versions. Update with one click in HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Manual Valve Aware</h3>
+                <p>Open the valve from the physical button, the Zigbee app, or HA — NeverDry tracks the session, updates the deficit, and auto-closes at the minimum between water needed and safety timeout.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Multiple Triggers</h3>
+                <p>Irrigate from the scheduler, from a Lovelace button, from automations, from the valve itself, or just record "I watered with the hose" — NeverDry keeps the deficit honest in all four cases.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -84,7 +84,7 @@
 <section class="hero">
     <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
     <h1>NeverDry</h1>
-    <p class="tagline">Irrigazione intelligente per Home Assistant. Un modello scientifico di bilancio idrico che sa quando e quanto irrigare il tuo giardino.</p>
+    <p class="tagline">Irrigazione intelligente per Home Assistant. Un modello scientifico di bilancio idrico che decide quando e quanto irrigare in base al fabbisogno reale del giardino.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
@@ -101,38 +101,48 @@
         <div class="feature-grid">
             <div class="feature-card">
                 <div class="icon">🌡️</div>
-                <h3>Modello ET Scientifico</h3>
-                <p>Bilancio idrico FAO-56 semplificato. Stima l'evapotraspirazione dalla temperatura con due parametri calibrabili.</p>
+                <h3>Modello ET scientifico</h3>
+                <p>Bilancio idrico ispirato allo standard FAO-56 in forma semplificata. L'evapotraspirazione &egrave; stimata a partire dalla temperatura con due parametri calibrabili.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">🌱</div>
-                <h3>10 Famiglie di Piante</h3>
-                <p>Coefficiente colturale (Kc) per zona con variazione stagionale. Prato, ortaggi, succulente, alberi da frutto e altro. Adattamento automatico all'emisfero.</p>
+                <h3>Dieci famiglie di piante</h3>
+                <p>Coefficiente colturale (K<sub>c</sub>) per zona con variazione stagionale: prato, ortaggi, succulente, alberi da frutto e altri profili predefiniti. L'andamento si adatta automaticamente all'emisfero di installazione.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">🚿</div>
-                <h3>Controllo Diretto Valvole</h3>
-                <p>Apre e chiude le valvole automaticamente. Irrigazione multi-zona sequenziale con arresto d'emergenza.</p>
+                <h3>Controllo diretto delle valvole</h3>
+                <p>Apertura e chiusura automatica delle valvole, irrigazione multi-zona in sequenza per evitare cali di pressione e arresto di emergenza disponibile in qualsiasi momento.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">📊</div>
-                <h3>Deficit per Zona</h3>
-                <p>Ogni zona traccia il proprio deficit idrico del suolo. Piante diverse si asciugano a velocit&agrave; diverse — com'&egrave; giusto che sia.</p>
+                <h3>Deficit per zona</h3>
+                <p>Ogni zona mantiene il proprio deficit idrico del suolo. Piante diverse si asciugano a ritmi diversi e ricevono acqua di conseguenza.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">🌧️</div>
-                <h3>Sensibile alla Pioggia</h3>
-                <p>Salta automaticamente l'irrigazione nei giorni di pioggia. Il deficit diminuisce ad ogni evento piovoso.</p>
+                <h3>Sensibile alla pioggia</h3>
+                <p>L'irrigazione viene omessa quando le precipitazioni hanno gi&agrave; ricostituito la riserva idrica. Il deficit diminuisce a ogni evento piovoso rilevato dal sensore.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">⚙️</div>
-                <h3>Configurazione da UI</h3>
-                <p>Configurazione completa dall'interfaccia di Home Assistant. Nessuna modifica YAML necessaria.</p>
+                <h3>Configurazione da interfaccia</h3>
+                <p>Tutta la configurazione avviene dall'interfaccia di Home Assistant, senza modifiche a file YAML.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">🔄</div>
-                <h3>Aggiornamenti Trasparenti</h3>
-                <p>Release automatiche tramite GitHub Actions. La migrazione della configurazione preserva le impostazioni tra le versioni. Aggiornamento con un click in HACS.</p>
+                <h3>Aggiornamenti senza interruzioni</h3>
+                <p>Le release sono pubblicate automaticamente tramite GitHub Actions e la migrazione di configurazione preserva le impostazioni tra una versione e l'altra. L'aggiornamento avviene con un clic da HACS.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>Apertura manuale riconosciuta</h3>
+                <p>Quando la valvola viene aperta dal pulsante fisico, dall'applicazione Zigbee o dallo switch di Home Assistant, NeverDry rileva la sessione, aggiorna il deficit e chiude la valvola al minore fra il volume necessario e il timeout di sicurezza.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Tutte le modalit&agrave; di innesco</h3>
+                <p>Irrigazione programmata, pulsante &laquo;Irriga&raquo; sulla scheda della zona, automazioni di Home Assistant, pulsante a bordo valvola e registrazione di un'irrigazione effettuata con mezzi esterni (ad esempio canna o tubo): in tutti i casi il deficit resta coerente con la realt&agrave; del giardino.</p>
             </div>
         </div>
     </div>
@@ -140,33 +150,33 @@
 
 <section class="how-it-works">
     <div class="container">
-        <h2>Come Funziona</h2>
-        <p>NeverDry traccia un semplice bilancio idrico per ogni zona di irrigazione:</p>
+        <h2>Come funziona</h2>
+        <p>NeverDry mantiene un bilancio idrico per ciascuna zona di irrigazione secondo la relazione:</p>
         <div class="formula">
-            D<sub>zona</sub>(t) = D<sub>zona</sub>(t-1) + ET<sub>h</sub> &times; Kc &times; &Delta;t &minus; pioggia
+            D<sub>zona</sub>(t) = D<sub>zona</sub>(t-1) + ET<sub>h</sub> &times; K<sub>c</sub> &times; &Delta;t &minus; pioggia
         </div>
-        <p>Quando il deficit &egrave; alto, il suolo &egrave; secco e ha bisogno d'acqua. Quando piove, il deficit cala. Dopo l'irrigazione, si azzera. <strong>1 mm di deficit = 1 litro per metro quadro necessario.</strong></p>
+        <p>Quando il deficit &egrave; elevato il suolo &egrave; asciutto e richiede acqua; quando piove il deficit diminuisce; dopo un'irrigazione si riporta a zero (o si riduce in proporzione al volume effettivamente erogato). <strong>Un millimetro di deficit corrisponde a un litro di acqua per ogni metro quadrato da reintegrare.</strong></p>
     </div>
 </section>
 
 <section class="families">
     <div class="container">
-        <h2>Famiglie di Piante</h2>
+        <h2>Famiglie di piante</h2>
         <table>
             <thead>
                 <tr><th>Famiglia</th><th>Inverno</th><th>Primavera</th><th>Estate</th><th>Autunno</th></tr>
             </thead>
             <tbody>
-                <tr><td>Prato / Tappeto erboso</td><td>0.45</td><td>0.85</td><td>1.00</td><td>0.70</td></tr>
-                <tr><td>Ortaggi (stagionali)</td><td>0.30</td><td>0.70</td><td>1.10</td><td>0.50</td></tr>
-                <tr><td>Alberi da frutto (decidui)</td><td>0.35</td><td>0.70</td><td>0.95</td><td>0.55</td></tr>
-                <tr><td>Arbusti ornamentali</td><td>0.40</td><td>0.65</td><td>0.80</td><td>0.55</td></tr>
-                <tr><td>Erbe aromatiche (mediterranee)</td><td>0.30</td><td>0.55</td><td>0.70</td><td>0.40</td></tr>
-                <tr><td>Agrumi / Sempreverdi da frutto</td><td>0.60</td><td>0.65</td><td>0.70</td><td>0.65</td></tr>
-                <tr><td>Rose</td><td>0.35</td><td>0.75</td><td>0.95</td><td>0.55</td></tr>
-                <tr><td>Succulente / Cactacee</td><td>0.15</td><td>0.25</td><td>0.35</td><td>0.20</td></tr>
-                <tr><td>Tappezzanti autoctone</td><td>0.25</td><td>0.45</td><td>0.55</td><td>0.35</td></tr>
-                <tr><td>Giardino misto</td><td>0.40</td><td>0.70</td><td>0.90</td><td>0.55</td></tr>
+                <tr><td>Prato / tappeto erboso</td><td>0,45</td><td>0,85</td><td>1,00</td><td>0,70</td></tr>
+                <tr><td>Ortaggi (stagionali)</td><td>0,30</td><td>0,70</td><td>1,10</td><td>0,50</td></tr>
+                <tr><td>Alberi da frutto (decidui)</td><td>0,35</td><td>0,70</td><td>0,95</td><td>0,55</td></tr>
+                <tr><td>Arbusti ornamentali</td><td>0,40</td><td>0,65</td><td>0,80</td><td>0,55</td></tr>
+                <tr><td>Erbe aromatiche (mediterranee)</td><td>0,30</td><td>0,55</td><td>0,70</td><td>0,40</td></tr>
+                <tr><td>Agrumi e sempreverdi da frutto</td><td>0,60</td><td>0,65</td><td>0,70</td><td>0,65</td></tr>
+                <tr><td>Rose</td><td>0,35</td><td>0,75</td><td>0,95</td><td>0,55</td></tr>
+                <tr><td>Succulente e cactacee</td><td>0,15</td><td>0,25</td><td>0,35</td><td>0,20</td></tr>
+                <tr><td>Tappezzanti autoctone</td><td>0,25</td><td>0,45</td><td>0,55</td><td>0,35</td></tr>
+                <tr><td>Giardino misto</td><td>0,40</td><td>0,70</td><td>0,90</td><td>0,55</td></tr>
             </tbody>
         </table>
     </div>
@@ -176,39 +186,39 @@
     <div class="container">
         <h2>Installazione</h2>
         <div class="install-steps">
-            <h3>Tramite HACS (consigliato)</h3>
+            <h3>Tramite HACS (consigliata)</h3>
             <ol>
-                <li>Apri HACS &rarr; Integrazioni &rarr; <strong>Repository personalizzati</strong></li>
-                <li>Aggiungi <code>https://github.com/drake69/NeverDry</code> come <strong>Integrazione</strong></li>
-                <li>Cerca <strong>NeverDry</strong> e installa</li>
-                <li>Riavvia Home Assistant</li>
-                <li>Vai su Impostazioni &rarr; Dispositivi e Servizi &rarr; <strong>Aggiungi Integrazione</strong> &rarr; NeverDry</li>
+                <li>Apri HACS &rarr; Integrazioni &rarr; <strong>Repository personalizzati</strong>.</li>
+                <li>Aggiungi <code>https://github.com/drake69/NeverDry</code> come <strong>integrazione</strong>.</li>
+                <li>Cerca <strong>NeverDry</strong> e procedi con l'installazione.</li>
+                <li>Riavvia Home Assistant.</li>
+                <li>Apri Impostazioni &rarr; Dispositivi e servizi &rarr; <strong>Aggiungi integrazione</strong> &rarr; NeverDry.</li>
             </ol>
-            <h3 style="margin-top: 1.5em;">Manuale</h3>
+            <h3 style="margin-top: 1.5em;">Installazione manuale</h3>
             <ol>
-                <li>Copia <code>custom_components/never_dry/</code> nella directory config di HA</li>
-                <li>Riavvia Home Assistant</li>
-                <li>Aggiungi l'integrazione dall'interfaccia</li>
+                <li>Copia la cartella <code>custom_components/never_dry/</code> nella directory di configurazione di Home Assistant.</li>
+                <li>Riavvia Home Assistant.</li>
+                <li>Aggiungi l'integrazione dall'interfaccia.</li>
             </ol>
         </div>
     </div>
 </section>
 
 <section class="support">
-    <h2>Supporta il Progetto</h2>
-    <p>Se NeverDry salva il tuo giardino e la bolletta dell'acqua, considera una donazione:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Supporta su Ko-fi</a>
+    <h2>Sostieni il progetto</h2>
+    <p>Se NeverDry ti aiuta a curare il giardino e a ridurre la bolletta dell'acqua, valuta una piccola donazione.</p>
+    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Sostieni su Ko-fi</a>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">
     <div class="container" style="text-align: left; max-width: 700px;">
         <h2 style="text-align: center;">Avvertenze</h2>
-        <p style="font-size: 0.9em; color: #555;">NeverDry &egrave; un progetto hobbistico per uso residenziale. Non &egrave; certificato per applicazioni agricole, commerciali o critiche per la sicurezza. Il modello ET &egrave; una semplificazione dello standard FAO-56 e non sostituisce la consulenza agronomica professionale. Monitora sempre il tuo impianto di irrigazione. Gli autori declinano ogni responsabilit&agrave; per danni o perdite.</p>
+        <p style="font-size: 0.9em; color: #555;">NeverDry &egrave; un progetto amatoriale destinato a un uso residenziale. Non &egrave; certificato per applicazioni agricole, commerciali o di sicurezza. Il modello di evapotraspirazione &egrave; una semplificazione dello standard FAO-56 e non sostituisce la consulenza agronomica professionale. Si raccomanda di monitorare regolarmente l'impianto di irrigazione. Gli autori declinano ogni responsabilit&agrave; per eventuali danni o perdite.</p>
 
         <h2 style="text-align: center; margin-top: 2em;">Ringraziamenti</h2>
-        <p style="font-size: 0.9em; color: #555;">Sviluppato con l'assistenza di <a href="https://claude.ai">Claude</a> di <a href="https://anthropic.com">Anthropic</a>.</p>
+        <p style="font-size: 0.9em; color: #555;">Sviluppato con il supporto di <a href="https://claude.ai">Claude</a> di <a href="https://anthropic.com">Anthropic</a>.</p>
 
-        <h2 style="text-align: center; margin-top: 2em;">Riferimenti Scientifici</h2>
+        <h2 style="text-align: center; margin-top: 2em;">Riferimenti scientifici</h2>
         <ul style="font-size: 0.85em; color: #555; line-height: 1.8;">
             <li>Allen, R.G. et al. (1998). <em>Crop evapotranspiration.</em> <a href="https://www.fao.org/4/x0490e/x0490e00.htm">FAO Irrigation and Drainage Paper 56</a>.</li>
             <li>Hargreaves, G.H. &amp; Samani, Z.A. (1985). Reference crop evapotranspiration from temperature. <em>Applied Eng. in Agriculture.</em> <a href="https://doi.org/10.13031/2013.26773">DOI: 10.13031/2013.26773</a></li>
@@ -221,13 +231,13 @@
 
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
-        Questa traduzione &egrave; stata generata automaticamente. Ogni contributo per migliorarla &egrave; benvenuto —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">apri una issue</a> o invia una pull request.
+        Questa pagina &egrave; tradotta in italiano. Per segnalazioni o miglioramenti puoi
+        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">aprire una issue</a> o inviare una pull request.
     </div>
 </section>
 
 <footer>
-    <p>NeverDry &mdash; Licenza MIT &mdash; Fatto con 🌱 da <a href="https://github.com/drake69">drake69</a></p>
+    <p>NeverDry &mdash; Licenza MIT &mdash; Sviluppato da <a href="https://github.com/drake69">drake69</a></p>
 </footer>
 
 </body>

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -129,6 +129,16 @@
                 <h3>Atualiza&ccedil;&otilde;es Transparentes</h3>
                 <p>Releases automatizadas via GitHub Actions. A migra&ccedil;&atilde;o de configura&ccedil;&atilde;o preserva as defini&ccedil;&otilde;es entre vers&otilde;es. Atualiza&ccedil;&atilde;o com um clique no HACS.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🖐️</div>
+                <h3>V&aacute;lvula manual reconhecida</h3>
+                <p>Abra a v&aacute;lvula pelo bot&atilde;o f&iacute;sico, app Zigbee ou HA — o NeverDry segue a sess&atilde;o, atualiza o d&eacute;fice e fecha automaticamente no m&iacute;nimo entre &aacute;gua necess&aacute;ria e timeout de seguran&ccedil;a.</p>
+            </div>
+            <div class="feature-card">
+                <div class="icon">💧</div>
+                <h3>Todos os gatilhos cobertos</h3>
+                <p>Rega pelo agendador, bot&atilde;o Lovelace, automa&ccedil;&otilde;es, bot&atilde;o da v&aacute;lvula, ou registe &laquo;reguei com a mangueira&raquo; — o NeverDry mant&eacute;m o d&eacute;fice exato em todos os quatro casos.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/ha_integration_guide.md
+++ b/docs/ha_integration_guide.md
@@ -280,7 +280,9 @@ self._hass.bus.async_fire(
     EVENT_IRRIGATION_COMPLETE,      # "never_dry_irrigation_complete"
     {
         "zone": zone_name,
-        "source": "automatic",      # or "manual"
+        "source": self._current_source or "automatic",
+        # "button" | "scheduled" | "reactive" | "manual"
+        # (fallback "automatic" only if no caller set _current_source)
         "volume_liters": 45.2,
         "duration_s": 340,
         "deficit_mm": 5.0,

--- a/docs/ha_integration_guide.md
+++ b/docs/ha_integration_guide.md
@@ -328,35 +328,55 @@ def register_services(self) -> None:
         )
 ```
 
-**The problem**: if the user opens a valve manually (from HA dashboard, or physically), NeverDry doesn't know water was delivered. The deficit stays high and NeverDry will irrigate again unnecessarily.
+**The problem**: if the user opens a valve manually (physical button on the Sonoff SWV, Zigbee app, HA switch toggled by hand), NeverDry doesn't know water was delivered. The deficit stays high and NeverDry will irrigate again unnecessarily — *and* the valve could stay open indefinitely.
 
-**The solution**: listen to valve state changes. If the valve goes `off → on → off` and the controller is NOT running (`self._running is False`), it was manual irrigation.
+**The solution**: listen to valve state changes and treat the external open as a tracked session — same state attribute (`is_irrigating`), same flow-meter accounting, plus an auto-close that mirrors `delivery_timeout`.
 
 ```python
 @callback
 def _on_valve_state_change(self, event) -> None:
-    if self._running:
-        return  # we're driving the valve, ignore
+    operator = self._valve_operators.get(entity_id)
+    if operator is not None and operator.state != ValveState.IDLE:
+        return  # commanded cycle in progress — ignore
+    elif self._running:
+        return  # legacy: another commanded cycle in progress
 
-    # ... extract entity_id, old_state, new_state ...
+    # ... extract entity_id, old_state, new_state, look up zone ...
 
     if old_state.state == "off" and new_state.state == "on":
         # Record flow meter baseline if available
         self._manual_valve_open[entity_id] = flow_start
+        zone.set_irrigating(True)
+        zone.async_write_ha_state()
+        # Start the auto-close monitor (min of volume target and timeout)
+        self._manual_safety_tasks[entity_id] = self._hass.async_create_task(
+            self._external_session_monitor(entity_id, zone_name),
+        )
 
     elif old_state.state == "on" and new_state.state == "off":
-        # Valve closed — compensate deficit
-        if zone.flow_meter_sensor and flow_start is not None:
-            delivered_liters = flow_end - flow_start
-            delivered_mm = delivered_liters / zone._area
-            zone._zone_deficit -= delivered_mm * zone._efficiency
-        else:
-            zone.reset_deficit()  # no meter → assume fully irrigated
+        # Cancel the monitor: either the user closed first, or the
+        # monitor's switch.turn_off just landed.
+        task = self._manual_safety_tasks.pop(entity_id, None)
+        if task and not task.done():
+            task.cancel()
+        zone.set_irrigating(False)
+        # ... flow-meter compensation / deficit reset ...
 ```
 
-**With flow meter**: we measure exactly how much water was delivered and subtract the equivalent mm from the deficit. Formula: `mm = liters / area_m² × efficiency`.
+**Distinguishing commanded vs external** uses the `ValveOperator` FSM state. If the operator is *not* in `IDLE`, NeverDry is currently driving the valve (OPENING, OPEN_VERIFIED, CLOSING, …) and the state-change is the natural consequence of a commanded cycle — we ignore it. The same state-change has already been routed into the FSM via `OBS_SWITCH_ON`/`OBS_SWITCH_OFF` to confirm the open/close. So one switch transition can mean two different things depending on FSM state: confirmation of a commanded action, or evidence of an external action.
 
-**Without flow meter**: we can't know how much water was delivered, so we reset the deficit to zero (conservative assumption: enough water was delivered).
+**The auto-close monitor** (`_external_session_monitor`) is an async task that closes the valve at the minimum of:
+
+1. **Volume target reached** — if the zone has a flow meter, poll it (cumulative diff or rate integration depending on `unit_of_measurement`) until `delivered >= zone.volume_liters`.
+2. **Estimated duration** — without a flow meter but with a configured `flow_rate`, sleep for `volume / flow_rate × 60` seconds.
+3. **Safety timeout** — `delivery_timeout` always caps the wait, so a forgotten-open valve cannot run forever.
+
+When the monitor wakes up it sends `switch.turn_off`. The resulting `on → off` transition re-enters `_on_valve_state_change`, which finalises the session (deficit, `last_irrigated`, `last_volume_delivered`, `is_irrigating=False`, `never_dry_irrigation_complete` event with `source: "manual"`). If the user closes manually first, the monitor is cancelled and never sends the service call — manual close always wins.
+
+**With flow meter**: deficit is reduced by `liters / area_m² × efficiency` mm.
+**Without flow meter, no valid baseline**: deficit is fully reset (same semantics as `mark_irrigated`), because the user did irrigate and we have no measurement to do better.
+
+**Why the auto-close?** Without it, pressing the physical button on the valve would drain the line for as long as the user forgets — typically days, until the SWV battery runs out. Reusing the existing `delivery_timeout` keeps the configuration surface small: the same number the user picks for commanded cycles also bounds manual ones.
 
 ### Battery monitoring
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -321,8 +321,8 @@ This diagram shows the complete irrigation decision flow, from weather data to v
 │    scheduled / reactive / manual     │
 │  deficit: full reset OR -mm × η      │
 │  fire never_dry_irrigation_complete  │
-│  (event source = automatic for       │
-│   commanded, manual for external)    │
+│  (event source = same string as      │
+│   last_irrigation_source)            │
 └──────────────────────────────────────┘
 ```
 
@@ -404,7 +404,7 @@ Its purpose is to keep NeverDry from over-watering on top of irrigation it has n
 | **On open** | Detected via switch state change. `is_irrigating=True`, flow meter baseline saved, auto-close monitor started. | NeverDry commands `switch.turn_on` via ValveOperator. FSM verifies the open. `is_irrigating=True`. | Nothing — no valve is opened. |
 | **During delivery** | Monitor polls the flow meter (or sleeps for the estimated duration) tracking how much water has flowed. | `_deliver_water` runs the chosen delivery mode (`estimated_flow`, `flow_meter`, `volume_preset`). | Nothing. |
 | **On close** | Whichever of (volume target reached, estimated duration elapsed, safety timeout) fires first → NeverDry calls `switch.turn_off`. The user can also close manually at any time. | Target reached, user pressed Stop, or `delivery_timeout` fires → NeverDry calls `switch.turn_off`. | Nothing. |
-| **After close** | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source="manual"`, deficit adjusted by measured volume (or fully reset without measurement), `never_dry_irrigation_complete` event fired with `source: "manual"`. | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source` set to `"button"`/`"reactive"`/`"scheduled"` depending on the trigger, deficit reset (full delivery) or reduced (partial), `never_dry_irrigation_complete` event fired with `source: "automatic"`. | Deficit reset to zero, `last_irrigated=now`, `last_irrigation_source="mark_irrigated"`. No event. |
+| **After close** | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source="manual"`, deficit adjusted by measured volume (or fully reset without measurement), `never_dry_irrigation_complete` event fired with `source: "manual"`. | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source` and the event `source` both set to `"button"`/`"reactive"`/`"scheduled"` depending on the trigger, deficit reset (full delivery) or reduced (partial). | Deficit reset to zero, `last_irrigated=now`, `last_irrigation_source="mark_irrigated"`. No event. |
 
 ### 7.3 Why the auto-close on manual open?
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -317,10 +317,12 @@ This diagram shows the complete irrigation decision flow, from weather data to v
 │  set_irrigating = False              │
 │  last_irrigated = now                │
 │  last_volume_delivered = measured    │
+│  last_irrigation_source = button /   │
+│    scheduled / reactive / manual     │
 │  deficit: full reset OR -mm × η      │
 │  fire never_dry_irrigation_complete  │
-│  (source = button / scheduled /      │
-│   reactive / manual)                 │
+│  (event source = automatic for       │
+│   commanded, manual for external)    │
 └──────────────────────────────────────┘
 ```
 
@@ -402,7 +404,7 @@ Its purpose is to keep NeverDry from over-watering on top of irrigation it has n
 | **On open** | Detected via switch state change. `is_irrigating=True`, flow meter baseline saved, auto-close monitor started. | NeverDry commands `switch.turn_on` via ValveOperator. FSM verifies the open. `is_irrigating=True`. | Nothing — no valve is opened. |
 | **During delivery** | Monitor polls the flow meter (or sleeps for the estimated duration) tracking how much water has flowed. | `_deliver_water` runs the chosen delivery mode (`estimated_flow`, `flow_meter`, `volume_preset`). | Nothing. |
 | **On close** | Whichever of (volume target reached, estimated duration elapsed, safety timeout) fires first → NeverDry calls `switch.turn_off`. The user can also close manually at any time. | Target reached, user pressed Stop, or `delivery_timeout` fires → NeverDry calls `switch.turn_off`. | Nothing. |
-| **After close** | `is_irrigating=False`, `last_irrigated=now`, deficit adjusted by measured volume (or fully reset without measurement), event fired with `source=manual`. | `is_irrigating=False`, `last_irrigated=now`, deficit reset (full delivery) or reduced (partial), event fired with `source=button/reactive/scheduled`. | Deficit reset to zero, `last_irrigated=now`, `source=mark_irrigated`. No event. |
+| **After close** | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source="manual"`, deficit adjusted by measured volume (or fully reset without measurement), `never_dry_irrigation_complete` event fired with `source: "manual"`. | `is_irrigating=False`, `last_irrigated=now`, `last_irrigation_source` set to `"button"`/`"reactive"`/`"scheduled"` depending on the trigger, deficit reset (full delivery) or reduced (partial), `never_dry_irrigation_complete` event fired with `source: "automatic"`. | Deficit reset to zero, `last_irrigated=now`, `last_irrigation_source="mark_irrigated"`. No event. |
 
 ### 7.3 Why the auto-close on manual open?
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -276,54 +276,52 @@ This diagram shows the complete irrigation decision flow, from weather data to v
               │          - Rain             │
               └──────────────┬──────────────┘
                              │
-         ┌───────────────────┼───────────────────┐
-         │                   │                   │
-  ┌──────▼──────┐    ┌──────▼──────┐    ┌──────▼──────┐
-  │  Scheduled  │    │   Button    │    │   Manual    │
-  │  (HH:MM)   │    │  "Irrigate" │    │ valve open  │
-  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘
-         │                  │                  │
-  ┌──────▼──────┐           │           ┌──────▼──────┐
-  │ Deficit >=  │           │           │  Detect via │
-  │ Threshold?  │           │           │ state_change│
-  │             │           │           │   listener  │
-  ├─── No ──┐   │           │           └──────┬──────┘
-  │  skip   │   │           │                  │
-  └─────────┘   │           │                  │
-         │ Yes  │           │                  │
-         └──────┼───────────┘                  │
-                │                              │
-     ┌──────────▼──────────┐                   │
-     │   Open Valve        │                   │
-     │   (switch.turn_on)  │                   │
-     └──────────┬──────────┘                   │
-                │                              │
-     ┌──────────▼──────────┐         ┌─────────▼─────────┐
-     │   Monitor Delivery  │         │  On valve close:  │
-     │                     │         │  Read flow meter  │
-     │  ┌─ estimated_flow  │         │  Compute volume   │
-     │  │  (timer-based)   │         │  Adjust deficit   │
-     │  │                  │         └───────────────────┘
-     │  ├─ flow_meter      │
-     │  │  (cumulative L)  │
-     │  │                  │
-     │  └─ flow_rate       │
-     │     (integrate L/h) │
-     └──────────┬──────────┘
-                │
-     ┌──────────▼──────────┐
-     │  Close Valve        │
-     │  (target reached    │
-     │   OR timeout)       │
-     └──────────┬──────────┘
-                │
-     ┌──────────▼──────────┐
-     │  Update Deficit     │
-     │                     │
-     │  Full:  D = 0       │
-     │  Partial: D -= vol  │
-     │    × η / area       │
-     └─────────────────────┘
+    ┌──────────┬──────────┬──────────┬──────────────┐
+    │          │          │          │              │
+┌───▼───┐ ┌────▼────┐ ┌───▼────┐ ┌───▼──────┐ ┌─────▼──────┐
+│Schedul│ │ Button  │ │External│ │ Mark     │ │ Reactive   │
+│ (HH:MM│ │"Irrigate│ │ open   │ │irrigated │ │ (Mode A)   │
+│  )    │ │   "     │ │(physic)│ │(no valve)│ │            │
+└───┬───┘ └────┬────┘ └───┬────┘ └────┬─────┘ └─────┬──────┘
+    │ deficit  │           │           │             │ deficit
+    │ ≥ thr?   │           │           │             │ ≥ thr?
+    │          │           │           │             │
+    │   ┌──────┼───────────┼───────────┼─────────────┘
+    │   │      │           │           │
+┌───▼───▼──────▼──┐  ┌─────▼─────┐  ┌──▼─────────────┐
+│ Open valve via  │  │ External  │  │ Reset deficit  │
+│ ValveOperator   │  │ session   │  │ (no valve)     │
+│ (FSM verified)  │  │ monitor   │  │ source=mark_   │
+│                 │  │ starts    │  │ irrigated      │
+│ set_irrigating  │  │           │  └────────────────┘
+│ = True          │  │ is_irrig= │
+└────────┬────────┘  │ True      │
+         │           │ baseline= │
+┌────────▼────────┐  │ flow read │
+│ Monitor deliver │  └─────┬─────┘
+│  • estimated    │        │
+│  • flow_meter   │  ┌─────▼──────────────────────┐
+│  • flow_rate    │  │ Wait for min(              │
+│  • volume_preset│  │  volume_target reached,    │
+└────────┬────────┘  │  estimated duration,       │
+         │           │  delivery_timeout          │
+┌────────▼────────┐  │ )                          │
+│ Close valve     │  │ → switch.turn_off          │
+│ (target reached │  └─────┬──────────────────────┘
+│  / stop /       │        │
+│  timeout)       │        │ OR user closes manually
+└────────┬────────┘        │
+         │                 │
+┌────────▼─────────────────▼───────────┐
+│ on→off detected → finalise session   │
+│  set_irrigating = False              │
+│  last_irrigated = now                │
+│  last_volume_delivered = measured    │
+│  deficit: full reset OR -mm × η      │
+│  fire never_dry_irrigation_complete  │
+│  (source = button / scheduled /      │
+│   reactive / manual)                 │
+└──────────────────────────────────────┘
 ```
 
 ### Key concepts
@@ -337,6 +335,82 @@ This diagram shows the complete irrigation decision flow, from weather data to v
 | **Delivery Mode** | How the valve delivers water: timer, flow meter (cumulative), or flow rate (L/h integration). |
 | **Partial Irrigation** | If timeout or stop, deficit is reduced proportionally to the volume actually delivered. |
 | **Manual Detection** | If someone opens the valve manually (app, button), NeverDry detects it and adjusts the deficit. |
+
+### 7.1 The four irrigation triggers
+
+A zone's irrigated state (`is_irrigating`, `last_irrigated`, `last_volume_delivered`, deficit) can be modified in exactly four ways. NeverDry handles **all four** with the same final accounting — the only thing that changes is *who* opens and closes the valve.
+
+| # | Trigger | Who opens the valve | Who closes the valve | NeverDry valve involved? | Flow meter used (if configured)? |
+|---|---|---|---|---|---|
+| 1 | **Physical button on the valve** / Zigbee remote / HA switch toggled by hand | The user (outside NeverDry) | NeverDry (auto-close) or the user, whichever happens first | Yes | Yes |
+| 2 | **"Irrigate" button** on the zone device in HA | NeverDry (via `irrigate_zone` service) | NeverDry | Yes | Yes |
+| 3 | **Automation / scheduler** (Mode A reactive, Mode B scheduled, manual `irrigate_zone`/`irrigate_all` service from an automation) | NeverDry | NeverDry | Yes | Yes |
+| 4 | **"Mark irrigated" button** / `mark_irrigated` service | Nobody — the user has already watered with a *different* tool (a hose, a separate sprinkler, rain not detected by the sensor) | Nobody | **No** — the water did not pass through NeverDry's valve | **No** — the flow meter would not have seen anything anyway |
+
+#### Trigger 1 — Physical button on the valve (or any external open)
+
+This covers any case where the valve switch turns **on** without NeverDry having asked for it: pressing the button on the Sonoff SWV, opening the valve from the Zigbee app, flipping the HA switch directly, an automation that bypasses NeverDry and calls `switch.turn_on` on the valve entity.
+
+What happens:
+
+1. NeverDry sees the switch transition `off → on`. If a NeverDry cycle is already running on that valve it is ignored (the FSM is not idle); otherwise the manual session starts.
+2. `is_irrigating` is set to `True` on the zone, so the UI and any automation listening on the attribute reacts as if a commanded cycle were running.
+3. A baseline is recorded for the flow meter (current cumulative reading, or open timestamp for rate sensors).
+4. An **auto-close monitor** starts in the background. It will close the valve via `switch.turn_off` at the **minimum** of:
+   - **Volume needed** — if the zone has a flow meter, the monitor polls it and closes as soon as the delivered volume covers the current deficit-driven target (`volume_liters`). Without a flow meter but with a configured `flow_rate`, the monitor sleeps for the estimated duration `volume / flow_rate`.
+   - **Safety timeout** (`delivery_timeout`, default 1 hour) — always honoured as the upper bound, so a forgotten-open valve cannot run indefinitely.
+5. When the switch goes `on → off` (either because the user closed it, or because the monitor closed it):
+   - `is_irrigating` flips back to `False`.
+   - `last_irrigated` is stamped with the current time.
+   - `last_irrigation_source` is set to `"manual"`.
+   - The deficit is reduced by the delivered volume. With a flow meter the reduction is exact; without one (or with a zero reading) the deficit is fully reset.
+   - `last_volume_delivered` is updated and `never_dry_irrigation_complete` is fired on the HA event bus with `source: manual`.
+
+> **No deficit → manual open still works.** If you open the valve when the zone has no deficit, NeverDry still tracks the session and updates `last_irrigated`; the deficit just cannot go below zero. The monitor falls back to the safety timeout because there is no volume target to aim for.
+
+#### Trigger 2 — "Irrigate" button on the device page
+
+The per-zone **Irrigate** button calls the `never_dry.irrigate_zone` service. NeverDry computes the target from the current deficit, opens the valve through the ValveOperator (with its OPEN/CLOSE verification FSM and retry policy), monitors delivery according to the configured `delivery_mode`, and closes the valve when the target is reached, the user presses **Stop**, or the timeout fires.
+
+`is_irrigating` is `True` for the duration of the cycle, `last_irrigation_source` is `"button"`, and the deficit is fully reset on success or proportionally reduced on partial delivery. `last_volume_delivered` reflects the measured (flow meter) or estimated (timer) volume.
+
+#### Trigger 3 — Automation / scheduler
+
+Same code path as trigger 2, only the source differs:
+
+- **Mode A (reactive)** — fires when the deficit crosses the threshold. `last_irrigation_source = "reactive"`.
+- **Mode B (scheduled)** — fires at the configured daily time if the deficit is above threshold. `last_irrigation_source = "scheduled"`.
+- **Custom automation** — your own automation calling `never_dry.irrigate_zone` or `never_dry.irrigate_all`. Source = `"button"` (same as the manual button — the service entry point is shared).
+
+All of them go through `ValveOperator` and `_deliver_water`. Volume tracking, partial irrigation, and the `never_dry_irrigation_complete` event behave identically to trigger 2.
+
+#### Trigger 4 — "Mark irrigated" button
+
+Use this **only** when you watered the zone *without* using NeverDry's valve: a hand-held hose, a separate non-integrated sprinkler, an unmetered rain event, your neighbour helping out. The button calls the `never_dry.mark_irrigated` service, which:
+
+- Does **not** open or close any valve.
+- Does **not** read any flow meter.
+- Resets the zone deficit to zero and stamps `last_irrigated` with `source = "mark_irrigated"`.
+- Does **not** touch `is_irrigating` (no actual NeverDry-tracked irrigation is happening).
+
+Its purpose is to keep NeverDry from over-watering on top of irrigation it has no other way of knowing about.
+
+### 7.2 Open and close — what NeverDry does in each case
+
+| Step | Trigger 1 (manual) | Trigger 2/3 (button / automation) | Trigger 4 (mark_irrigated) |
+|---|---|---|---|
+| **On open** | Detected via switch state change. `is_irrigating=True`, flow meter baseline saved, auto-close monitor started. | NeverDry commands `switch.turn_on` via ValveOperator. FSM verifies the open. `is_irrigating=True`. | Nothing — no valve is opened. |
+| **During delivery** | Monitor polls the flow meter (or sleeps for the estimated duration) tracking how much water has flowed. | `_deliver_water` runs the chosen delivery mode (`estimated_flow`, `flow_meter`, `volume_preset`). | Nothing. |
+| **On close** | Whichever of (volume target reached, estimated duration elapsed, safety timeout) fires first → NeverDry calls `switch.turn_off`. The user can also close manually at any time. | Target reached, user pressed Stop, or `delivery_timeout` fires → NeverDry calls `switch.turn_off`. | Nothing. |
+| **After close** | `is_irrigating=False`, `last_irrigated=now`, deficit adjusted by measured volume (or fully reset without measurement), event fired with `source=manual`. | `is_irrigating=False`, `last_irrigated=now`, deficit reset (full delivery) or reduced (partial), event fired with `source=button/reactive/scheduled`. | Deficit reset to zero, `last_irrigated=now`, `source=mark_irrigated`. No event. |
+
+### 7.3 Why the auto-close on manual open?
+
+Imagine pressing the button on the valve and then forgetting about it. Without an auto-close, the valve stays open until the battery dies — which on a Sonoff SWV is days of continuous flow.
+
+NeverDry's auto-close uses the *same* `delivery_timeout` you already configured for commanded cycles (default 1 hour, editable per zone in the options flow). On top of that, if the zone has a flow meter or a calibrated `flow_rate`, NeverDry will close the valve *earlier* — as soon as the deficit-driven volume is reached — saving water exactly like a scheduled cycle would. The user-initiated open still benefits from the same closed-loop control.
+
+If you want to bypass the auto-close (for example to flush a line at the start of the season), close the valve from the same physical button before the timeout. Manual close always wins over the monitor.
 
 ---
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -807,6 +807,21 @@ class TestIrrigationEvent:
         assert call_args.args[1]["source"] == "automatic"
         assert call_args.args[1]["zone"] == "Orto"
 
+    @pytest.mark.parametrize("source", ["button", "scheduled", "reactive"])
+    @pytest.mark.asyncio
+    async def test_event_propagates_specific_source(self, controller, hass_mock, zone_orto, source):
+        """The bus event must carry the specific trigger source set by
+        the caller (button, scheduled, reactive) rather than collapsing
+        every commanded cycle into the generic 'automatic'."""
+        zone_orto._zone_deficit = 5.0
+        controller._wait_with_stop_check = AsyncMock()
+        controller._current_source = source
+
+        await controller._irrigate_zones(["Orto"])
+
+        hass_mock.bus.async_fire.assert_called()
+        assert hass_mock.bus.async_fire.call_args.args[1]["source"] == source
+
     @pytest.mark.asyncio
     async def test_no_event_on_stop(self, controller, hass_mock, zone_orto, zone_prato):
         """No event should fire if irrigation is stopped."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -623,6 +623,103 @@ class TestManualValveDetection:
         controller._on_valve_state_change(event)
         assert "switch.unknown" not in controller._manual_valve_open
 
+    def test_manual_open_sets_is_irrigating(self, controller, zone_orto):
+        """Manual valve open should flip is_irrigating to True so the
+        UI and automations see the zone as currently irrigating, the
+        same way a commanded cycle does."""
+        zone_orto._zone_deficit = 10.0
+        assert zone_orto.is_irrigating is False
+        event = self._make_valve_event("switch.valve_orto", "off", "on")
+        controller._on_valve_state_change(event)
+        assert zone_orto.is_irrigating is True
+
+    def test_manual_close_clears_is_irrigating(self, controller, zone_orto):
+        """Manual valve close must clear is_irrigating regardless of
+        whether the flow meter is configured."""
+        zone_orto._zone_deficit = 10.0
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "off", "on"))
+        assert zone_orto.is_irrigating is True
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "on", "off"))
+        assert zone_orto.is_irrigating is False
+
+    def test_manual_open_starts_monitor_task(self, controller, zone_orto):
+        """Opening the valve manually must start the auto-close monitor."""
+        zone_orto._zone_deficit = 10.0
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "off", "on"))
+        assert "switch.valve_orto" in controller._manual_safety_tasks
+        task = controller._manual_safety_tasks["switch.valve_orto"]
+        assert not task.done() or task.cancelled()
+        task.cancel()
+
+    def test_manual_close_cancels_monitor_task(self, controller, zone_orto):
+        """If the user closes the valve before the monitor fires, the
+        monitor task must be cancelled to avoid a spurious turn_off
+        after the fact."""
+        zone_orto._zone_deficit = 10.0
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "off", "on"))
+        task = controller._manual_safety_tasks.get("switch.valve_orto")
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "on", "off"))
+        assert "switch.valve_orto" not in controller._manual_safety_tasks
+        # The task may not yet be observed as cancelled() (the loop hasn't
+        # processed the CancelledError), but a cancel request must have
+        # been issued.
+        assert task is not None
+        assert task._must_cancel or task.cancelled() or task.done()
+
+
+class TestExternalSessionMonitor:
+    """Auto-close behaviour for manually-opened valves."""
+
+    @pytest.mark.asyncio
+    async def test_no_target_falls_back_to_timeout(self, controller, zone_orto, hass_mock, monkeypatch):
+        """With no deficit and no flow info, the monitor sleeps until
+        delivery_timeout, then turns the valve off if still open."""
+        zone_orto._zone_deficit = 0.0
+        zone_orto._delivery_timeout = 1
+        sleeps = []
+
+        async def fake_sleep(s):
+            sleeps.append(s)
+
+        monkeypatch.setattr("never_dry.controller.asyncio.sleep", fake_sleep)
+        # Simulate valve still ON when monitor wakes up.
+        on_state = MagicMock()
+        on_state.state = "on"
+        hass_mock.states.get = MagicMock(return_value=on_state)
+        hass_mock.services.async_call.reset_mock()
+
+        await controller._external_session_monitor("switch.valve_orto", "Orto")
+
+        assert sleeps == [1]
+        hass_mock.services.async_call.assert_called_with(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.valve_orto"},
+            blocking=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_estimated_duration_caps_at_timeout(self, controller, zone_orto, hass_mock, monkeypatch):
+        """When estimated duration exceeds the safety timeout, the
+        timeout wins (min of the two)."""
+        # Big deficit → long estimated duration.
+        zone_orto._zone_deficit = 1000.0
+        zone_orto._delivery_timeout = 30
+        zone_orto._flow_rate = 1.0  # L/min — irrelevant magnitude here
+
+        sleeps = []
+
+        async def fake_sleep(s):
+            sleeps.append(s)
+
+        monkeypatch.setattr("never_dry.controller.asyncio.sleep", fake_sleep)
+        on_state = MagicMock(state="on")
+        hass_mock.states.get = MagicMock(return_value=on_state)
+
+        await controller._external_session_monitor("switch.valve_orto", "Orto")
+
+        assert sleeps == [30]
+
 
 class TestBatteryMonitoring:
     """Test low-battery alert for valve sensors."""


### PR DESCRIPTION
## Summary

- When the valve is opened outside NeverDry's commanded path (physical button on the Sonoff SWV, ZHA app, HA switch toggled manually), the zone now flips `is_irrigating=True` for the session and back to `False` on close — matching what the commanded "Irrigate" button and the scheduler already did.
- A new `_external_session_monitor` task closes the valve at the **minimum** between volume needed (deficit-driven target, measured via flow meter or estimated from `flow_rate`) and the safety `delivery_timeout`. A forgotten-open valve cannot drain the line anymore.
- The `never_dry_irrigation_complete` event now carries the **specific** trigger source (`"button"` / `"scheduled"` / `"reactive"` / `"manual"`) instead of collapsing every commanded cycle into `"automatic"`. Automations can filter on it directly without having to read the zone attribute after the fact.
- `mark_irrigated` is unchanged: it remains the "I watered with a tool NeverDry does not see" entry point — no valve, no flow meter, deficit reset only.

## Behaviour matrix

| Trigger | Path | `is_irrigating` toggled | Event `source` | Auto-close brain |
|---|---|---|---|---|
| External switch open | `_on_valve_state_change` + `_external_session_monitor` | yes | `"manual"` | min(volume needed, `delivery_timeout`) |
| "Irrigate" button / service | `_handle_irrigate_zone` → `_irrigate_zones` → `_deliver_water` | yes | `"button"` | delivery mode logic |
| Reactive / scheduled | `_make_*_handler` → `_irrigate_zones` | yes | `"reactive"` / `"scheduled"` | delivery mode logic |
| `mark_irrigated` | `_handle_mark_irrigated` | no | *(no event)* | n/a |

## Test plan

- [x] `pytest tests/` — 368/368 green (+6 new: 4 manual-detection regression, 2 monitor behaviour, 3 parametric source propagation, minus 3 superseded counts)
- [x] Manual smoke test on the dev rig: open valve from Sonoff SWV button → `is_irrigating` goes True → auto-close fires at target volume → deficit reduced, `last_irrigated` stamped, `source: "manual"` event observed
- [x] Regression: scheduled cycle still completes normally, partial irrigation deficit reduction unchanged
- [x] Docs cross-checked against code (source strings, method names, FSM gating)

## Docs

- `docs/user_manual.md` — new §7.1/7.2/7.3 covering the four triggers and their open/close lifecycle, flow diagram redrawn
- `docs/developer_manual.md` — architecture of the monitor and FSM-state discrimination
- `docs/ha_integration_guide.md` — §8 rewritten with the new gating and monitor logic
- `docs/gh-pages/*.html` — two new feature cards in all nine languages; Italian landing page rewritten for tone and grammar

Tracked as AI-053 in the backlog.