### PR TITLE
feat: expose valve FSM state and add ResetMaintenanceButton

### DIFF
--- a/.coding_agent/2026-06-15_session.md
+++ b/.coding_agent/2026-06-15_session.md
@@ -1,0 +1,46 @@
+# Session diary — 2026-06-15
+
+## Cosa è stato fatto
+
+Sessione interamente dedicata a marketing e comunicazione community, nessuna modifica al codice.
+
+1. **Confronto NeverDry vs HAsmartirrigation** — analisi tecnica approfondita delle due integrazioni:
+   ET formula, modello water balance, Kc, controllo valvole, scheduling, maturità/community.
+   Il confronto ha chiarito il posizionamento competitivo di NeverDry.
+
+2. **Reply forum HA (post #6, johnnyh1975)** — domanda pubblica "how does it compare to smart
+   irrigation?". Decisione: rispondere in modo neutro e non competitivo, valorizzando entrambi
+   gli strumenti senza fare una guerra di feature.
+
+3. **Documento competitive_positioning.md** — creato in `documents/03_marketing/` con:
+   - Posizionamento chiave NeverDry vs HAsmartirrigation
+   - Messaggi efficaci da riusare
+   - Testo del reply forum come riferimento
+   - Roadmap ET da comunicare (wind/radiation/Penman-Monteith futuri)
+   - Profilo utente target (giardiniere casalingo, non agronomo)
+
+4. **Memory project_ha_community_post.md** — aggiornata con il log del reply a johnnyh1975
+   (testo completo + data).
+
+## Decisioni prese
+
+- **Non fare comparazioni dirette sulla community**: tono neutro, rispetto per HAsmartirrigation,
+  focus sull'utente target di NeverDry piuttosto che su "siamo meglio".
+
+- **Framing del vantaggio NeverDry**: la semplicità (solo temperatura + pioggia) è una scelta
+  di design deliberata per l'utente target, non una limitazione permanente. La roadmap
+  (wind/radiation/altri modelli ET) va comunicata proattivamente per dimostrare che il progetto
+  cresce.
+
+- **Punto forte da ribadire**: Brooks-Corey hydraulic conductivity in HAsmartirrigation è
+  scientificamente corretto ma inaccessibile per un giardiniere casalingo. NeverDry usa 2
+  parametri intuitivi calibrabili per osservazione.
+
+## Aperto / da fare
+
+- Pubblicare il reply su community.home-assistant.io (da fare manualmente)
+- Cross-post r/homeautomation settimana del 2026-06-20 (già pianificato in memory)
+
+## Blocchi / dipendenze
+
+Nessuno.

--- a/.coding_agent/2026-06-18_session.md
+++ b/.coding_agent/2026-06-18_session.md
@@ -1,0 +1,48 @@
+# Session diary — 2026-06-18
+
+## Cosa è stato fatto
+
+### Analisi architetturale (read-only)
+- Chiarito il flusso UML di `MarkIrrigatedButton`: interagisce con `ButtonEntity` (ereditarietà), `HomeAssistant`, `DeviceInfo`, e indirettamente con `NeverDryController` via service bus HA (`SERVICE_MARK_IRRIGATED`).
+- Confermato che il controller **non scala il deficit in tempo reale** durante l'apertura manuale: la compensazione avviene in un colpo solo alla chiusura della valvola, usando `delivered_liters / area × efficiency`.
+- Chiarito il funzionamento del pulsante `IrrigateButton`: tre modalità di consegna (`estimated_flow` = durata pre-calcolata, `flow_meter` = polling real-time, `volume_preset` = delega alla valvola smart). Il deficit viene azzerato solo nel `finally` di `_irrigate_zones`.
+
+### Lettura log diagnostico
+- Percorso corretto del log: `/config/never_dry_activity.log` (non dentro `custom_components/`).
+- Log montato in `/Volumes/config/never_dry_activity.log` e letto direttamente.
+- Rilevati due errori gravi del 2026-06-17/18: `CLOSE_VERIFICATION_FAILED` su Giardino Ortensia (23:03) e Giardino Melino (07:00). Entrambe le valvole hanno raggiunto il timeout massimo di 3600s con delivery parziale (Ortensia 6.7/77.8L, Melino 207.6/326.8L).
+- Conseguenza: `_running = True` per ore → pulsante Irrigate bloccato da "Irrigation already in progress".
+
+### Bug fix: blocking call in event loop (AI-068)
+- `RotatingFileHandler(...)` chiama `open()` nel costruttore, bloccando l'event loop di HA (rilevato come WARNING da `homeassistant.util.loop`).
+- Fix in `__init__.py`: `_setup_file_logger` e `_teardown_file_logger` wrappati in `hass.async_add_executor_job`.
+
+### Bug diagnosticato: flow_rate in unità errate
+- L'utente aveva configurato Melograno con `flow_rate = 200` intendendo L/h, ma il campo è `flow_rate_lpm` (L/min).
+- Calcolo durata: `duration_s = volume_liters / flow_rate * 60 = 36.1 / 200 * 60 ≈ 11s` → valvola aperta solo 11 secondi invece di ~11 minuti.
+- Valore corretto: `200 L/h ÷ 60 = 3.33 L/min`.
+
+### Feature: last_session_duration_s + dashboard (AI-069)
+- Aggiunto `_last_session_duration_s: int` a `ZoneSensor` (sensor.py): valorizzato in `_settle_irrigated_zones` (cicli comandati) e in `_on_valve_state_change` alla chiusura manuale.
+- Esposto in `extra_state_attributes` e restorato da stato HA al reload.
+- Dashboard (`config/dashboard.yaml`): aggiunto `flow_rate_lpm` e `last_session_duration_s` su tutte le zone; aggiunte Giardino Pino e Giardino Melograno che mancavano.
+
+## Decisioni prese
+
+- `last_session_duration_s` esposto solo se `last_irrigated` è valorizzato (coerente con gli altri attributi last_*).
+- Per le sessioni manuali la durata è calcolata da `_manual_session_meta` (ts_start → datetime.now() alla chiusura), non da `time.monotonic()` per uniformità con i cicli comandati.
+
+### Guard flow_rate_lpm > 30 (AI-070)
+Aggiunto warning in `ZoneSensor.__init__` se `flow_rate_lpm > 30` L/min: mostra equivalente in L/h e suggerisce la divisione per 60. Soglia 30 L/min (1800 L/h) copre impianti a pioggia grandi senza falsi positivi. Il flow meter sensor fisico ha già conversione automatica delle unità via `unit_of_measurement` — il guard riguarda solo il parametro di configurazione manuale.
+
+## Cosa rimane aperto
+
+- Bug flow_rate Melograno: da correggere in configurazione HA (3.33 L/min).
+- `CLOSE_VERIFICATION_FAILED` su Ortensia e Melino: problema fisico/Zigbee da investigare (valvola non risponde al turn_off?).
+- Commit e PR delle modifiche di sessione ancora da fare (proposto all'utente).
+- Sessione di irrigazione Melograno col pulsante Irrigate: non tracciata nel log (nessuna entry dopo 22:09), da investigare al prossimo accesso.
+
+## Blocchi / dipendenze
+
+- Nessuno bloccante per il codice.
+- `CLOSE_VERIFICATION_FAILED` dipende da connettività Zigbee hardware — fuori dal controllo del software.

--- a/config/dashboard.yaml
+++ b/config/dashboard.yaml
@@ -9,6 +9,7 @@
 #    sensor.neverdry_<zone_slug>_volume
 #    button.neverdry_<zone_slug>_irrigate
 #    button.neverdry_<zone_slug>_mark_irrigated
+#    button.neverdry_<zone_slug>_reset_valve
 #
 #  Adjust entity IDs to match your zone names.
 ##############################################################
@@ -29,11 +30,10 @@ cards:
     entities:
       - entity: sensor.neverdry_dryness_index
         name: Global (Kc=1)
-      # ── Add one line per zone ──
       - entity: sensor.neverdry_giardino_melino_deficit
         name: Giardino Melino
       - entity: sensor.neverdry_giardino_ortensia_deficit
-        name: Giardino ortensia
+        name: Giardino Ortensia
 
   # ── ET Hourly ───────────────────────────────────────────
   - type: history-graph
@@ -64,12 +64,20 @@ cards:
         attribute: last_session_duration_s
         name: Last session (s)
         icon: mdi:timer-outline
+      - type: attribute
+        entity: sensor.neverdry_giardino_melino_deficit
+        attribute: valve_fsm_state
+        name: Valve state
+        icon: mdi:valve
       - entity: button.neverdry_giardino_melino_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
       - entity: button.neverdry_giardino_melino_mark_irrigated
         name: Mark as irrigated
         icon: mdi:water-check
+      - entity: button.neverdry_giardino_melino_reset_valve
+        name: Reset valve (unlock)
+        icon: mdi:lock-reset
 
   # ── Zone: Giardino Ortensia ─────────────────────────────
   - type: entities
@@ -92,12 +100,20 @@ cards:
         attribute: last_session_duration_s
         name: Last session (s)
         icon: mdi:timer-outline
+      - type: attribute
+        entity: sensor.neverdry_giardino_ortensia_deficit
+        attribute: valve_fsm_state
+        name: Valve state
+        icon: mdi:valve
       - entity: button.neverdry_giardino_ortensia_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
       - entity: button.neverdry_giardino_ortensia_mark_irrigated
         name: Mark as irrigated
         icon: mdi:water-check
+      - entity: button.neverdry_giardino_ortensia_reset_valve
+        name: Reset valve (unlock)
+        icon: mdi:lock-reset
 
   # ── Zone: Giardino Pino ─────────────────────────────────
   - type: entities
@@ -120,12 +136,20 @@ cards:
         attribute: last_session_duration_s
         name: Last session (s)
         icon: mdi:timer-outline
+      - type: attribute
+        entity: sensor.neverdry_giardino_pino_deficit
+        attribute: valve_fsm_state
+        name: Valve state
+        icon: mdi:valve
       - entity: button.neverdry_giardino_pino_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
       - entity: button.neverdry_giardino_pino_mark_irrigated
         name: Mark as irrigated
         icon: mdi:water-check
+      - entity: button.neverdry_giardino_pino_reset_valve
+        name: Reset valve (unlock)
+        icon: mdi:lock-reset
 
   # ── Zone: Giardino Melograno ────────────────────────────
   - type: entities
@@ -148,9 +172,17 @@ cards:
         attribute: last_session_duration_s
         name: Last session (s)
         icon: mdi:timer-outline
+      - type: attribute
+        entity: sensor.neverdry_giardino_melograno_deficit
+        attribute: valve_fsm_state
+        name: Valve state
+        icon: mdi:valve
       - entity: button.neverdry_giardino_melograno_irrigate
         name: Irrigate now
         icon: mdi:sprinkler
       - entity: button.neverdry_giardino_melograno_mark_irrigated
         name: Mark as irrigated
         icon: mdi:water-check
+      - entity: button.neverdry_giardino_melograno_reset_valve
+        name: Reset valve (unlock)
+        icon: mdi:lock-reset

--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -1,6 +1,6 @@
 """Button platform for the NeverDry integration.
 
-Provides per-zone buttons: "Irrigate" and "Mark as irrigated".
+Provides per-zone buttons: "Irrigate", "Mark as irrigated", and "Reset valve".
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     SERVICE_IRRIGATE_ZONE,
     SERVICE_MARK_IRRIGATED,
+    SERVICE_RESET_VALVE,
 )
 
 
@@ -57,6 +58,8 @@ def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -
         device_info = _zone_device_info(entry_id, zone_name)
         buttons.append(MarkIrrigatedButton(hass, zone_name, device_info))
         buttons.append(IrrigateButton(hass, zone_name, device_info))
+        if zone_conf.get("valve"):
+            buttons.append(ResetMaintenanceButton(hass, zone_name, device_info))
     return buttons
 
 
@@ -104,5 +107,29 @@ class IrrigateButton(ButtonEntity):
         await self._hass.services.async_call(
             DOMAIN,
             SERVICE_IRRIGATE_ZONE,
+            {ATTR_ZONE_NAME: self._zone_name},
+        )
+
+
+class ResetMaintenanceButton(ButtonEntity):
+    """Button to reset a valve FSM from MAINTENANCE back to IDLE."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:lock-reset"
+
+    def __init__(self, hass: HomeAssistant, zone_name: str, device_info: DeviceInfo | None = None) -> None:
+        self._hass = hass
+        self._zone_name = zone_name
+        slug = zone_name.lower().replace(" ", "_")
+        self._attr_name = "Reset valve"
+        self._attr_unique_id = f"reset_valve_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press — clear valve MAINTENANCE lock."""
+        await self._hass.services.async_call(
+            DOMAIN,
+            SERVICE_RESET_VALVE,
             {ATTR_ZONE_NAME: self._zone_name},
         )

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -103,6 +103,7 @@ SERVICE_IRRIGATE_ZONE = "irrigate_zone"
 SERVICE_IRRIGATE_ALL = "irrigate_all"
 SERVICE_STOP = "stop"
 SERVICE_MARK_IRRIGATED = "mark_irrigated"
+SERVICE_RESET_VALVE = "reset_valve"
 
 ATTR_ZONE_NAME = "zone_name"
 

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -41,6 +41,7 @@ from .const import (
     SERVICE_IRRIGATE_ZONE,
     SERVICE_MARK_IRRIGATED,
     SERVICE_RESET,
+    SERVICE_RESET_VALVE,
     SERVICE_STOP,
 )
 from .valve_fsm import ValveState
@@ -138,6 +139,7 @@ class IrrigationController:
         self._hass.services.async_register(DOMAIN, SERVICE_IRRIGATE_ALL, self._handle_irrigate_all)
         self._hass.services.async_register(DOMAIN, SERVICE_STOP, self._handle_stop)
         self._hass.services.async_register(DOMAIN, SERVICE_MARK_IRRIGATED, self._handle_mark_irrigated)
+        self._hass.services.async_register(DOMAIN, SERVICE_RESET_VALVE, self._handle_reset_valve)
 
         # Monitor valve state changes to detect manual irrigation
         valve_entities = [v for v in self._valve_to_zone if v]
@@ -392,6 +394,24 @@ class IrrigationController:
                 zs.reset_deficit("mark_irrigated")
                 zs.async_write_ha_state()
             _LOGGER.info("All zones marked as irrigated, deficits reset")
+
+    async def _handle_reset_valve(self, call: ServiceCall) -> None:
+        """Reset valve FSM from MAINTENANCE to IDLE for a specific zone."""
+        zone_name = call.data.get(ATTR_ZONE_NAME)
+        zone = self._zones.get(zone_name)
+        if zone is None:
+            _LOGGER.error("reset_valve: zone '%s' not found", zone_name)
+            return
+        if not zone.valve:
+            _LOGGER.error("reset_valve: zone '%s' has no valve configured", zone_name)
+            return
+        operator = self._valve_operators.get(zone.valve)
+        if operator is None:
+            _LOGGER.warning("reset_valve: zone '%s' has no operator (volume_preset mode?)", zone_name)
+            return
+        await operator.reset_maintenance()
+        zone.async_write_ha_state()
+        _LOGGER.info("Valve maintenance reset: zone='%s'", zone_name)
 
     # ── Core irrigation logic ────────────────────────────
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -333,7 +333,7 @@ def _setup_controller(
         if getattr(zs, "delivery_mode", None) == "volume_preset":
             continue
         hw_entity, hw_mult = _discover_hw_max_duration(hass, zs.valve)
-        valve_operators[zs.valve] = ValveOperator(
+        op = ValveOperator(
             hass=hass,
             switch_entity_id=zs.valve,
             flow_sensor_entity_id=zs.flow_meter_sensor,
@@ -345,6 +345,8 @@ def _setup_controller(
             hw_max_duration_topic=zs.hw_max_duration_topic,
             hw_max_duration_payload_template=zs.hw_max_duration_payload,
         )
+        valve_operators[zs.valve] = op
+        zs.set_operator(op)
 
     controller = IrrigationController(
         hass,
@@ -801,6 +803,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._last_volume_delivered: float = 0.0
         self._last_irrigation_source: str | None = None
         self._last_session_duration_s: int = 0
+        self._operator = None  # set by _setup_controller after operator creation
         # Snapshot of zone_deficit captured by the controller at the start
         # of an irrigation cycle. Used by flow-metered delivery modes for
         # real-time deficit updates: every update is computed as
@@ -950,7 +953,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         Returns the greater of the configured floor and the estimated delivery
         duration, so large deficits never hit the timeout before completion.
         """
-        return max(self._delivery_timeout, self.duration_s)
+        return max(self._delivery_timeout, round(self.duration_s * 1.1))
 
     @property
     def hw_max_duration_topic(self) -> str | None:
@@ -961,6 +964,10 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     def hw_max_duration_payload(self) -> str:
         """Payload template for the hw_max_duration MQTT publish (``{value}`` placeholder)."""
         return self._hw_max_duration_payload
+
+    def set_operator(self, operator) -> None:
+        """Attach the ValveOperator so FSM state can be exposed in attributes."""
+        self._operator = operator
 
     @property
     def is_irrigating(self) -> bool:
@@ -1050,6 +1057,9 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             attrs["flow_meter_sensor"] = self._flow_meter_sensor
         if self._delivery_mode != DELIVERY_MODE_ESTIMATED_FLOW:
             attrs["delivery_timeout_s"] = self.delivery_timeout
+        if self._operator is not None:
+            attrs["valve_fsm_state"] = self._operator.state.value
+            attrs["valve_in_maintenance"] = self._operator.is_in_maintenance
         return attrs
 
 

--- a/custom_components/never_dry/services.yaml
+++ b/custom_components/never_dry/services.yaml
@@ -44,3 +44,18 @@ mark_irrigated:
       example: "Vegetable Garden"
       selector:
         text:
+
+reset_valve:
+  name: Reset valve (unlock maintenance)
+  description: >
+    Reset the valve FSM from MAINTENANCE back to IDLE. Use this after
+    repeated close-verification failures to allow the zone to irrigate again.
+    The valve must be physically closed before resetting.
+  fields:
+    zone_name:
+      name: Zone name
+      description: The zone whose valve should be unlocked.
+      required: true
+      example: "Vegetable Garden"
+      selector:
+        text:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -24,7 +24,7 @@ class TestControllerState:
 
     def test_register_services(self, controller, hass_mock):
         controller.register_services()
-        assert hass_mock.services.async_register.call_count == 5
+        assert hass_mock.services.async_register.call_count == 6
 
 
 class TestIrrigateSingleZone:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Exposes `valve_fsm_state` and `valve_in_maintenance` as zone sensor attributes so the user can see when a valve is blocked in MAINTENANCE state (after 3× `CLOSE_VERIFICATION_FAILED`)
- Adds `ResetMaintenanceButton` (entity `button.neverdry_<zone>_reset_valve`) — pressing it calls the new `reset_valve` service which unlocks the FSM via `ValveOperator.reset_maintenance()`
- Fixes `delivery_timeout` to include a 10% margin: `max(configured_floor, round(duration_s × 1.1))`, preventing the software watchdog from firing during a legitimate large irrigation
- Updates `config/dashboard.yaml`: adds `valve_fsm_state` attribute row and reset button to all four zones

## Test plan

- [ ] 449 tests pass (`uv run pytest -q`)
- [ ] `test_register_services` asserts 6 registered services (including `reset_valve`)
- [ ] Verify in HA that zone sensor shows `valve_fsm_state: idle` under attributes
- [ ] Simulate MAINTENANCE: manually trigger 3× close failures, confirm `valve_in_maintenance: true`, press Reset Valve button, confirm returns to `idle`
- [ ] Verify large irrigation (>3600 s needed) does not trigger watchdog prematurely