### PR TITLE
fix(sensor): delivery_timeout adapts to estimated delivery duration

### DIFF
--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -933,8 +933,12 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
 
     @property
     def delivery_timeout(self) -> int:
-        """Safety timeout in seconds for flow_meter and volume_preset modes."""
-        return self._delivery_timeout
+        """Safety timeout in seconds for flow_meter and volume_preset modes.
+
+        Returns the greater of the configured floor and the estimated delivery
+        duration, so large deficits never hit the timeout before completion.
+        """
+        return max(self._delivery_timeout, self.duration_s)
 
     @property
     def hw_max_duration_topic(self) -> str | None:
@@ -1032,7 +1036,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         if self._flow_meter_sensor:
             attrs["flow_meter_sensor"] = self._flow_meter_sensor
         if self._delivery_mode != DELIVERY_MODE_ESTIMATED_FLOW:
-            attrs["delivery_timeout_s"] = self._delivery_timeout
+            attrs["delivery_timeout_s"] = self.delivery_timeout
         return attrs
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -701,13 +701,12 @@ class TestExternalSessionMonitor:
         )
 
     @pytest.mark.asyncio
-    async def test_estimated_duration_caps_at_timeout(self, controller, zone_orto, hass_mock, monkeypatch):
-        """When estimated duration exceeds the safety timeout, the
-        timeout wins (min of the two)."""
-        # Big deficit → long estimated duration.
-        zone_orto._zone_deficit = 1000.0
-        zone_orto._delivery_timeout = 30
-        zone_orto._flow_rate = 1.0  # L/min — irrelevant magnitude here
+    async def test_estimated_duration_used_when_no_flow_meter(self, controller, zone_orto, hass_mock, monkeypatch):
+        """When no flow meter is present, the monitor waits exactly the estimated
+        delivery duration (volume / flow_rate). delivery_timeout adapts to be >=
+        duration_s so it never cuts the wait short."""
+        zone_orto._zone_deficit = 5.0
+        zone_orto._flow_rate = 8.0  # L/min
 
         sleeps = []
 
@@ -720,7 +719,8 @@ class TestExternalSessionMonitor:
 
         await controller._external_session_monitor("switch.valve_orto", "Orto")
 
-        assert sleeps == [30]
+        expected_s = int(zone_orto.volume_liters / zone_orto._flow_rate * 60)
+        assert sleeps == [expected_s]
 
 
 class TestBatteryMonitoring:


### PR DESCRIPTION
## Problem

`delivery_timeout` was a fixed safety floor (`DEFAULT_DELIVERY_TIMEOUT_S = 3600 s`). For zones with a large deficit the estimated delivery duration (`duration_s = volume_liters / flow_rate × 60`) can exceed 3600 s, causing `flow_meter` and `volume_preset` modes to hit the timeout and close the valve before delivering the required volume.

## Fix

`delivery_timeout` is now a computed property:

```python
return max(self._delivery_timeout, self.duration_s)
```

The safety timeout always covers the full estimated delivery while still guaranteeing a minimum of `_delivery_timeout` (3600 s default, or user-configured floor) for small zones.

## Test update

`test_estimated_duration_caps_at_timeout` tested the old "timeout caps the wait" behavior. With the new property `timeout_s >= estimated_s` always holds, so the external session monitor on the estimated-flow path waits exactly `duration_s`. Test renamed and updated accordingly.