### PR TITLE
feat: activity log file, diagnostic logging, HA diagnostics platform (v0.7.1)

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -61,6 +61,7 @@ def _teardown_file_logger(handler: logging.Handler) -> None:
     logging.getLogger("custom_components.never_dry").removeHandler(handler)
     handler.close()
 
+
 PLATFORMS = ["sensor", "button"]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)

--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -8,6 +8,7 @@ Supports both YAML configuration and UI-based config flow.
 """
 
 import logging
+import logging.handlers
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
@@ -17,6 +18,48 @@ from homeassistant.helpers.typing import ConfigType
 from .const import CONFIG_VERSION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+_ACTIVITY_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
+_ACTIVITY_LOG_BACKUP_COUNT = 2
+
+
+def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
+    """Attach a rotating file handler to the never_dry logger namespace.
+
+    All modules under custom_components.never_dry use _LOGGER = logging.getLogger(__name__),
+    which inherits from this namespace. Attaching once here captures every
+    INFO/DEBUG line across controller, sensor, valve_operator, etc.
+
+    File: <ha_config_dir>/never_dry_activity.log (5 MB × 3 files).
+    """
+    log_path = hass.config.path("never_dry_activity.log")
+    handler = logging.handlers.RotatingFileHandler(
+        log_path,
+        maxBytes=_ACTIVITY_LOG_MAX_BYTES,
+        backupCount=_ACTIVITY_LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    logging.getLogger("custom_components.never_dry").addHandler(handler)
+    _LOGGER.info(
+        "NeverDry activity log → %s (%.0f MB × %d)",
+        log_path,
+        _ACTIVITY_LOG_MAX_BYTES / 1024 / 1024,
+        _ACTIVITY_LOG_BACKUP_COUNT + 1,
+    )
+    return handler
+
+
+def _teardown_file_logger(handler: logging.Handler) -> None:
+    """Remove the rotating file handler from the never_dry logger and close it."""
+    logging.getLogger("custom_components.never_dry").removeHandler(handler)
+    handler.close()
 
 PLATFORMS = ["sensor", "button"]
 
@@ -71,6 +114,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NeverDry from a config entry (UI)."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
+    handler = _setup_file_logger(hass)
+    hass.data[DOMAIN][f"_log_handler_{entry.entry_id}"] = handler
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     return True
@@ -80,5 +125,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        handler = hass.data[DOMAIN].pop(f"_log_handler_{entry.entry_id}", None)
+        if handler is not None:
+            _teardown_file_logger(handler)
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok

--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -30,7 +30,7 @@ def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
     which inherits from this namespace. Attaching once here captures every
     INFO/DEBUG line across controller, sensor, valve_operator, etc.
 
-    File: <ha_config_dir>/never_dry_activity.log (5 MB × 3 files).
+    File: <ha_config_dir>/never_dry_activity.log (5 MB x 3 files).
     """
     log_path = hass.config.path("never_dry_activity.log")
     handler = logging.handlers.RotatingFileHandler(
@@ -48,7 +48,7 @@ def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
     )
     logging.getLogger("custom_components.never_dry").addHandler(handler)
     _LOGGER.info(
-        "NeverDry activity log → %s (%.0f MB × %d)",
+        "NeverDry activity log -> %s (%.0f MB x %d)",
         log_path,
         _ACTIVITY_LOG_MAX_BYTES / 1024 / 1024,
         _ACTIVITY_LOG_BACKUP_COUNT + 1,

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -219,9 +219,15 @@ class IrrigationController:
                 "threshold_mm",
                 DEFAULT_THRESHOLD,
             )
+            _LOGGER.info(
+                "Scheduled check fired: zone='%s', deficit=%.1fmm, threshold=%.1fmm",
+                zone_name,
+                zone._zone_deficit,
+                threshold,
+            )
             if zone._zone_deficit < threshold:
-                _LOGGER.debug(
-                    "Scheduled check: zone='%s' deficit=%.1fmm < threshold=%.1fmm, skipping",
+                _LOGGER.info(
+                    "Scheduled check: zone='%s' deficit=%.1fmm < threshold=%.1fmm — no irrigation needed",
                     zone_name,
                     zone._zone_deficit,
                     threshold,
@@ -256,6 +262,13 @@ class IrrigationController:
             if zone._zone_deficit < zone._threshold:
                 return
             if self._running:
+                _LOGGER.info(
+                    "Reactive check: zone='%s' deficit=%.1fmm >= threshold=%.1fmm"
+                    " — skipping, irrigation already running",
+                    zone_name,
+                    zone._zone_deficit,
+                    zone._threshold,
+                )
                 return
             if self._is_throttled("reactive", zone_name):
                 return
@@ -433,18 +446,23 @@ class IrrigationController:
 
                 if zone.volume_liters <= 0:
                     _LOGGER.info(
-                        "Zone '%s' needs 0L irrigation (deficit=%.1fmm), skipping",
+                        "Zone '%s' needs 0L irrigation — skipping"
+                        " (deficit=%.1fmm, area=%.1fm², efficiency=%.2f)",
                         zone_name,
                         zone._zone_deficit,
+                        zone._area,
+                        zone._efficiency,
                     )
                     continue
 
                 _LOGGER.info(
-                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL, deficit=%.1fmm",
+                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL,"
+                    " deficit=%.1fmm, timeout=%ds",
                     zone_name,
                     zone.delivery_mode,
                     zone.volume_liters,
                     zone._zone_deficit,
+                    zone.delivery_timeout,
                 )
 
                 volume_target = zone.volume_liters
@@ -921,6 +939,7 @@ class IrrigationController:
         (used for valves without an operator, including the test harness).
         """
         self._active_valve = entity_id
+        _LOGGER.info("Attempting valve open: '%s'", entity_id)
         operator = self._valve_operators.get(entity_id)
         if operator is None:
             await self._hass.services.async_call("switch", "turn_on", {"entity_id": entity_id})

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -446,8 +446,7 @@ class IrrigationController:
 
                 if zone.volume_liters <= 0:
                     _LOGGER.info(
-                        "Zone '%s' needs 0L irrigation — skipping"
-                        " (deficit=%.1fmm, area=%.1fm², efficiency=%.2f)",
+                        "Zone '%s' needs 0L irrigation — skipping (deficit=%.1fmm, area=%.1fm², efficiency=%.2f)",
                         zone_name,
                         zone._zone_deficit,
                         zone._area,
@@ -456,8 +455,7 @@ class IrrigationController:
                     continue
 
                 _LOGGER.info(
-                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL,"
-                    " deficit=%.1fmm, timeout=%ds",
+                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL, deficit=%.1fmm, timeout=%ds",
                     zone_name,
                     zone.delivery_mode,
                     zone.volume_liters,

--- a/custom_components/never_dry/diagnostics.py
+++ b/custom_components/never_dry/diagnostics.py
@@ -1,0 +1,80 @@
+"""Diagnostics support for NeverDry.
+
+Provides the data bundle downloadable via
+Settings → Devices & Services → NeverDry → ⋮ → Download diagnostics.
+
+The bundle includes:
+- Tail of the dedicated activity log (never_dry_activity.log)
+- State snapshot of all NeverDry entities
+- Sanitised config entry data (secrets redacted)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+
+_LOG_TAIL_LINES = 500
+_REDACT_KEYS = {"password", "token", "api_key", "secret", "access_token"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return the diagnostics bundle for a NeverDry config entry.
+
+    Called by HA when the user clicks Download diagnostics in the UI.
+    """
+    # ── 1. Entity states ─────────────────────────────────────────────────────
+    registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(registry, entry.entry_id)
+    entity_states: dict[str, Any] = {}
+    for ent in entities:
+        state = hass.states.get(ent.entity_id)
+        if state is not None:
+            entity_states[ent.entity_id] = {
+                "state": state.state,
+                "attributes": dict(state.attributes),
+                "last_changed": state.last_changed.isoformat(),
+                "last_updated": state.last_updated.isoformat(),
+            }
+
+    # ── 2. Activity log tail ──────────────────────────────────────────────────
+    log_path = hass.config.path("never_dry_activity.log")
+    if os.path.isfile(log_path):
+        try:
+            with open(log_path, encoding="utf-8", errors="replace") as fh:  # noqa: PTH123
+                lines = fh.readlines()
+            log_tail = "".join(lines[-_LOG_TAIL_LINES:])
+            log_total_lines = len(lines)
+        except OSError as exc:
+            log_tail = f"<log file unreadable: {exc}>"
+            log_total_lines = 0
+    else:
+        log_tail = "<log file not yet created — restart or reload the integration>"
+        log_total_lines = 0
+
+    # ── 3. Sanitised config ───────────────────────────────────────────────────
+    config_data = async_redact_data(dict(entry.data), _REDACT_KEYS)
+
+    return {
+        "domain": DOMAIN,
+        "config_entry_id": entry.entry_id,
+        "config_entry_title": entry.title,
+        "config_data": config_data,
+        "entity_states": entity_states,
+        "activity_log": {
+            "path": log_path,
+            "total_lines": log_total_lines,
+            "lines_shown": _LOG_TAIL_LINES,
+            "tail": log_tail,
+        },
+    }

--- a/custom_components/never_dry/diagnostics.py
+++ b/custom_components/never_dry/diagnostics.py
@@ -51,7 +51,7 @@ async def async_get_config_entry_diagnostics(
     log_path = hass.config.path("never_dry_activity.log")
     if os.path.isfile(log_path):
         try:
-            with open(log_path, encoding="utf-8", errors="replace") as fh:  # noqa: PTH123
+            with open(log_path, encoding="utf-8", errors="replace") as fh:
                 lines = fh.readlines()
             log_tail = "".join(lines[-_LOG_TAIL_LINES:])
             log_total_lines = len(lines)

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -13,6 +13,7 @@
 9. [Versioning and releases](#9-versioning-and-releases)
 10. [Config entry migration](#10-config-entry-migration)
 11. [Security CI](#11-security-ci)
+12. [Activity log and diagnostics](#12-activity-log-and-diagnostics)
 
 ---
 
@@ -493,3 +494,93 @@ bandit -r custom_components/never_dry/ --severity-level medium --confidence-leve
 grep -rn 'eval\|exec\|subprocess\|os\.system\|pickle\|__import__' custom_components/never_dry/ --include='*.py'
 # Should return nothing
 ```
+
+---
+
+## 12. Activity log and diagnostics
+
+### 12.1 Dedicated activity log file
+
+When the integration loads, `async_setup_entry` in `__init__.py` attaches a
+`RotatingFileHandler` to the `custom_components.never_dry` Python logger namespace.
+Every `_LOGGER.*()` call in every module — `controller.py`, `sensor.py`,
+`valve_operator.py`, `valve_fsm.py` — flows there automatically because all modules
+use `logging.getLogger(__name__)`, which inherits from the namespace.
+
+**File location:** `<ha_config_dir>/never_dry_activity.log`
+**Rotation:** 5 MB per file, 2 backups (up to ~15 MB total)
+**Level:** `DEBUG` — captures everything, including decision-point traces
+
+The handler is torn down cleanly in `async_unload_entry` so it does not accumulate
+on reload.
+
+### 12.2 Key log markers
+
+The following structured tokens appear in the activity log and are easy to grep for:
+
+| Token | Level | When |
+|---|---|---|
+| `Scheduled check fired:` | INFO | Scheduled handler triggered by `async_track_time_change` |
+| `no irrigation needed` | INFO | Threshold not met at scheduled time |
+| `Scheduled irrigation triggered:` | INFO | Threshold met, cycle starting |
+| `Scheduled irrigation for '…' skipped` | WARNING | Cycle already running at trigger time |
+| `Reactive check:` | INFO | Reactive handler saw deficit ≥ threshold but skipped (running) |
+| `Reactive irrigation triggered:` | INFO | Reactive handler launched a cycle |
+| `Attempting valve open:` | INFO | `_open_valve` about to send the service call |
+| `Starting irrigation:` | INFO | Cycle begun — includes `mode`, `volume`, `deficit`, `timeout` |
+| `needs 0L irrigation — skipping` | INFO | Volume is 0 — includes `deficit`, `area`, `efficiency` |
+| `SESSION_RESULT` | INFO | End-of-session structured line (stable format, grep-friendly) |
+| `flow_meter timeout` / `flow_rate timeout` | WARNING | Delivery timed out before target volume reached |
+
+**Useful one-liners for field diagnosis:**
+
+```bash
+# All events for today
+grep "$(date +%Y-%m-%d)" /config/never_dry_activity.log
+
+# Why did it fire (or not fire)?
+grep -E "Scheduled check|triggered|skipped|no irrigation" /config/never_dry_activity.log
+
+# All completed irrigation sessions
+grep "SESSION_RESULT" /config/never_dry_activity.log
+
+# Valve open/close events
+grep -E "Attempting valve|Valve open failed|Valve close" /config/never_dry_activity.log
+
+# Timeouts and errors
+grep -E "timeout|ERROR|WARNING" /config/never_dry_activity.log
+```
+
+### 12.3 HA diagnostics download
+
+`diagnostics.py` implements the standard HA diagnostics platform. A
+**Download diagnostics** button appears automatically in the integration UI under
+**Settings → Devices & Services → NeverDry → ⋮**.
+
+The downloaded JSON bundle contains:
+
+| Field | Content |
+|---|---|
+| `config_data` | Config entry data (secrets redacted) |
+| `entity_states` | Snapshot of all NeverDry entity states and attributes |
+| `activity_log.tail` | Last 500 lines of `never_dry_activity.log` |
+| `activity_log.path` | Absolute path to the log file on the HA host |
+| `activity_log.total_lines` | Total line count at download time |
+
+This bundle is designed to be attached to a bug report or a field-test session
+without exposing any credentials.
+
+### 12.4 Enabling DEBUG in HA logger (optional)
+
+By default, HA logs at INFO for custom integrations. The activity log file always
+captures DEBUG regardless of the HA logger setting. To also see DEBUG in the main
+HA log (useful during development), add to `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.never_dry: debug
+```
+
+Restart or reload the integration after the change.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -662,6 +662,41 @@ card:
 
 ## 14. Troubleshooting
 
+### Reading the NeverDry activity log
+
+NeverDry writes a dedicated log file to your HA configuration directory:
+
+```
+<ha_config_dir>/never_dry_activity.log
+```
+
+Every decision the integration makes — whether the threshold was met, whether the
+valve was told to open, how long the timeout was, why a cycle was skipped — is
+recorded there at INFO level. The file rotates at 5 MB and keeps 2 backups, so you
+always have the recent history available.
+
+**Quickest way to read it:** use the **Download diagnostics** button in the
+integration card (**Settings → Devices & Services → NeverDry → ⋮ → Download
+diagnostics**). The downloaded JSON includes the last 500 log lines plus a state
+snapshot of all NeverDry entities — ready to attach to a bug report or share with
+the community.
+
+### Irrigation did not fire today
+
+If you expected irrigation but nothing happened, open the activity log and search
+for the scheduled time. You will find one of these outcomes:
+
+| What you see | Meaning |
+|---|---|
+| No `Scheduled check fired:` entry | The time trigger never ran — check the zone's `irrigation_time` setting and reload the integration |
+| `no irrigation needed` | The deficit was below the threshold at trigger time — check `deficit_mm` and `threshold_mm` in the log line |
+| `Scheduled irrigation for '…' skipped` | Another zone was still irrigating — check the previous cycle's `SESSION_RESULT` for its duration |
+| `needs 0L irrigation — skipping` | `volume_liters` computed to 0 — log line shows `deficit`, `area`, `efficiency`; check zone configuration |
+| `Attempting valve open:` present, no `Completed irrigation:` | Valve failed to open — look for `ERROR` lines immediately after |
+
+For reactive mode, search for `Reactive check:` to see if a skip due to a
+concurrent cycle is logged, or `Reactive irrigation triggered:` to confirm it fired.
+
 ### Sensors show "unavailable"
 
 - Check that the temperature and rain sensor entity IDs are correct in the integration settings


### PR DESCRIPTION
## Summary

- **Dedicated activity log** (`never_dry_activity.log` in HA config dir): rotating 5 MB × 3, captures every decision across all modules — no HA log noise.
- **7 diagnostic log improvements** in `controller.py`: fills in the silent gaps that made missed-irrigation diagnosis impossible without reading source code (scheduled check fired, threshold comparison result, reactive skip while running, delivery timeout, valve open attempt, volume=0 reason with area + efficiency).
- **HA diagnostics platform** (`diagnostics.py`): adds a native **Download diagnostics** button to the integration card (Settings → Devices & Services → NeverDry → ⋮). Bundle: last 500 log lines + all entity state snapshots + sanitised config.
- **Docs updated**: developer manual §12 (log markers, grep recipes, DEBUG config), user manual §14 troubleshooting entry "Irrigation did not fire today".
- **Version bump** to 0.7.1.

## Test plan

- [ ] Reload integration → confirm `never_dry_activity.log` appears in HA config dir
- [ ] Check log contains "NeverDry activity log →" startup line
- [ ] Trigger scheduled zone at its configured time → confirm "Scheduled check fired" appears in log
- [ ] Set deficit below threshold → confirm "no irrigation needed" appears (was invisible at DEBUG before)
- [ ] Settings → Devices & Services → NeverDry → ⋮ → Download diagnostics → confirm JSON contains `activity_log.tail` with recent lines
- [ ] Reload integration → confirm no duplicate log handlers accumulate
- [ ] Run CI: `uv run pytest -v`