### PR TITLE
docs: add star CTA to README and gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5)](https://github.com/hacs/integration)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
+[![GitHub stars](https://img.shields.io/github/stars/drake69/NeverDry?style=social)](https://github.com/drake69/NeverDry/stargazers)
+
+If NeverDry is useful to you, **[leave a star](https://github.com/drake69/NeverDry/stargazers)** ⭐ — it helps others find the project.
 
 ---
 

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -264,6 +264,9 @@
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repository</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentation</a>
+    <div style="margin-top: 1.2em; font-size: 0.95em; opacity: 0.85;">
+        If NeverDry is useful to you, <a href="https://github.com/drake69/NeverDry/stargazers" style="color: white; font-weight: 600;">leave a ⭐ on GitHub</a> — it helps others find the project.
+    </div>
 </section>
 
 <!-- Features -->


### PR DESCRIPTION
## Summary

- Add GitHub star badge + CTA line below badges in README
- Add star CTA in gh-pages hero section, below the main buttons

Light touch — one line of text with a link, no popup or banner.