### PR TITLE
release: bump version to v0.7.0

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
## Summary

- Bump `manifest.json` version `0.6.0` → `0.7.0`

## What's in this release

### New features (PR #56)
- **Valve safety watchdog** (AI-033): `ValveOperator` starts an asyncio watchdog task on every OPEN cycle; fires `switch.turn_off` + CRITICAL notification if the valve stays open past `max_open_duration_s`. Independent of controller delivery logic — survives controller hangs.
- **Hardware max-duration interlock** (AI-033 ext): on every open cycle, `ValveOperator` programs the on-device timer via HA entity (`number.set_value`) or MQTT fallback. Last-resort hardware safety net independent of software.
- **ET sensor buffer** (AI-058): `SensorBuffer` (rolling N=10, median) rejects unavailable/NaN/out-of-range temperature readings. A single sensor glitch no longer zeros ET for the whole cycle.
- **SESSION_RESULT log line**: stable `INFO` marker emitted at end of every irrigation session (auto + manual) for post-hoc field analysis.

### CI / deps
- pytest-asyncio ≥ 1.4.0
- codecov/codecov-action 6.0.1 → 7.0.0
- github/codeql-action 4.35.5 → 4.36.2
- hacs/action (hash bump)

## Test plan
- [x] CI green on this branch (419 tests passing)
- [x] HACS Validation ✅
- [x] Hassfest ✅