### PR TITLE
docs(gh-pages): add Releases download link to manual install

### DIFF
--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -188,6 +188,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuell</h3>
             <ol>
+                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
                 <li><code>custom_components/never_dry/</code> ins HA-Konfigurationsverzeichnis kopieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Integration &uuml;ber die Oberfl&auml;che hinzuf&uuml;gen</li>

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -131,6 +131,11 @@
                 <h3>Alle Ausl&ouml;ser abgedeckt</h3>
                 <p>Bew&auml;sserung per Scheduler, Lovelace-Button, Automation, Ventilknopf oder &raquo;Mit dem Schlauch gegossen&laquo; — NeverDry h&auml;lt das Defizit in allen vier F&auml;llen aktuell.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Mehrstufige Sicherheit</h3>
+                <p>Drei unabh&auml;ngige Sicherheitsebenen verhindern dauerhaft offene Ventile: Software-Watchdog (asyncio-Task), Hardware-Verriegelung (Zigbee-Entity oder MQTT) und Lieferzeitlimit. F&auml;llt eine Ebene aus, greift die n&auml;chste.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -144,6 +144,11 @@
                 <h3>Alle Ausl&ouml;ser abgedeckt</h3>
                 <p>Bew&auml;sserung per Scheduler, Lovelace-Button, Automation, Ventilknopf oder &raquo;Mit dem Schlauch gegossen&laquo; — NeverDry h&auml;lt das Defizit in allen vier F&auml;llen aktuell.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Mehrstufige Sicherheit</h3>
+                <p>Drei unabh&auml;ngige Sicherheitsebenen verhindern dauerhaft offene Ventile: Software-Watchdog (asyncio-Task), Hardware-Verriegelung (Zigbee-Entity oder MQTT) und Lieferzeitlimit. F&auml;llt eine Ebene aus, greift die n&auml;chste.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -201,6 +201,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuell</h3>
             <ol>
+                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
                 <li><code>custom_components/never_dry/</code> in Ihr HA-Konfigurationsverzeichnis kopieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Integration &uuml;ber die Oberfl&auml;che hinzuf&uuml;gen</li>

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -139,6 +139,11 @@
                 <h3>Todos los disparadores cubiertos</h3>
                 <p>Riego desde el programador, bot&oacute;n Lovelace, automatizaciones, bot&oacute;n de la v&aacute;lvula, o registra &laquo;regu&eacute; con la manguera&raquo; — NeverDry mantiene el d&eacute;ficit honesto en los cuatro casos.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Seguridad multicapa</h3>
+                <p>Tres capas de seguridad independientes evitan que la v&aacute;lvula quede abierta indefinidamente: watchdog de software (tarea asyncio), enclavamiento de hardware (entidad Zigbee o MQTT) y l&iacute;mite de tiempo de entrega. Si una capa falla, la siguiente act&uacute;a.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -196,6 +196,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
+                <li>Descargar el &uacute;ltimo <code>never_dry.zip</code> desde <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> y extraerlo</li>
                 <li>Copiar <code>custom_components/never_dry/</code> en el directorio config de HA</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>A&ntilde;adir la integraci&oacute;n desde la interfaz</li>

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -201,6 +201,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuel</h3>
             <ol>
+                <li>T&eacute;l&eacute;charger le dernier <code>never_dry.zip</code> depuis <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> et l'extraire</li>
                 <li>Copier <code>custom_components/never_dry/</code> dans le r&eacute;pertoire config de HA</li>
                 <li>Red&eacute;marrer Home Assistant</li>
                 <li>Ajouter l'int&eacute;gration depuis l'interface</li>

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -144,6 +144,11 @@
                 <h3>Tous les d&eacute;clencheurs couverts</h3>
                 <p>Arrosage depuis le planificateur, bouton Lovelace, automatisations, bouton de la vanne, ou enregistrez &laquo;j'ai arros&eacute; au tuyau&raquo; — NeverDry garde le d&eacute;ficit &agrave; jour dans les quatre cas.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>S&eacute;curit&eacute; multicouche</h3>
+                <p>Trois couches de s&eacute;curit&eacute; ind&eacute;pendantes prot&egrave;gent contre une vanne bloqu&eacute;e ouverte&nbsp;: watchdog logiciel (t&acirc;che asyncio), interverrouillage mat&eacute;riel (entit&eacute; Zigbee ou MQTT) et d&eacute;lai de livraison. Si une couche &eacute;choue, la suivante prend le relais.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -188,6 +188,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Ru&ccaron;no</h3>
             <ol>
+                <li>Preuzmite najnoviji <code>never_dry.zip</code> s <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> i raspakirajte ga</li>
                 <li>Kopirajte <code>custom_components/never_dry/</code> u HA config direktorij</li>
                 <li>Ponovo pokrenite Home Assistant</li>
                 <li>Dodajte integraciju iz su&ccaron;elja</li>

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -131,6 +131,11 @@
                 <h3>Svi okida&ccaron;i pokriveni</h3>
                 <p>Navodnjavanje iz rasporeda, Lovelace gumba, automatizacija, gumba na ventilu, ili zabilje&zcaron;ite &laquo;zalio sam crijevom&raquo; — NeverDry odr&zcaron;ava deficit to&ccaron;nim u sva &ccaron;etiri slu&ccaron;aja.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Vi&scaron;eslojna sigurnost</h3>
+                <p>Tri neovisna sigurnosna sloja sprje&ccaron;avaju trajno otvoreni ventil: softverski watchdog (asyncio zadatak), hardversko blokiranje (Zigbee entitet ili MQTT) i vremensko ograni&ccaron;enje isporuke. Ako jedan sloj zakaže, sljede&cacute;i preuzima.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -131,6 +131,11 @@
                 <h3>Minden trigger lefedve</h3>
                 <p>&Ouml;nt&ouml;z&eacute;s &uuml;temez&eacute;sb&odblac;l, Lovelace gombr&oacute;l, automatiz&aacute;ci&oacute;b&oacute;l, szelep gombr&oacute;l, vagy r&ouml;gz&iacute;tsd hogy &laquo;locsoltam tuk&aacute;val&raquo; — a NeverDry n&eacute;gy esetb&odblac;l mind n&eacute;gyben pontosan tartja a hi&aacute;nyt.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>T&ouml;bbr&eacute;teg&#369; biztons&aacute;g</h3>
+                <p>H&aacute;rom f&uuml;ggetlen biztons&aacute;gi r&eacute;teg v&eacute;di a szelepet: szoftveres watchdog (asyncio task), hardveres reteszel&eacute;s (Zigbee entit&aacute;s vagy MQTT) &eacute;s sz&aacute;ll&iacute;t&aacute;si id&#337;korl&aacute;t. Ha az egyik r&eacute;teg meghibas&oacute;dik, a k&ouml;vetkez&#337; l&eacute;p k&ouml;zbe.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -188,6 +188,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manu&aacute;lis</h3>
             <ol>
+                <li>A legfrissebb <code>never_dry.zip</code> let&ouml;lt&eacute;se a <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> oldalr&oacute;l &eacute;s kicsomagol&aacute;sa</li>
                 <li><code>custom_components/never_dry/</code> m&aacute;sol&aacute;sa a HA config k&ouml;nyvt&aacute;rba</li>
                 <li>Home Assistant &uacute;jraind&iacute;t&aacute;sa</li>
                 <li>Integr&aacute;ci&oacute; hozz&aacute;ad&aacute;sa a fel&uuml;letr&odblac;l</li>

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -372,6 +372,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
+                <li>Download the latest <code>never_dry.zip</code> from <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> and extract it</li>
                 <li>Copy <code>custom_components/never_dry/</code> to your HA config directory</li>
                 <li>Restart Home Assistant</li>
                 <li>Add the integration from the UI</li>

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -312,6 +312,11 @@
                 <h3>Multiple Triggers</h3>
                 <p>Irrigate from the scheduler, from a Lovelace button, from automations, from the valve itself, or just record "I watered with the hose" — NeverDry keeps the deficit honest in all four cases.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Multi-layer Safety</h3>
+                <p>Three independent safety nets prevent valve run-on: software watchdog (asyncio task), hardware interlock that programs the on-device timer via Zigbee entity or MQTT, and delivery timeout. If one layer fails, the next one catches it.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -201,6 +201,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Installazione manuale</h3>
             <ol>
+                <li>Scarica l'ultima versione di <code>never_dry.zip</code> dalla pagina <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> ed estraila</li>
                 <li>Copia la cartella <code>custom_components/never_dry/</code> nella directory di configurazione di Home Assistant.</li>
                 <li>Riavvia Home Assistant.</li>
                 <li>Aggiungi l'integrazione dall'interfaccia.</li>

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -144,6 +144,11 @@
                 <h3>Tutte le modalit&agrave; di innesco</h3>
                 <p>Irrigazione programmata, pulsante &laquo;Irriga&raquo; sulla scheda della zona, automazioni di Home Assistant, pulsante a bordo valvola e registrazione di un'irrigazione effettuata con mezzi esterni (ad esempio canna o tubo): in tutti i casi il deficit resta coerente con la realt&agrave; del giardino.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Sicurezza a pi&ugrave; livelli</h3>
+                <p>Tre strati di sicurezza indipendenti prevengono l'apertura prolungata della valvola: watchdog software (task asyncio), interlock hardware che programma il timer sul dispositivo via entit&agrave; Zigbee o MQTT, e timeout di consegna. Se un livello fallisce, il successivo interviene.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -196,6 +196,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
+                <li>Descarregar o &uacute;ltimo <code>never_dry.zip</code> em <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> e extrair</li>
                 <li>Copiar <code>custom_components/never_dry/</code> para o diret&oacute;rio config do HA</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>Adicionar a integra&ccedil;&atilde;o pela interface</li>

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -139,6 +139,11 @@
                 <h3>Todos os gatilhos cobertos</h3>
                 <p>Rega pelo agendador, bot&atilde;o Lovelace, automa&ccedil;&otilde;es, bot&atilde;o da v&aacute;lvula, ou registe &laquo;reguei com a mangueira&raquo; — o NeverDry mant&eacute;m o d&eacute;fice exato em todos os quatro casos.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🛡️</div>
+                <h3>Seguran&ccedil;a multicamada</h3>
+                <p>Tr&ecirc;s camadas de seguran&ccedil;a independentes evitam que a v&aacute;lvula fique aberta: watchdog de software (tarefa asyncio), intertravamento de hardware (entidade Zigbee ou MQTT) e limite de tempo de entrega. Se uma camada falhar, a seguinte atua.</p>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Adds explicit 'Download from Releases' step to the manual installation section in all 9 language pages. Previously the manual section said 'copy the files' without explaining where to get them.