### PR TITLE
feat(sensor): Duration and Last duration sensors per zone; fix flow meter icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ NeverDry is configured entirely through the UI — no YAML required.
 | Threshold | No | 20.0 | Mode A trigger [mm] |
 | Battery sensor | No | — | Valve battery sensor — mirrored in the zone device card |
 | Flow meter sensor | No | — | Flow meter entity — mirrored in the zone device card |
-| Moisture sensor | No | — | Soil moisture sensor — mirrored in the zone device card |
 
 ---
 
@@ -198,7 +197,7 @@ The ET model is a simplification of the FAO-56 standard and is **not a substitut
 
 ## Acknowledgments
 
-This project was developed with the assistance of [Claude](https://claude.ai) by [Anthropic](https://anthropic.com) — an AI assistant that contributed to architecture design, code implementation, scientific modeling, documentation, and testing.
+Developed by [drake69](https://github.com/drake69) with AI assistance ([Claude](https://claude.ai) by Anthropic).
 
 ---
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -248,6 +248,8 @@ def _create_entities(
         entities.append(ZoneLastIrrigatedSensor(zone_sensor, zone_device))
         entities.append(ZoneLastSourceSensor(zone_sensor, zone_device))
         entities.append(ZoneLastVolumeSensor(zone_sensor, zone_device))
+        entities.append(ZoneDurationSensor(zone_sensor, zone_device))
+        entities.append(ZoneLastDurationSensor(zone_sensor, zone_device))
         entities.append(ZoneKcSensor(zone_sensor, zone_device))
         # Diagnostic (config)
         entities.append(ZoneIrrigationModeSensor(zone_sensor, zone_device))
@@ -285,7 +287,7 @@ def _create_entities(
                     hass,
                     zone_conf[CONF_ZONE_FLOW_METER_SENSOR],
                     "Flow meter",
-                    "mdi:water-flow",
+                    "mdi:gauge",
                     f"linked_flow_{slug}",
                     zone_device,
                 )
@@ -1264,6 +1266,75 @@ class ZoneYearlyWaterSensor(SensorEntity):
     @property
     def native_value(self) -> float:
         return round(self._zone_sensor._yearly_water_delivered, 1)
+
+
+# ══════════════════════════════════════════════════════════
+#  ZoneDurationSensor / ZoneLastDurationSensor
+# ══════════════════════════════════════════════════════════
+
+
+class ZoneDurationSensor(SensorEntity):
+    """Planned irrigation duration for the next session [s]."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Duration"
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:timer"
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        zone_sensor: IrrigationZoneSensor,
+        device_info: DeviceInfo | None = None,
+    ) -> None:
+        self._zone_sensor = zone_sensor
+        slug = zone_sensor.zone_name.lower().replace(" ", "_")
+        self._attr_unique_id = f"duration_zone_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
+        zone_sensor._dryness.register_zone_listener(self._on_update)
+
+    def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> int:
+        return self._zone_sensor.duration_s
+
+
+class ZoneLastDurationSensor(SensorEntity):
+    """Actual duration of the last completed irrigation session [s]."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Last duration"
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:timer"
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        zone_sensor: IrrigationZoneSensor,
+        device_info: DeviceInfo | None = None,
+    ) -> None:
+        self._zone_sensor = zone_sensor
+        slug = zone_sensor.zone_name.lower().replace(" ", "_")
+        self._attr_unique_id = f"last_duration_zone_{slug}"
+        if device_info:
+            self._attr_device_info = device_info
+        zone_sensor._dryness.register_zone_listener(self._on_update)
+
+    def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._zone_sensor._last_irrigated:
+            return None
+        return self._zone_sensor._last_session_duration_s
 
 
 # ══════════════════════════════════════════════════════════

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -248,6 +248,7 @@ def _create_entities(
         entities.append(ZoneLastIrrigatedSensor(zone_sensor, zone_device))
         entities.append(ZoneLastSourceSensor(zone_sensor, zone_device))
         entities.append(ZoneLastVolumeSensor(zone_sensor, zone_device))
+        entities.append(ZoneFlowRateSensor(zone_sensor, zone_device))
         entities.append(ZoneDurationSensor(zone_sensor, zone_device))
         entities.append(ZoneLastDurationSensor(zone_sensor, zone_device))
         entities.append(ZoneKcSensor(zone_sensor, zone_device))
@@ -1402,6 +1403,25 @@ class ZoneLastSourceSensor(_ZoneTextSensor):
     @property
     def native_value(self) -> str | None:
         return self._zone_sensor._last_irrigation_source
+
+
+class ZoneFlowRateSensor(_ZoneTextSensor):
+    """Configured flow rate for this zone [L/min]."""
+
+    _attr_native_unit_of_measurement = "L/min"
+
+    def __init__(self, zone_sensor, device_info=None):
+        super().__init__(
+            zone_sensor,
+            "Flow rate",
+            "mdi:gauge",
+            "flow_rate_zone",
+            device_info,
+        )
+
+    @property
+    def native_value(self) -> float:
+        return round(self._zone_sensor._flow_rate, 2)
 
 
 class ZoneLastVolumeSensor(_ZoneTextSensor):

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -400,7 +400,7 @@
         <p style="font-size: 0.9em; color: #555;">NeverDry is a hobby project for residential use. It is not certified for agricultural, commercial, or safety-critical applications. The ET model is a simplification of the FAO-56 standard and is not a substitute for professional agronomic advice. Always monitor your irrigation system. The authors accept no liability for any damage or loss.</p>
 
         <h2 style="text-align: center; margin-top: 2em;">Acknowledgments</h2>
-        <p style="font-size: 0.9em; color: #555;">Developed with the assistance of <a href="https://claude.ai">Claude</a> by <a href="https://anthropic.com">Anthropic</a>.</p>
+        <p style="font-size: 0.9em; color: #555;">Developed by <a href="https://github.com/drake69">drake69</a> with AI assistance (<a href="https://claude.ai">Claude</a> by Anthropic).</p>
 
         <h2 style="text-align: center; margin-top: 2em;">Scientific References</h2>
         <ul style="font-size: 0.85em; color: #555; line-height: 1.8;">

--- a/tests/test_zone_duration_sensors.py
+++ b/tests/test_zone_duration_sensors.py
@@ -1,0 +1,179 @@
+"""Tests for ZoneDurationSensor and ZoneLastDurationSensor."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_NAME,
+    CONF_ZONE_THRESHOLD,
+    CONF_ZONE_VALVE,
+)
+from never_dry.sensor import IrrigationZoneSensor, ZoneDurationSensor, ZoneLastDurationSensor
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config = MagicMock()
+    hass.config.latitude = 45.0
+    return hass
+
+
+def _make_zone(di_sensor, name="Orto", flow_rate=8.0, area=20.0, efficiency=0.90):
+    zone_config = {
+        CONF_ZONE_NAME: name,
+        CONF_ZONE_VALVE: "switch.valve",
+        CONF_ZONE_AREA: area,
+        CONF_ZONE_EFFICIENCY: efficiency,
+        CONF_ZONE_FLOW_RATE: flow_rate,
+        CONF_ZONE_THRESHOLD: 15.0,
+    }
+    return IrrigationZoneSensor(_make_hass(), zone_config, di_sensor)
+
+
+class TestZoneDurationSensor:
+    def test_name(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        assert sensor._attr_name == "Duration"
+
+    def test_unit(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        assert sensor._attr_native_unit_of_measurement == "s"
+
+    def test_icon(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        assert sensor._attr_icon == "mdi:timer"
+
+    def test_unique_id(self, di_sensor):
+        zone = _make_zone(di_sensor, name="Giardino Melino")
+        sensor = ZoneDurationSensor(zone)
+        assert sensor._attr_unique_id == "duration_zone_giardino_melino"
+
+    def test_device_info_assigned(self, di_sensor):
+        from homeassistant.helpers.device_registry import DeviceInfo
+
+        zone = _make_zone(di_sensor)
+        device = DeviceInfo(identifiers={("never_dry", "orto")})
+        sensor = ZoneDurationSensor(zone, device)
+        assert sensor._attr_device_info is device
+
+    def test_initial_value_zero_when_no_deficit(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        assert sensor.native_value == 0
+
+    def test_value_with_deficit(self, di_sensor):
+        # volume = deficit * area / efficiency = 10 * 20 / 0.90 ≈ 222.2 L
+        # duration = round(222.2 / 8 * 60) = 1667 s
+        zone = _make_zone(di_sensor, flow_rate=8.0, area=20.0, efficiency=0.90)
+        zone._zone_deficit = 10.0
+        sensor = ZoneDurationSensor(zone)
+        assert sensor.native_value == pytest.approx(1667, abs=2)
+
+    def test_value_tracks_deficit_changes(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        zone._zone_deficit = 5.0
+        v1 = sensor.native_value
+        zone._zone_deficit = 10.0
+        v2 = sensor.native_value
+        assert v2 > v1
+
+    def test_registers_dryness_listener(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        initial_count = len(di_sensor._zone_listeners)
+        ZoneDurationSensor(zone)
+        assert len(di_sensor._zone_listeners) == initial_count + 1
+
+    def test_on_update_writes_state_when_hass_set(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+        sensor._on_update(1.0, 0.5, 0.0)
+        sensor.async_write_ha_state.assert_called_once()
+
+    def test_on_update_no_write_without_hass(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneDurationSensor(zone)
+        sensor.async_write_ha_state = MagicMock()
+        sensor._on_update(1.0, 0.5, 0.0)
+        sensor.async_write_ha_state.assert_not_called()
+
+
+class TestZoneLastDurationSensor:
+    def test_name(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor._attr_name == "Last duration"
+
+    def test_unit(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor._attr_native_unit_of_measurement == "s"
+
+    def test_icon(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor._attr_icon == "mdi:timer"
+
+    def test_unique_id(self, di_sensor):
+        zone = _make_zone(di_sensor, name="Giardino Pino")
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor._attr_unique_id == "last_duration_zone_giardino_pino"
+
+    def test_device_info_assigned(self, di_sensor):
+        from homeassistant.helpers.device_registry import DeviceInfo
+
+        zone = _make_zone(di_sensor)
+        device = DeviceInfo(identifiers={("never_dry", "orto")})
+        sensor = ZoneLastDurationSensor(zone, device)
+        assert sensor._attr_device_info is device
+
+    def test_none_before_first_irrigation(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor.native_value is None
+
+    def test_value_after_irrigation(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        zone._last_irrigated = datetime.now()
+        zone._last_session_duration_s = 270
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor.native_value == 270
+
+    def test_value_tracks_zone(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        zone._last_irrigated = datetime.now()
+        zone._last_session_duration_s = 180
+        sensor = ZoneLastDurationSensor(zone)
+        assert sensor.native_value == 180
+        zone._last_session_duration_s = 360
+        assert sensor.native_value == 360
+
+    def test_registers_dryness_listener(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        initial_count = len(di_sensor._zone_listeners)
+        ZoneLastDurationSensor(zone)
+        assert len(di_sensor._zone_listeners) == initial_count + 1
+
+    def test_on_update_writes_state_when_hass_set(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        sensor.hass = MagicMock()
+        sensor.async_write_ha_state = MagicMock()
+        sensor._on_update(1.0, 0.5, 0.0)
+        sensor.async_write_ha_state.assert_called_once()
+
+    def test_on_update_no_write_without_hass(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneLastDurationSensor(zone)
+        sensor.async_write_ha_state = MagicMock()
+        sensor._on_update(1.0, 0.5, 0.0)
+        sensor.async_write_ha_state.assert_not_called()

--- a/tests/test_zone_duration_sensors.py
+++ b/tests/test_zone_duration_sensors.py
@@ -1,4 +1,4 @@
-"""Tests for ZoneDurationSensor and ZoneLastDurationSensor."""
+"""Tests for ZoneFlowRateSensor, ZoneDurationSensor and ZoneLastDurationSensor."""
 
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -12,7 +12,12 @@ from never_dry.const import (
     CONF_ZONE_THRESHOLD,
     CONF_ZONE_VALVE,
 )
-from never_dry.sensor import IrrigationZoneSensor, ZoneDurationSensor, ZoneLastDurationSensor
+from never_dry.sensor import (
+    IrrigationZoneSensor,
+    ZoneDurationSensor,
+    ZoneFlowRateSensor,
+    ZoneLastDurationSensor,
+)
 
 
 def _make_hass():
@@ -32,6 +37,38 @@ def _make_zone(di_sensor, name="Orto", flow_rate=8.0, area=20.0, efficiency=0.90
         CONF_ZONE_THRESHOLD: 15.0,
     }
     return IrrigationZoneSensor(_make_hass(), zone_config, di_sensor)
+
+
+class TestZoneFlowRateSensor:
+    def test_name(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor._attr_name == "Flow rate"
+
+    def test_unit(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor._attr_native_unit_of_measurement == "L/min"
+
+    def test_icon(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor._attr_icon == "mdi:gauge"
+
+    def test_unique_id(self, di_sensor):
+        zone = _make_zone(di_sensor, name="Giardino Orto")
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor._attr_unique_id == "flow_rate_zone_giardino_orto"
+
+    def test_value(self, di_sensor):
+        zone = _make_zone(di_sensor, flow_rate=3.33)
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor.native_value == pytest.approx(3.33, abs=0.01)
+
+    def test_value_rounded(self, di_sensor):
+        zone = _make_zone(di_sensor, flow_rate=8.0)
+        sensor = ZoneFlowRateSensor(zone)
+        assert sensor.native_value == 8.0
 
 
 class TestZoneDurationSensor:


### PR DESCRIPTION
## Summary

- Add `ZoneDurationSensor`: planned irrigation duration for the next session [s], updates in real time on every ET cycle
- Add `ZoneLastDurationSensor`: actual duration of the last completed irrigation session [s]; shows `unknown` before the first irrigation
- Fix `ZoneLinkedSensor` flow meter icon: `mdi:water-flow` → `mdi:gauge` (`mdi:water-flow` is not in HA's bundled MDI version)
- Fix README/gh-pages acknowledgment wording (credit to author, not AI)
- Remove non-existent moisture sensor field from README zone config table

## Test plan

- [ ] Restart HA and verify `Duration` and `Last duration` appear in zone device card
- [ ] Confirm `Last duration` shows `unknown` before first irrigation, then correct seconds after
- [ ] Confirm `Duration` updates as deficit changes (e.g. after rain or ET cycle)
- [ ] Confirm flow meter icon now renders correctly in zone device card
- [ ] 474 tests pass