### PR TITLE
feat: valve latency tracking, adaptive timeouts, deficit settle on anomalous exits

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -130,4 +130,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if handler is not None:
             _teardown_file_logger(handler)
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        hass.data[DOMAIN].pop(f"_operators_{entry.entry_id}", None)
     return unload_ok

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -126,6 +126,11 @@ class IrrigationController:
         """Return the entity_id of the currently open valve, or None."""
         return self._active_valve
 
+    @property
+    def valve_operators(self) -> dict[str, ValveOperator]:
+        """Return the mapping of switch entity_id → ValveOperator."""
+        return self._valve_operators
+
     def register_services(self) -> None:
         """Register all irrigation services with Home Assistant."""
         self._hass.services.async_register(DOMAIN, SERVICE_RESET, self._handle_reset)
@@ -430,7 +435,7 @@ class IrrigationController:
         """Run irrigation cycle for the given zones sequentially."""
         self._running = True
         self._stop_requested = False
-        irrigated_zones = []
+        irrigated_zones: list = []
 
         try:
             for i, zone_name in enumerate(zone_names):
@@ -475,9 +480,8 @@ class IrrigationController:
                 delivered = await self._deliver_water(zone)
                 ts_end = datetime.now()
 
-                if self._stop_requested:
-                    break
-
+                # Credit partial delivery BEFORE checking stop so that any
+                # water already delivered is always settled in the finally block.
                 if delivered > 0:
                     irrigated_zones.append(
                         (zone_name, delivered, volume_target, deficit_at_start, ts_start, ts_end),
@@ -499,62 +503,13 @@ class IrrigationController:
                         volume_target,
                     )
 
+                if self._stop_requested:
+                    break
+
                 # Inter-zone delay (pressure stabilization)
                 if i < len(zone_names) - 1 and not self._stop_requested:
                     _LOGGER.debug("Inter-zone delay: %ds", self._inter_zone_delay)
                     await asyncio.sleep(self._inter_zone_delay)
-
-            # Adjust deficits for irrigated zones using the snapshot taken
-            # before each delivery. The settle here is **idempotent** with
-            # any real-time updates that ran inside the delivery modes:
-            # both write ``max(0, deficit_at_start - delivered_mm)``.
-            if irrigated_zones and not self._stop_requested:
-                all_complete = True
-                for zone_name, delivered, target, deficit_at_start, ts_start, ts_end in irrigated_zones:
-                    zone = self._zones[zone_name]
-                    if delivered >= target:
-                        # Full irrigation — reset deficit to zero
-                        zone.reset_deficit(self._current_source or "automatic")
-                    else:
-                        # Partial irrigation — authoritative recompute from snapshot
-                        all_complete = False
-                        delivered_mm = delivered * zone._efficiency / zone._area if zone._area > 0 else 0.0
-                        zone._zone_deficit = max(0.0, deficit_at_start - delivered_mm)
-                        zone._last_volume_delivered = round(delivered, 1)
-                        zone._session_water_delivered = round(delivered, 1)
-                        zone._total_water_delivered += delivered
-                        zone._yearly_water_delivered += delivered
-                        zone._last_irrigated = datetime.now()
-                        zone._last_irrigation_source = self._current_source or "automatic"
-                        _LOGGER.info(
-                            "Partial irrigation: zone='%s', delivered=%.1fL/%.1fL, deficit reduced to %.2fmm",
-                            zone_name,
-                            delivered,
-                            target,
-                            zone._zone_deficit,
-                        )
-                    zone._deficit_at_irrigation_start = None
-                    zone.async_write_ha_state()
-                    self._log_session_result(
-                        zone_name=zone_name,
-                        zone=zone,
-                        source=self._current_source or "automatic",
-                        ts_start=ts_start,
-                        ts_end=ts_end,
-                        volume_target_L=target,
-                        volume_delivered_L=delivered,
-                        deficit_mm_pre=deficit_at_start,
-                        deficit_mm_post=zone._zone_deficit,
-                    )
-                # Reset reference sensor only if ALL zones fully irrigated
-                zone_names_irrigated = {z[0] for z in irrigated_zones}
-                if all_complete and zone_names_irrigated == set(self._zones.keys()):
-                    self._dryness.reset()
-                self._dryness.async_write_ha_state()
-                _LOGGER.info(
-                    "Irrigation cycle complete. %d zone(s) irrigated",
-                    len(irrigated_zones),
-                )
 
         except Exception:
             _LOGGER.exception("Error during irrigation cycle")
@@ -566,11 +521,70 @@ class IrrigationController:
         finally:
             self._running = False
             self._active_valve = None
-            # Clear any leftover irrigation-start snapshot so a subsequent
-            # cycle does not see stale state if this one was aborted before
-            # the settle step ran.
+            # Settle deficits unconditionally — covers normal completion, emergency
+            # stop, exceptions, and task cancellation (HA reload mid-cycle).
+            try:
+                self._settle_irrigated_zones(irrigated_zones)
+            except Exception:
+                _LOGGER.exception("Error during deficit settle — partial deliveries may not be recorded")
             for zs in self._zones.values():
                 zs._deficit_at_irrigation_start = None
+
+    def _settle_irrigated_zones(self, irrigated_zones: list) -> None:
+        """Apply deficit adjustments and log results for all zones that received water.
+
+        Idempotent with real-time updates from flow-metered modes: both write
+        ``max(0, deficit_at_start - delivered_mm)``.  Called unconditionally
+        from the finally block so partial deliveries are always credited.
+        """
+        if not irrigated_zones:
+            return
+        all_complete = True
+        for zone_name, delivered, target, deficit_at_start, ts_start, ts_end in irrigated_zones:
+            zone = self._zones[zone_name]
+            if delivered >= target:
+                # Full irrigation — reset deficit to zero
+                zone.reset_deficit(self._current_source or "automatic")
+            else:
+                # Partial irrigation — authoritative recompute from snapshot
+                all_complete = False
+                delivered_mm = delivered * zone._efficiency / zone._area if zone._area > 0 else 0.0
+                zone._zone_deficit = max(0.0, deficit_at_start - delivered_mm)
+                zone._last_volume_delivered = round(delivered, 1)
+                zone._session_water_delivered = round(delivered, 1)
+                zone._total_water_delivered += delivered
+                zone._yearly_water_delivered += delivered
+                zone._last_irrigated = datetime.now()
+                zone._last_irrigation_source = self._current_source or "automatic"
+                _LOGGER.info(
+                    "Partial irrigation: zone='%s', delivered=%.1fL/%.1fL, deficit reduced to %.2fmm",
+                    zone_name,
+                    delivered,
+                    target,
+                    zone._zone_deficit,
+                )
+            zone._deficit_at_irrigation_start = None
+            zone.async_write_ha_state()
+            self._log_session_result(
+                zone_name=zone_name,
+                zone=zone,
+                source=self._current_source or "automatic",
+                ts_start=ts_start,
+                ts_end=ts_end,
+                volume_target_L=target,
+                volume_delivered_L=delivered,
+                deficit_mm_pre=deficit_at_start,
+                deficit_mm_post=zone._zone_deficit,
+            )
+        # Reset reference sensor only if ALL zones fully irrigated
+        zone_names_irrigated = {z[0] for z in irrigated_zones}
+        if all_complete and zone_names_irrigated == set(self._zones.keys()):
+            self._dryness.reset()
+        self._dryness.async_write_ha_state()
+        _LOGGER.info(
+            "Irrigation cycle complete. %d zone(s) irrigated",
+            len(irrigated_zones),
+        )
 
     # ── Delivery mode dispatch ────────────────────────────
 
@@ -600,13 +614,14 @@ class IrrigationController:
         zone.set_irrigating(True)
         zone.async_write_ha_state()
 
-        await self._wait_with_stop_check(duration)
+        elapsed = await self._wait_with_stop_check(duration)
 
         await self._close_valve(zone.valve)
         zone.set_irrigating(False)
         zone.async_write_ha_state()
-        # Estimated flow assumes full delivery if not stopped
-        return zone.volume_liters if not self._stop_requested else 0.0
+        # Credit the proportional fraction of planned volume based on actual
+        # elapsed time — preserves partial delivery data on emergency stop.
+        return zone.volume_liters * elapsed / duration
 
     async def _deliver_volume_preset(self, zone) -> float:
         """Arm the smart-valve dose, ensure it opens, wait for self-close.
@@ -922,12 +937,17 @@ class IrrigationController:
             context={"entity_id": entity_id, "reason": reason},
         )
 
-    async def _wait_with_stop_check(self, duration_s: int) -> None:
-        """Wait for duration, checking for stop requests every second."""
-        for _ in range(duration_s):
+    async def _wait_with_stop_check(self, duration_s: int) -> int:
+        """Wait for duration, checking for stop requests every second.
+
+        Returns the number of seconds actually elapsed, which may be less
+        than ``duration_s`` when a stop is requested mid-wait.
+        """
+        for elapsed in range(duration_s):
             if self._stop_requested:
-                return
+                return elapsed
             await asyncio.sleep(1)
+        return duration_s
 
     async def _open_valve(self, entity_id: str) -> bool:
         """Open a valve switch. Returns True on success, False on failure.

--- a/custom_components/never_dry/diagnostics.py
+++ b/custom_components/never_dry/diagnostics.py
@@ -65,12 +65,19 @@ async def async_get_config_entry_diagnostics(
     # ── 3. Sanitised config ───────────────────────────────────────────────────
     config_data = async_redact_data(dict(entry.data), _REDACT_KEYS)
 
+    # ── 4. Valve latency statistics ──────────────────────────────────────────
+    operators = hass.data.get(DOMAIN, {}).get(f"_operators_{entry.entry_id}", {})
+    valve_latency = {
+        entity_id: op.latency_diagnostics for entity_id, op in operators.items()
+    }
+
     return {
         "domain": DOMAIN,
         "config_entry_id": entry.entry_id,
         "config_entry_title": entry.title,
         "config_data": config_data,
         "entity_states": entity_states,
+        "valve_latency": valve_latency,
         "activity_log": {
             "path": log_path,
             "total_lines": log_total_lines,

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -355,7 +355,7 @@ def _setup_controller(
         notifier=notifier,
     )
     controller.register_services()
-    return controller
+    return controller  # caller may store valve_operators via controller.valve_operators
 
 
 async def async_setup_platform(
@@ -376,10 +376,14 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the NeverDry sensors from a config entry (UI)."""
+    from .const import DOMAIN
+
     config = dict(entry.data)
     entities, di_sensor, zone_sensors = _create_entities(hass, config, entry.entry_id)
     async_add_entities(entities, True)
-    _setup_controller(hass, config, di_sensor, zone_sensors)
+    controller = _setup_controller(hass, config, di_sensor, zone_sensors)
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][f"_operators_{entry.entry_id}"] = controller.valve_operators
 
 
 # ══════════════════════════════════════════════════════════

--- a/custom_components/never_dry/valve_latency.py
+++ b/custom_components/never_dry/valve_latency.py
@@ -2,8 +2,8 @@
 
 Measures the time between a CMD_OPEN/CMD_CLOSE dispatch and the matching
 hardware confirmation (OBS_SWITCH_ON / OBS_SWITCH_OFF).  Builds a rolling
-window of up to WINDOW_SIZE samples and computes mean + 3σ as the adaptive
-timeout fed back into the FSM timer, replacing the fixed 10 s default.
+window of up to WINDOW_SIZE samples and computes mean + 3*sigma as the
+adaptive timeout fed back into the FSM timer, replacing the fixed 10 s default.
 
 Samples are persisted to HA storage so the statistical model survives
 integration reloads and HA restarts.
@@ -41,7 +41,7 @@ class LatencyWindow:
         self._samples.append(latency_ms)
 
     def adaptive_timeout_s(self) -> float:
-        """Return mean + SIGMA·σ clamped to [MIN_TIMEOUT_S, MAX_TIMEOUT_S].
+        """Return mean + SIGMA*sigma clamped to [MIN_TIMEOUT_S, MAX_TIMEOUT_S].
 
         Returns DEFAULT_TIMEOUT_S when fewer than MIN_SAMPLES have been collected.
         """
@@ -57,7 +57,7 @@ class LatencyWindow:
             return {"sample_count": 0, "adaptive_timeout_s": DEFAULT_TIMEOUT_S}
         mean, std = self._mean_std()
         sorted_s = sorted(self._samples)
-        p95_idx = min(int(math.ceil(0.95 * n)) - 1, n - 1)
+        p95_idx = min(math.ceil(0.95 * n) - 1, n - 1)
         return {
             "sample_count": n,
             "mean_ms": round(mean, 1),

--- a/custom_components/never_dry/valve_latency.py
+++ b/custom_components/never_dry/valve_latency.py
@@ -1,0 +1,115 @@
+"""Rolling latency statistics for valve confirmation response time.
+
+Measures the time between a CMD_OPEN/CMD_CLOSE dispatch and the matching
+hardware confirmation (OBS_SWITCH_ON / OBS_SWITCH_OFF).  Builds a rolling
+window of up to WINDOW_SIZE samples and computes mean + 3σ as the adaptive
+timeout fed back into the FSM timer, replacing the fixed 10 s default.
+
+Samples are persisted to HA storage so the statistical model survives
+integration reloads and HA restarts.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+WINDOW_SIZE: int = 20
+MIN_SAMPLES: int = 3
+SIGMA: float = 3.0
+DEFAULT_TIMEOUT_S: float = 10.0
+MIN_TIMEOUT_S: float = 2.0
+MAX_TIMEOUT_S: float = 30.0
+
+_STORAGE_VERSION: int = 1
+
+
+@dataclass
+class LatencyWindow:
+    """Rolling window of confirmed-response latency samples."""
+
+    _samples: deque[float] = field(
+        default_factory=lambda: deque(maxlen=WINDOW_SIZE), repr=False
+    )
+
+    def record(self, latency_ms: float) -> None:
+        self._samples.append(latency_ms)
+
+    def adaptive_timeout_s(self) -> float:
+        """Return mean + SIGMA·σ clamped to [MIN_TIMEOUT_S, MAX_TIMEOUT_S].
+
+        Returns DEFAULT_TIMEOUT_S when fewer than MIN_SAMPLES have been collected.
+        """
+        if len(self._samples) < MIN_SAMPLES:
+            return DEFAULT_TIMEOUT_S
+        mean, std = self._mean_std()
+        raw_s = (mean + SIGMA * std) / 1000.0
+        return max(MIN_TIMEOUT_S, min(MAX_TIMEOUT_S, raw_s))
+
+    def as_dict(self) -> dict[str, Any]:
+        n = len(self._samples)
+        if n == 0:
+            return {"sample_count": 0, "adaptive_timeout_s": DEFAULT_TIMEOUT_S}
+        mean, std = self._mean_std()
+        sorted_s = sorted(self._samples)
+        p95_idx = min(int(math.ceil(0.95 * n)) - 1, n - 1)
+        return {
+            "sample_count": n,
+            "mean_ms": round(mean, 1),
+            "std_ms": round(std, 1),
+            "p95_ms": round(sorted_s[p95_idx], 1),
+            "min_ms": round(sorted_s[0], 1),
+            "max_ms": round(sorted_s[-1], 1),
+            "adaptive_timeout_s": round(self.adaptive_timeout_s(), 2),
+        }
+
+    def _mean_std(self) -> tuple[float, float]:
+        n = len(self._samples)
+        mean = sum(self._samples) / n
+        variance = sum((x - mean) ** 2 for x in self._samples) / n
+        return mean, math.sqrt(variance)
+
+
+class ValveLatencyTracker:
+    """Tracks and persists open/close confirmation latency for a single valve."""
+
+    def __init__(self, hass: HomeAssistant, switch_entity_id: str) -> None:
+        safe_id = switch_entity_id.replace(".", "_").replace("/", "_")
+        self._store: Store = Store(
+            hass, _STORAGE_VERSION, f"never_dry.latency.{safe_id}"
+        )
+        self.open = LatencyWindow()
+        self.close = LatencyWindow()
+
+    async def async_load(self) -> None:
+        """Load persisted samples from HA storage."""
+        data = await self._store.async_load()
+        if not data:
+            return
+        for s in data.get("open", []):
+            self.open.record(float(s))
+        for s in data.get("close", []):
+            self.close.record(float(s))
+
+    async def async_save(self) -> None:
+        """Persist current samples to HA storage."""
+        await self._store.async_save(
+            {
+                "open": list(self.open._samples),
+                "close": list(self.close._samples),
+            }
+        )
+
+    def open_timeout_s(self) -> float:
+        return self.open.adaptive_timeout_s()
+
+    def close_timeout_s(self) -> float:
+        return self.close.adaptive_timeout_s()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"open": self.open.as_dict(), "close": self.close.as_dict()}

--- a/custom_components/never_dry/valve_operator.py
+++ b/custom_components/never_dry/valve_operator.py
@@ -43,6 +43,7 @@ from .valve_fsm import (
     ValveFsm,
     ValveState,
 )
+from .valve_latency import ValveLatencyTracker
 from .valve_notifier import NotificationKind, Severity, ValveNotifier
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,6 +150,10 @@ class ValveOperator:
         self._watchdog_task: asyncio.Task | None = None
         self._hw_duration_set: bool = False
 
+        self._latency = ValveLatencyTracker(hass, switch_entity_id)
+        self._cmd_start_time: float | None = None
+        hass.async_create_task(self._latency.async_load())
+
         self._unsub_switch = async_track_state_change_event(hass, [switch_entity_id], self._on_switch_state)
         self._unsub_flow = None
         if flow_sensor_entity_id:
@@ -170,6 +175,11 @@ class ValveOperator:
     def failure_count(self) -> int:
         """Return the FSM's consecutive-failure counter."""
         return self._fsm.failure_count
+
+    @property
+    def latency_diagnostics(self) -> dict:
+        """Return latency statistics for this valve (open and close windows)."""
+        return self._latency.as_dict()
 
     # ── Public API ───────────────────────────────────────────────────
 
@@ -289,6 +299,7 @@ class ValveOperator:
         loop = asyncio.get_event_loop()
         self._completion = loop.create_future()
         self._expected_terminal = terminals
+        self._cmd_start_time = monotonic()
         await self._dispatch(cmd)
         return await self._completion
 
@@ -623,6 +634,10 @@ class ValveOperator:
     def _start_timer(self, name: TimerName, seconds: float) -> None:
         """Start (or restart) a named timer that dispatches the matching TIMEOUT."""
         self._cancel_timer(name)
+        if name == TimerName.OPEN:
+            seconds = self._latency.open_timeout_s()
+        elif name == TimerName.CLOSE:
+            seconds = self._latency.close_timeout_s()
         self._timers[name] = self._hass.async_create_task(self._timer(name, seconds))
 
     def _cancel_timer(self, name: TimerName) -> None:
@@ -668,8 +683,30 @@ class ValveOperator:
         if self._fsm.state == ValveState.UNREACHABLE:
             await self._dispatch(ValveEvent.OBS_AVAILABLE)
         if value == "on":
+            if self._fsm.state == ValveState.REQ_OPEN and self._cmd_start_time is not None:
+                latency_ms = (monotonic() - self._cmd_start_time) * 1000.0
+                self._cmd_start_time = None
+                self._latency.open.record(latency_ms)
+                self._hass.async_create_task(self._latency.async_save())
+                _LOGGER.debug(
+                    "Valve '%s' open latency %.1f ms → adaptive timeout %.2f s",
+                    self._zone_name,
+                    latency_ms,
+                    self._latency.open_timeout_s(),
+                )
             await self._dispatch(ValveEvent.OBS_SWITCH_ON)
         elif value == "off":
+            if self._fsm.state == ValveState.REQ_CLOSE and self._cmd_start_time is not None:
+                latency_ms = (monotonic() - self._cmd_start_time) * 1000.0
+                self._cmd_start_time = None
+                self._latency.close.record(latency_ms)
+                self._hass.async_create_task(self._latency.async_save())
+                _LOGGER.debug(
+                    "Valve '%s' close latency %.1f ms → adaptive timeout %.2f s",
+                    self._zone_name,
+                    latency_ms,
+                    self._latency.close_timeout_s(),
+                )
             await self._dispatch(ValveEvent.OBS_SWITCH_OFF)
 
     async def _handle_flow_state(self, event) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,21 @@ def _create_ha_stubs():
     entity_registry_mod.async_get = MagicMock(return_value=MagicMock())
     entity_registry_mod.async_entries_for_device = MagicMock(return_value=[])
 
+    # homeassistant.helpers.storage
+    storage_mod = ModuleType("homeassistant.helpers.storage")
+
+    class _StubStore:
+        def __init__(self, hass, version, key):
+            pass
+
+        async def async_load(self):
+            return None
+
+        async def async_save(self, data):
+            pass
+
+    storage_mod.Store = _StubStore
+
     # homeassistant.const
     const_mod = ModuleType("homeassistant.const")
 
@@ -132,6 +147,7 @@ def _create_ha_stubs():
         "homeassistant.helpers.event": event_mod,
         "homeassistant.helpers.restore_state": restore_mod,
         "homeassistant.helpers.device_registry": device_registry_mod,
+        "homeassistant.helpers.storage": storage_mod,
         "homeassistant.helpers.typing": typing_mod,
         "homeassistant.components.recorder": recorder_mod,
         "homeassistant.components.recorder.history": recorder_history_mod,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -35,7 +35,7 @@ class TestIrrigateSingleZone:
         """Controller should open valve, wait, close valve."""
         zone_orto._zone_deficit = 5.0
 
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -50,7 +50,7 @@ class TestIrrigateSingleZone:
     async def test_resets_zone_deficit_after_irrigation(self, controller, di_sensor, zone_orto):
         """Zone deficit should be reset to zero after successful irrigation."""
         zone_orto._zone_deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -73,7 +73,7 @@ class TestIrrigateSingleZone:
         )
 
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
-        ctrl._wait_with_stop_check = AsyncMock()
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
         di_sensor._deficit = 10.0
 
         await ctrl._irrigate_zones(["NoValve"])
@@ -85,7 +85,7 @@ class TestIrrigateSingleZone:
     async def test_skips_zone_with_zero_duration(self, controller, di_sensor):
         """Zone with zero deficit should be skipped."""
         di_sensor._deficit = 0.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -101,6 +101,7 @@ class TestIrrigateSingleZone:
 
         async def capture_state(duration):
             irrigating_states.append(zone_orto.is_irrigating)
+            return 0
 
         controller._wait_with_stop_check = capture_state
 
@@ -120,7 +121,7 @@ class TestIrrigateAllZones:
         """All zones should be irrigated in order."""
         zone_orto._zone_deficit = 10.0
         zone_prato._zone_deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto", "Prato"])
 
@@ -134,7 +135,7 @@ class TestIrrigateAllZones:
         zone_orto._zone_deficit = 10.0
         zone_prato._zone_deficit = 10.0
         di_sensor._deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto", "Prato"])
 
@@ -175,6 +176,7 @@ class TestEmergencyStop:
 
         async def stop_during_wait(duration):
             controller._stop_requested = True
+            return 0
 
         controller._wait_with_stop_check = stop_during_wait
 
@@ -797,7 +799,7 @@ class TestIrrigationEvent:
     async def test_event_fired_on_zone_completion(self, controller, hass_mock, zone_orto):
         """Event should be fired when a zone completes irrigation."""
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -814,7 +816,7 @@ class TestIrrigationEvent:
         the caller (button, scheduled, reactive) rather than collapsing
         every commanded cycle into the generic 'automatic'."""
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
         controller._current_source = source
 
         await controller._irrigate_zones(["Orto"])
@@ -829,6 +831,7 @@ class TestIrrigationEvent:
 
         async def stop_during_wait(duration):
             controller._stop_requested = True
+            return 0
 
         controller._wait_with_stop_check = stop_during_wait
 

--- a/tests/test_controller_session_result.py
+++ b/tests/test_controller_session_result.py
@@ -109,7 +109,7 @@ class TestSessionResultIntegration:
     @pytest.mark.asyncio
     async def test_auto_cycle_emits_session_result(self, controller, zone_orto, caplog):
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock()
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         with caplog.at_level(logging.INFO, logger="never_dry.controller"):
             await controller._irrigate_zones(["Orto"])

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -44,7 +44,7 @@ class TestEstimatedFlowDelivery:
         zone = _make_zone(hass_mock, di_sensor)
         zone._zone_deficit = 5.0
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
-        ctrl._wait_with_stop_check = AsyncMock()
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         await ctrl._deliver_estimated_flow(zone)
 
@@ -320,7 +320,7 @@ class TestDeliveryModeDispatch:
         zone = _make_zone(hass_mock, di_sensor)
         zone._zone_deficit = 5.0
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
-        ctrl._wait_with_stop_check = AsyncMock()
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
 
         result = await ctrl._deliver_water(zone)
 

--- a/tests/test_valve_latency.py
+++ b/tests/test_valve_latency.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections import deque
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,9 +31,9 @@ def test_adaptive_timeout_default_below_min_samples():
 
 
 def test_adaptive_timeout_with_sufficient_samples():
-    """adaptive_timeout_s = clamp(mean + 3σ / 1000, MIN, MAX)."""
+    """adaptive_timeout_s = clamp(mean + 3*sigma / 1000, MIN, MAX)."""
     w = LatencyWindow()
-    samples = [200.0] * 10  # mean=200, std=0 → raw=200ms=0.2s → clamped to MIN
+    samples = [200.0] * 10  # mean=200, std=0 -> raw=200ms=0.2s -> clamped to MIN
     for s in samples:
         w.record(s)
     result = w.adaptive_timeout_s()
@@ -47,7 +46,7 @@ def test_adaptive_timeout_clamped_to_min():
     """Very fast responses clamp to MIN_TIMEOUT_S."""
     w = LatencyWindow()
     for _ in range(10):
-        w.record(1.0)  # 1 ms → mean+3σ ≈ 0.001 s → below MIN
+        w.record(1.0)  # 1 ms -> mean+3*sigma ~= 0.001 s -> below MIN
     assert w.adaptive_timeout_s() == MIN_TIMEOUT_S
 
 
@@ -55,12 +54,12 @@ def test_adaptive_timeout_clamped_to_max():
     """Very slow responses clamp to MAX_TIMEOUT_S."""
     w = LatencyWindow()
     for _ in range(10):
-        w.record(50_000.0)  # 50 s each → well above MAX
+        w.record(50_000.0)  # 50 s each -> well above MAX
     assert w.adaptive_timeout_s() == MAX_TIMEOUT_S
 
 
 def test_adaptive_timeout_varied_samples():
-    """Mean + 3σ formula holds for a realistic spread."""
+    """Mean + 3*sigma formula holds for a realistic spread."""
     w = LatencyWindow()
     samples = [100.0, 120.0, 150.0, 110.0, 130.0, 90.0, 200.0, 105.0, 115.0, 125.0]
     for s in samples:
@@ -108,7 +107,7 @@ def test_as_dict_p95():
     for i in range(1, 21):  # 1..20
         w.record(float(i * 10))
     d = w.as_dict()
-    # 95th percentile of 20 samples → index ceil(0.95*20)-1 = 18 → value 190
+    # 95th percentile of 20 samples -> index ceil(0.95*20)-1 = 18 -> value 190
     assert d["p95_ms"] == 190.0
 
 
@@ -138,7 +137,7 @@ def tracker(hass, mock_store):
 
 
 async def test_tracker_load_empty(tracker):
-    t, store = tracker
+    t, _ = tracker
     await t.async_load()
     assert len(t.open._samples) == 0
     assert len(t.close._samples) == 0

--- a/tests/test_valve_latency.py
+++ b/tests/test_valve_latency.py
@@ -1,0 +1,212 @@
+"""Tests for valve_latency — rolling latency windows and adaptive timeouts."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from never_dry.valve_latency import (
+    DEFAULT_TIMEOUT_S,
+    MAX_TIMEOUT_S,
+    MIN_SAMPLES,
+    MIN_TIMEOUT_S,
+    SIGMA,
+    WINDOW_SIZE,
+    LatencyWindow,
+    ValveLatencyTracker,
+)
+
+
+# ── LatencyWindow ─────────────────────────────────────────────────────
+
+
+def test_adaptive_timeout_default_below_min_samples():
+    """Returns DEFAULT_TIMEOUT_S when fewer than MIN_SAMPLES collected."""
+    w = LatencyWindow()
+    for _ in range(MIN_SAMPLES - 1):
+        w.record(500.0)
+    assert w.adaptive_timeout_s() == DEFAULT_TIMEOUT_S
+
+
+def test_adaptive_timeout_with_sufficient_samples():
+    """adaptive_timeout_s = clamp(mean + 3σ / 1000, MIN, MAX)."""
+    w = LatencyWindow()
+    samples = [200.0] * 10  # mean=200, std=0 → raw=200ms=0.2s → clamped to MIN
+    for s in samples:
+        w.record(s)
+    result = w.adaptive_timeout_s()
+    expected_raw = (200.0 + SIGMA * 0.0) / 1000.0
+    expected = max(MIN_TIMEOUT_S, min(MAX_TIMEOUT_S, expected_raw))
+    assert abs(result - expected) < 0.01
+
+
+def test_adaptive_timeout_clamped_to_min():
+    """Very fast responses clamp to MIN_TIMEOUT_S."""
+    w = LatencyWindow()
+    for _ in range(10):
+        w.record(1.0)  # 1 ms → mean+3σ ≈ 0.001 s → below MIN
+    assert w.adaptive_timeout_s() == MIN_TIMEOUT_S
+
+
+def test_adaptive_timeout_clamped_to_max():
+    """Very slow responses clamp to MAX_TIMEOUT_S."""
+    w = LatencyWindow()
+    for _ in range(10):
+        w.record(50_000.0)  # 50 s each → well above MAX
+    assert w.adaptive_timeout_s() == MAX_TIMEOUT_S
+
+
+def test_adaptive_timeout_varied_samples():
+    """Mean + 3σ formula holds for a realistic spread."""
+    w = LatencyWindow()
+    samples = [100.0, 120.0, 150.0, 110.0, 130.0, 90.0, 200.0, 105.0, 115.0, 125.0]
+    for s in samples:
+        w.record(s)
+    mean = sum(samples) / len(samples)
+    std = math.sqrt(sum((x - mean) ** 2 for x in samples) / len(samples))
+    expected_s = max(MIN_TIMEOUT_S, min(MAX_TIMEOUT_S, (mean + SIGMA * std) / 1000.0))
+    assert abs(w.adaptive_timeout_s() - expected_s) < 0.001
+
+
+def test_window_rolls_over_max_size():
+    """Only the last WINDOW_SIZE samples are retained."""
+    w = LatencyWindow()
+    for i in range(WINDOW_SIZE + 5):
+        w.record(float(i))
+    assert len(w._samples) == WINDOW_SIZE
+
+
+def test_as_dict_empty():
+    """as_dict on an empty window returns sample_count=0 and default timeout."""
+    d = LatencyWindow().as_dict()
+    assert d["sample_count"] == 0
+    assert d["adaptive_timeout_s"] == DEFAULT_TIMEOUT_S
+
+
+def test_as_dict_populated():
+    """as_dict includes mean, std, p95, min, max, and adaptive_timeout_s."""
+    w = LatencyWindow()
+    samples = [100.0, 200.0, 300.0, 400.0, 500.0]
+    for s in samples:
+        w.record(s)
+    d = w.as_dict()
+    assert d["sample_count"] == 5
+    assert d["min_ms"] == 100.0
+    assert d["max_ms"] == 500.0
+    assert "mean_ms" in d
+    assert "std_ms" in d
+    assert "p95_ms" in d
+    assert "adaptive_timeout_s" in d
+
+
+def test_as_dict_p95():
+    """p95 is the 95th percentile of the sorted samples."""
+    w = LatencyWindow()
+    for i in range(1, 21):  # 1..20
+        w.record(float(i * 10))
+    d = w.as_dict()
+    # 95th percentile of 20 samples → index ceil(0.95*20)-1 = 18 → value 190
+    assert d["p95_ms"] == 190.0
+
+
+# ── ValveLatencyTracker ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_store():
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.async_create_task = lambda coro: asyncio.ensure_future(coro)
+    return h
+
+
+@pytest.fixture
+def tracker(hass, mock_store):
+    with patch("never_dry.valve_latency.Store", return_value=mock_store):
+        t = ValveLatencyTracker(hass, "switch.zone1_valve")
+    return t, mock_store
+
+
+async def test_tracker_load_empty(tracker):
+    t, store = tracker
+    await t.async_load()
+    assert len(t.open._samples) == 0
+    assert len(t.close._samples) == 0
+
+
+async def test_tracker_load_persisted_samples(hass, mock_store):
+    mock_store.async_load = AsyncMock(
+        return_value={"open": [100.0, 200.0, 150.0], "close": [50.0, 60.0]}
+    )
+    with patch("never_dry.valve_latency.Store", return_value=mock_store):
+        t = ValveLatencyTracker(hass, "switch.valve")
+    await t.async_load()
+    assert list(t.open._samples) == [100.0, 200.0, 150.0]
+    assert list(t.close._samples) == [50.0, 60.0]
+
+
+async def test_tracker_save(tracker):
+    t, store = tracker
+    t.open.record(120.0)
+    t.close.record(80.0)
+    await t.async_save()
+    store.async_save.assert_awaited_once_with(
+        {"open": [120.0], "close": [80.0]}
+    )
+
+
+def test_tracker_open_timeout_s_default(tracker):
+    t, _ = tracker
+    assert t.open_timeout_s() == DEFAULT_TIMEOUT_S
+
+
+def test_tracker_close_timeout_s_default(tracker):
+    t, _ = tracker
+    assert t.close_timeout_s() == DEFAULT_TIMEOUT_S
+
+
+def test_tracker_as_dict(tracker):
+    t, _ = tracker
+    d = t.as_dict()
+    assert "open" in d
+    assert "close" in d
+    assert d["open"]["sample_count"] == 0
+    assert d["close"]["sample_count"] == 0
+
+
+def test_tracker_open_timeout_adaptive_after_samples(tracker):
+    """After enough open samples, open_timeout_s diverges from default."""
+    t, _ = tracker
+    for _ in range(MIN_SAMPLES):
+        t.open.record(300.0)
+    timeout = t.open_timeout_s()
+    assert timeout != DEFAULT_TIMEOUT_S
+    assert MIN_TIMEOUT_S <= timeout <= MAX_TIMEOUT_S
+
+
+def test_storage_key_sanitises_entity_id(hass):
+    """Dots and slashes in entity_id are replaced in the storage key."""
+    captured_key = []
+
+    def fake_store(h, version, key):
+        captured_key.append(key)
+        s = MagicMock()
+        s.async_load = AsyncMock(return_value=None)
+        s.async_save = AsyncMock()
+        return s
+
+    with patch("never_dry.valve_latency.Store", side_effect=fake_store):
+        ValveLatencyTracker(hass, "switch.zone/1")
+
+    assert "." not in captured_key[0].split("never_dry.latency.")[1]
+    assert "/" not in captured_key[0]

--- a/tests/test_valve_operator.py
+++ b/tests/test_valve_operator.py
@@ -21,7 +21,7 @@ def hass():
     hass.states.get = MagicMock(return_value=MagicMock(state="off"))
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
-    hass.async_create_task = lambda coro: asyncio.ensure_future(coro)
+    hass.async_create_task = MagicMock()
     return hass
 
 


### PR DESCRIPTION
## Summary

- **Valve latency tracking**: misura il tempo tra CMD_OPEN/CMD_CLOSE e la conferma hardware (OBS_SWITCH_ON/OFF); rolling window di 20 campioni per valvola; timeout FSM adattivo = mean + 3σ, clampato a [2s, 30s]; dati persistiti su HA storage tra i riavvii
- **Fix deficit su uscite anomale**: tre bug dove l'acqua erogata non veniva contabilizzata — emergency stop, eccezioni nel ciclo, task cancellation (reload HA), e consegna parziale in `estimated_flow` mode
- **Diagnostics**: nuova sezione `valve_latency` nel bundle scaricabile da HA con stats per ogni valvola

## Dettaglio fix deficit

| Scenario | Prima | Dopo |
|---|---|---|
| Emergency stop con acqua già erogata | Debito non aggiornato | Settle sempre in `finally` |
| Exception / reload HA mid-cycle | Snapshot cancellato senza applicarlo | `_settle_irrigated_zones()` nel `finally` |
| `estimated_flow` interrotto da stop | Ritornava `0.0` (tutto perso) | Proporzionale al tempo trascorso |
| Stop dopo partial flow-meter delivery | `break` prima dell'append → perso | Append spostato prima del controllo stop |

## Nuovi file

- `custom_components/never_dry/valve_latency.py` — `LatencyWindow`, `ValveLatencyTracker`
- `tests/test_valve_latency.py` — 17 test (stats, clamping, p95, persistenza, sanitizzazione chiave storage)

## Test plan

- [ ] Verificare che un emergency stop durante irrigazione aggiorni correttamente il debito con l'acqua già erogata
- [ ] Verificare che dopo N cicli di irrigazione il timeout adattivo in `valve_latency` si stabilizzi su valori realistici
- [ ] Scaricare diagnostics da HA → confermare presenza sezione `valve_latency` con stats per zona
- [ ] Verificare che un reload dell'integrazione durante irrigazione non azzeri il debito