### PR TITLE
release: bump version to 0.6.0

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0"
 }


### PR DESCRIPTION
Bump manifest to 0.6.0 in preparation for the v0.6.0 tag + GitHub Release that will be the first version submitted to HACS default.

## Changes included since v0.4.0

- **#48 external-delivery-monitor** — `is_irrigating` flips correctly when the valve is opened outside NeverDry's commanded path; auto-close at min(volume needed, `delivery_timeout`); event `source` now propagates the specific trigger string (`button`/`scheduled`/`reactive`/`manual`).
- **#47 notify-unreachable-at-irrigation** — persistent notification when a valve switch is unavailable at irrigation time.
- **#46 realtime-deficit-update** — deficit updates while flow-metered delivery is in progress.

Plus the `chore` cleanup of the duplicate `hacs.json` inside `custom_components/never_dry/`.

## After merge

```
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
# release.yml runs tests, verifies manifest matches tag, creates GitHub Release
```

Then the HACS default submission can proceed against the v0.6.0 release.

## Test plan

- [x] Tests green on the merged feature branches
- [x] HACS Validation + Hassfest green on the latest commits
- [x] Manifest version matches the planned tag (release.yml check will enforce this)