### PR TITLE
fix(init): executor for file logger + last_session_duration_s attribute + dashboard

### DIFF
--- a/config/dashboard.yaml
+++ b/config/dashboard.yaml
@@ -54,6 +54,16 @@ cards:
       - entity: sensor.neverdry_giardino_melino_volume
         name: Volume to irrigate
         icon: mdi:water
+      - type: attribute
+        entity: sensor.neverdry_giardino_melino_deficit
+        attribute: flow_rate_lpm
+        name: Flow rate (L/min)
+        icon: mdi:gauge
+      - type: attribute
+        entity: sensor.neverdry_giardino_melino_deficit
+        attribute: last_session_duration_s
+        name: Last session (s)
+        icon: mdi:timer-outline
       - entity: button.neverdry_giardino_melino_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
@@ -61,9 +71,9 @@ cards:
         name: Mark as irrigated
         icon: mdi:water-check
 
-  # ── Zone: Giardino ortensia ─────────────────────────────
+  # ── Zone: Giardino Ortensia ─────────────────────────────
   - type: entities
-    title: Giardino ortensia
+    title: Giardino Ortensia
     icon: mdi:sprinkler-variant
     entities:
       - entity: sensor.neverdry_giardino_ortensia_deficit
@@ -72,9 +82,75 @@ cards:
       - entity: sensor.neverdry_giardino_ortensia_volume
         name: Volume to irrigate
         icon: mdi:water
+      - type: attribute
+        entity: sensor.neverdry_giardino_ortensia_deficit
+        attribute: flow_rate_lpm
+        name: Flow rate (L/min)
+        icon: mdi:gauge
+      - type: attribute
+        entity: sensor.neverdry_giardino_ortensia_deficit
+        attribute: last_session_duration_s
+        name: Last session (s)
+        icon: mdi:timer-outline
       - entity: button.neverdry_giardino_ortensia_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
       - entity: button.neverdry_giardino_ortensia_mark_irrigated
+        name: Mark as irrigated
+        icon: mdi:water-check
+
+  # ── Zone: Giardino Pino ─────────────────────────────────
+  - type: entities
+    title: Giardino Pino
+    icon: mdi:sprinkler-variant
+    entities:
+      - entity: sensor.neverdry_giardino_pino_deficit
+        name: Deficit
+        icon: mdi:water-percent-alert
+      - entity: sensor.neverdry_giardino_pino_volume
+        name: Volume to irrigate
+        icon: mdi:water
+      - type: attribute
+        entity: sensor.neverdry_giardino_pino_deficit
+        attribute: flow_rate_lpm
+        name: Flow rate (L/min)
+        icon: mdi:gauge
+      - type: attribute
+        entity: sensor.neverdry_giardino_pino_deficit
+        attribute: last_session_duration_s
+        name: Last session (s)
+        icon: mdi:timer-outline
+      - entity: button.neverdry_giardino_pino_irrigate
+        name: Irrigate now
+        icon: mdi:sprinkler
+      - entity: button.neverdry_giardino_pino_mark_irrigated
+        name: Mark as irrigated
+        icon: mdi:water-check
+
+  # ── Zone: Giardino Melograno ────────────────────────────
+  - type: entities
+    title: Giardino Melograno
+    icon: mdi:sprinkler-variant
+    entities:
+      - entity: sensor.neverdry_giardino_melograno_deficit
+        name: Deficit
+        icon: mdi:water-percent-alert
+      - entity: sensor.neverdry_giardino_melograno_volume
+        name: Volume to irrigate
+        icon: mdi:water
+      - type: attribute
+        entity: sensor.neverdry_giardino_melograno_deficit
+        attribute: flow_rate_lpm
+        name: Flow rate (L/min)
+        icon: mdi:gauge
+      - type: attribute
+        entity: sensor.neverdry_giardino_melograno_deficit
+        attribute: last_session_duration_s
+        name: Last session (s)
+        icon: mdi:timer-outline
+      - entity: button.neverdry_giardino_melograno_irrigate
+        name: Irrigate now
+        icon: mdi:sprinkler
+      - entity: button.neverdry_giardino_melograno_mark_irrigated
         name: Mark as irrigated
         icon: mdi:water-check

--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -115,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NeverDry from a config entry (UI)."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
-    handler = _setup_file_logger(hass)
+    handler = await hass.async_add_executor_job(_setup_file_logger, hass)
     hass.data[DOMAIN][f"_log_handler_{entry.entry_id}"] = handler
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
@@ -128,7 +128,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         handler = hass.data[DOMAIN].pop(f"_log_handler_{entry.entry_id}", None)
         if handler is not None:
-            _teardown_file_logger(handler)
+            await hass.async_add_executor_job(_teardown_file_logger, handler)
         hass.data[DOMAIN].pop(entry.entry_id, None)
         hass.data[DOMAIN].pop(f"_operators_{entry.entry_id}", None)
     return unload_ok

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -563,6 +563,7 @@ class IrrigationController:
                     target,
                     zone._zone_deficit,
                 )
+            zone._last_session_duration_s = round((ts_end - ts_start).total_seconds())
             zone._deficit_at_irrigation_start = None
             zone.async_write_ha_state()
             self._log_session_result(
@@ -1148,6 +1149,7 @@ class IrrigationController:
             session_meta = self._manual_session_meta.pop(entity_id, None)
             if session_meta is not None:
                 ts_start, deficit_pre = session_meta
+                zone._last_session_duration_s = round((datetime.now() - ts_start).total_seconds())
                 self._log_session_result(
                     zone_name=zone_name,
                     zone=zone,

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -776,6 +776,16 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._area = zone_config.get(CONF_ZONE_AREA, 0.0)
         self._system_type = zone_config.get(CONF_ZONE_SYSTEM_TYPE)
         self._flow_rate = zone_config.get(CONF_ZONE_FLOW_RATE, 0.0)
+        if self._flow_rate > 30:
+            _LOGGER.warning(
+                "Zone '%s': flow_rate_lpm=%.1f L/min (= %.0f L/h) looks unrealistically high "
+                "for garden irrigation. If you configured it in L/h, divide by 60 (e.g. %.0f L/h → %.2f L/min).",
+                zone_config.get(CONF_ZONE_NAME, "?"),
+                self._flow_rate,
+                self._flow_rate * 60,
+                self._flow_rate,
+                self._flow_rate / 60,
+            )
         self._threshold = zone_config.get(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD)
         self._delivery_mode = zone_config.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
         self._volume_entity = zone_config.get(CONF_ZONE_VOLUME_ENTITY)
@@ -790,6 +800,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._last_irrigated: datetime | None = None
         self._last_volume_delivered: float = 0.0
         self._last_irrigation_source: str | None = None
+        self._last_session_duration_s: int = 0
         # Snapshot of zone_deficit captured by the controller at the start
         # of an irrigation cycle. Used by flow-metered delivery modes for
         # real-time deficit updates: every update is computed as
@@ -845,6 +856,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                     self._last_irrigated = datetime.fromisoformat(ts)
                     self._last_volume_delivered = float(last.attributes.get("last_volume_delivered", 0.0))
                     self._last_irrigation_source = last.attributes.get("last_irrigation_source")
+                    self._last_session_duration_s = int(last.attributes.get("last_session_duration_s", 0))
             with contextlib.suppress(ValueError, TypeError):
                 self._total_rain = float(last.attributes.get("total_rain_mm", 0.0))
             with contextlib.suppress(ValueError, TypeError):
@@ -1031,6 +1043,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             attrs["last_irrigated"] = self._last_irrigated.isoformat()
             attrs["last_volume_delivered"] = self._last_volume_delivered
             attrs["last_irrigation_source"] = self._last_irrigation_source
+            attrs["last_session_duration_s"] = self._last_session_duration_s
         if self._volume_entity:
             attrs["volume_entity"] = self._volume_entity
         if self._flow_meter_sensor:


### PR DESCRIPTION
## Summary

- **Fix blocking call**: `RotatingFileHandler` calls `open()` in its constructor, blocking the HA event loop and triggering a `homeassistant.util.loop` warning on Python 3.14. Both `_setup_file_logger` and `_teardown_file_logger` are now wrapped in `async_add_executor_job`.
- **New attribute `last_session_duration_s`**: tracks actual irrigation duration (seconds) for both commanded cycles and manual valve sessions; persisted across reloads via `extra_state_attributes` restore.
- **Flow rate guard**: warns at startup if `flow_rate_lpm > 30 L/min` (= 1800 L/h), showing the L/h equivalent and the corrected L/min value — catches the common mistake of configuring the field in L/h instead of L/min.
- **Dashboard**: adds `flow_rate_lpm` and `last_session_duration_s` rows to all zone cards; adds missing Giardino Pino and Giardino Melograno sections.

## Test plan

- [ ] Reload integration — no `homeassistant.util.loop` blocking call warning in HA logs
- [ ] `never_dry_activity.log` is created and written correctly after reload
- [ ] After an irrigation cycle, `last_session_duration_s` attribute appears on the zone deficit sensor with the correct elapsed seconds
- [ ] After a manual valve open/close, `last_session_duration_s` is updated
- [ ] `last_session_duration_s` survives a HA restart (restored from state)
- [ ] Configure a zone with `flow_rate_lpm = 200` → WARNING in log with L/h equivalent and suggested L/min value
- [ ] Dashboard shows `flow_rate_lpm` and `last_session_duration_s` for all four zones