### PR TITLE
docs(readme): remove dead link, duplicate Ko-fi, outdated Automations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
 
-<a href="https://ko-fi.com/drake69"><img src="https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" height="35"></a>
-
 ---
 
 ## What it does
@@ -202,7 +200,6 @@ t    = V / FlowRate × 60                   [s]     irrigation duration
 
 - [User Manual](docs/user_manual.md)
 - [Developer Manual](docs/developer_manual.md)
-- [HACS Publishing Guide](docs/hacs_publishing_guide.md)
 - [Project Homepage](https://drake69.github.io/NeverDry/)
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -136,45 +136,6 @@ NeverDry is configured entirely through the UI — no YAML required.
 
 ---
 
-## Automations
-
-### Mode A — Threshold trigger (per zone)
-
-```yaml
-automation:
-  - alias: "Irrigation — Vegetable Garden"
-    trigger:
-      - platform: numeric_state
-        entity_id: sensor.never_dry
-        above: 15
-    condition:
-      - condition: time
-        after: "06:00:00"
-        before: "09:00:00"
-    action:
-      - service: never_dry.irrigate_zone
-        data:
-          zone_name: "Vegetable Garden"
-```
-
-### Mode B — Nightly all zones
-
-```yaml
-automation:
-  - alias: "Nightly irrigation"
-    trigger:
-      - platform: time
-        at: "23:00:00"
-    condition:
-      - condition: numeric_state
-        entity_id: sensor.never_dry
-        above: 1
-    action:
-      - service: never_dry.irrigate_all
-```
-
----
-
 ## Scientific Background
 
 Based on the FAO-56 water balance (Allen et al., 1998):


### PR DESCRIPTION
## Summary

- Remove dead link to `docs/hacs_publishing_guide.md` (file does not exist)
- Remove duplicate Ko-fi button (was appearing twice, top and bottom)
- Remove outdated **Automations** section — Mode A/B scheduling is built into the integration; users don't need to write any YAML automations

## No code changes — README only