### PR TITLE
docs(gh-pages): switch analytics from GoatCounter to Vemetric

### DIFF
--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Intelligente Bewässerung für Home Assistant</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Intelligente Bewässerung für Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Riego Inteligente para Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Irrigation Intelligente pour Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Pametno Navodnjavanje za Home Assistant</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Intelligens Öntözés a Home Assistant-hez</title>
     <style>
         :root { --accent: #1f6aa5; --accent-light: #d6e8f5; --bg: #f8fafb; --text: #2c3e50; --card-bg: #ffffff; }

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Smart Irrigation for Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Irrigazione Intelligente per Home Assistant</title>
     <style>
         :root {

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- GoatCounter (privacy-friendly, cookieless analytics — no banner needed) -->
-    <script data-goatcounter="https://neverdry.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <!-- Vemetric analytics -->
+    <script>
+      window.vmtrcq = window.vmtrcq || [];
+      window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+    </script>
+    <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="TmCTG71IzwQtA2Rv"></script>
     <title>NeverDry — Irrigação Inteligente para Home Assistant</title>
     <style>
         :root {


### PR DESCRIPTION
## Summary

- Replace GoatCounter with Vemetric analytics script across all 9 language pages (index, it, de, fr, es, pt, hr, hu, at)
- Token: `TmCTG71IzwQtA2Rv`
- No other changes

## Test plan

- [ ] Merge triggers gh-pages workflow deployment
- [ ] Verify Vemetric dashboard receives traffic after deploy