### PR TITLE
fix: controller robustness — reload lifecycle, valve safety, spurious events

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ If a valve doesn't respond after three attempts, NeverDry blocks that zone and s
 
 ## Sensors and entities
 
-| Entity | Unit | Description |
-|--------|------|-------------|
+| Entity | Native unit | Description |
+|--------|-------------|-------------|
 | `sensor.et_hourly_estimate` | mm/h | Instantaneous evapotranspiration rate |
 | `sensor.never_dry` | mm | Reference soil water deficit (Kc=1.0) |
 | `sensor.<zone>_volume` | L | Per-zone volume delivered; attributes: `duration_s`, `deficit_mm`, `kc`, `plant_family`, `irrigating`, ... |
@@ -56,6 +56,8 @@ If a valve doesn't respond after three attempts, NeverDry blocks that zone and s
 | `sensor.<zone>_battery` | % | Mirror of the valve battery sensor inside the zone device card |
 | `sensor.<zone>_flow_meter` | L/min | Mirror of the flow meter inside the zone device card |
 | `button.<zone>_reset_maintenance` | — | Unlock a valve that NeverDry blocked after repeated failures |
+
+All sensors that carry a physical unit declare the proper HA `device_class` (e.g. `precipitation`, `volume_storage`, `volume_flow_rate`). Home Assistant automatically converts the displayed unit to your system preference — go to **Settings → System → General → Unit system** to switch between metric and imperial. Deficit values appear in mm or inches; volumes in litres or gallons; flow rate in L/min or gal/min; ET rate in mm/h or in/h.
 
 ## Services
 
@@ -66,6 +68,7 @@ If a valve doesn't respond after three attempts, NeverDry blocks that zone and s
 | `never_dry.stop` | Emergency stop — close all valves immediately |
 | `never_dry.reset` | Reset all zone deficits to zero |
 | `never_dry.reset_valve` | Unlock a valve blocked by NeverDry after repeated close failures |
+| `never_dry.set_deficit` | Set the deficit of one zone (or all zones) to an arbitrary mm value — useful for testing and manual calibration |
 
 ## Plant Families
 

--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -7,8 +7,10 @@ water balance model.  Directly controls irrigation valves.
 Supports both YAML configuration and UI-based config flow.
 """
 
+import json
 import logging
 import logging.handlers
+import pathlib
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +23,9 @@ _LOGGER = logging.getLogger(__name__)
 
 _ACTIVITY_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
 _ACTIVITY_LOG_BACKUP_COUNT = 2
+_INTEGRATION_VERSION: str = json.loads((pathlib.Path(__file__).parent / "manifest.json").read_text(encoding="utf-8"))[
+    "version"
+]
 
 
 def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
@@ -46,9 +51,12 @@ def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
             datefmt="%Y-%m-%d %H:%M:%S",
         )
     )
-    logging.getLogger("custom_components.never_dry").addHandler(handler)
+    nd_logger = logging.getLogger("custom_components.never_dry")
+    nd_logger.setLevel(logging.DEBUG)
+    nd_logger.addHandler(handler)
     _LOGGER.info(
-        "NeverDry activity log -> %s (%.0f MB x %d)",
+        "NeverDry %s — activity log -> %s (%.0f MB x %d)",
+        _INTEGRATION_VERSION,
         log_path,
         _ACTIVITY_LOG_MAX_BYTES / 1024 / 1024,
         _ACTIVITY_LOG_BACKUP_COUNT + 1,
@@ -58,7 +66,9 @@ def _setup_file_logger(hass: HomeAssistant) -> logging.Handler:
 
 def _teardown_file_logger(handler: logging.Handler) -> None:
     """Remove the rotating file handler from the never_dry logger and close it."""
-    logging.getLogger("custom_components.never_dry").removeHandler(handler)
+    nd_logger = logging.getLogger("custom_components.never_dry")
+    nd_logger.removeHandler(handler)
+    nd_logger.setLevel(logging.NOTSET)
     handler.close()
 
 
@@ -108,6 +118,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the integration when config entry data changes (e.g. zone added)."""
+    _LOGGER.info("Config entry data changed — reloading integration")
     await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -124,6 +135,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    controller = hass.data.get(DOMAIN, {}).pop(f"_controller_{entry.entry_id}", None)
+    if controller is not None:
+        await controller.async_stop()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         handler = hass.data[DOMAIN].pop(f"_log_handler_{entry.entry_id}", None)

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -531,7 +531,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ): selector.TextSelector(),
                 vol.Optional(
                     CONF_ZONE_VALVE,
-                    default=_d(CONF_ZONE_VALVE),
+                    description={"suggested_value": _d(CONF_ZONE_VALVE, None)},
                 ): selector.EntitySelector(ent_sw),
                 vol.Optional(
                     CONF_ZONE_DELIVERY_MODE,
@@ -608,11 +608,11 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_ZONE_FLOW_METER_SENSOR,
-                    default=_d(CONF_ZONE_FLOW_METER_SENSOR),
+                    description={"suggested_value": _d(CONF_ZONE_FLOW_METER_SENSOR, None)},
                 ): selector.EntitySelector(ent_sn),
                 vol.Optional(
                     CONF_ZONE_VOLUME_ENTITY,
-                    default=_d(CONF_ZONE_VOLUME_ENTITY),
+                    description={"suggested_value": _d(CONF_ZONE_VOLUME_ENTITY, None)},
                 ): selector.EntitySelector(ent_nr),
                 vol.Optional(
                     CONF_ZONE_DELIVERY_TIMEOUT,

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -8,6 +8,7 @@ Provides a multi-step UI setup:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import voluptuous as vol
@@ -66,6 +67,8 @@ from .const import (
     SYSTEM_TYPE_MICRO_SPRINKLER,
     SYSTEM_TYPE_SPRINKLER,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 STEP_SENSORS_SCHEMA = vol.Schema(
     {
@@ -352,7 +355,10 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         """Edit ET model parameters."""
         if user_input is not None:
             new_data = {**self._config_entry.data, **user_input}
-            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            if new_data != dict(self._config_entry.data):
+                changed = [k for k in new_data if new_data[k] != self._config_entry.data.get(k)]
+                _LOGGER.debug("Config updated via model_params — changed keys: %s", changed)
+                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
             return self.async_create_entry(data={})
 
         current = self._config_entry.data
@@ -416,7 +422,9 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 )
             zones.append(user_input)
             new_data[CONF_ZONES] = zones
-            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            if new_data != dict(self._config_entry.data):
+                _LOGGER.debug("Config updated via add_zone — zone added: %s", user_input.get("zone_name"))
+                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
             return self.async_create_entry(data={})
 
         return self.async_show_form(
@@ -466,10 +474,12 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
             new_zones.append(user_input)
             new_data[CONF_ZONES] = new_zones
-            self.hass.config_entries.async_update_entry(
-                self._config_entry,
-                data=new_data,
-            )
+            if new_data != dict(self._config_entry.data):
+                _LOGGER.debug("Config updated via edit_zone — zone edited: %s", self._edit_zone_name)
+                self.hass.config_entries.async_update_entry(
+                    self._config_entry,
+                    data=new_data,
+                )
             return self.async_create_entry(data={})
 
         # Helper to get current value or UNDEFINED
@@ -684,7 +694,9 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             name_to_remove = user_input["zone_to_remove"]
             new_data = dict(self._config_entry.data)
             new_data[CONF_ZONES] = [z for z in zones if z[CONF_ZONE_NAME] != name_to_remove]
-            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            if new_data != dict(self._config_entry.data):
+                _LOGGER.debug("Config updated via remove_zone — zone removed: %s", name_to_remove)
+                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
             return self.async_create_entry(data={})
 
         return self.async_show_form(

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -104,8 +104,10 @@ SERVICE_IRRIGATE_ALL = "irrigate_all"
 SERVICE_STOP = "stop"
 SERVICE_MARK_IRRIGATED = "mark_irrigated"
 SERVICE_RESET_VALVE = "reset_valve"
+SERVICE_SET_DEFICIT = "set_deficit"
 
 ATTR_ZONE_NAME = "zone_name"
+ATTR_DEFICIT_MM = "deficit_mm"
 
 # ── Events ──────────────────────────────────────────────
 EVENT_IRRIGATION_COMPLETE = "never_dry_irrigation_complete"

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -93,6 +93,7 @@ class IrrigationController:
         self._irrigation_task: asyncio.Task | None = None
         self._monitoring_mode = not any(zs.valve for zs in zone_sensors)
         self._unsub_monitor = None
+        self._unsubs: list = []
         self._last_service_call: dict[str, float] = {}
         self._current_source: str | None = None
         # Manual valve tracking: valve_entity_id → flow meter reading at valve open
@@ -148,20 +149,22 @@ class IrrigationController:
         # Monitor valve state changes to detect manual irrigation
         valve_entities = [v for v in self._valve_to_zone if v]
         if valve_entities:
-            async_track_state_change_event(self._hass, valve_entities, self._on_valve_state_change)
+            self._unsubs.append(async_track_state_change_event(self._hass, valve_entities, self._on_valve_state_change))
 
         # Monitor battery sensors for low-battery alerts
         battery_entities = [b for b in self._battery_to_zone if b]
         if battery_entities:
-            async_track_state_change_event(self._hass, battery_entities, self._on_battery_change)
+            self._unsubs.append(async_track_state_change_event(self._hass, battery_entities, self._on_battery_change))
 
         # Periodic deficit anomaly check (all modes, every 6h)
         from datetime import timedelta
 
-        async_track_time_interval(
-            self._hass,
-            self._check_deficit_anomaly,
-            timedelta(hours=6),
+        self._unsubs.append(
+            async_track_time_interval(
+                self._hass,
+                self._check_deficit_anomaly,
+                timedelta(hours=6),
+            )
         )
 
         # Set up automatic irrigation per zone based on mode
@@ -174,12 +177,14 @@ class IrrigationController:
                 try:
                     parts = zs.irrigation_time.split(":")
                     hour, minute = int(parts[0]), int(parts[1])
-                    async_track_time_change(
-                        self._hass,
-                        self._make_scheduled_handler(zs.zone_name),
-                        hour=hour,
-                        minute=minute,
-                        second=0,
+                    self._unsubs.append(
+                        async_track_time_change(
+                            self._hass,
+                            self._make_scheduled_handler(zs.zone_name),
+                            hour=hour,
+                            minute=minute,
+                            second=0,
+                        )
                     )
                     _LOGGER.info(
                         "Mode B (scheduled): zone='%s' at %s",
@@ -215,6 +220,7 @@ class IrrigationController:
                 self._check_and_notify,
                 timedelta(hours=6),
             )
+            self._unsubs.append(self._unsub_monitor)
 
     # ── Scheduled irrigation ────────────────────────────────
 
@@ -377,6 +383,9 @@ class IrrigationController:
         if task is not None and not task.done():
             with contextlib.suppress(Exception):
                 await task
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
 
     async def _handle_stop(self, call: ServiceCall) -> None:
         """Emergency stop: close every configured valve concurrently."""

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -13,6 +13,7 @@ An emergency stop service closes all valves immediately.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from datetime import datetime
@@ -101,6 +102,9 @@ class IrrigationController:
         self._manual_session_meta: dict[str, tuple[datetime, float]] = {}
         # Per-valve safety-close watchdog for external (non-commanded) opens
         self._manual_safety_tasks: dict[str, asyncio.Task] = {}
+        # Valves currently being closed by the controller — suppresses spurious
+        # "manual irrigation detected" events while operator.close() is in flight.
+        self._controller_closing: set[str] = set()
         # Reverse map: valve_entity_id → zone_name
         self._valve_to_zone: dict[str, str] = {zs.valve: zs.zone_name for zs in zone_sensors if zs.valve}
         # Battery sensor → zone_name map
@@ -358,6 +362,22 @@ class IrrigationController:
         self._current_source = "button"
         self._irrigation_task = self._hass.async_create_task(self._irrigate_zones(list(self._zones.keys())))
 
+    async def async_stop(self) -> None:
+        """Stop any running irrigation and wait for the task to settle.
+
+        Called during entry unload so the old controller finishes cleanly
+        before the new one starts — prevents duplicate deficit updates.
+
+        Sets _stop_requested so the polling loop exits within ~1 s, then
+        awaits the task so the finally block can close the valve and settle
+        the deficit before the new controller takes over.
+        """
+        self._stop_requested = True
+        task = self._irrigation_task
+        if task is not None and not task.done():
+            with contextlib.suppress(Exception):
+                await task
+
     async def _handle_stop(self, call: ServiceCall) -> None:
         """Emergency stop: close every configured valve concurrently."""
         _LOGGER.info("Emergency stop requested")
@@ -480,10 +500,12 @@ class IrrigationController:
                     continue
 
                 _LOGGER.info(
-                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL, deficit=%.1fmm, timeout=%ds",
+                    "Starting irrigation: zone='%s', mode='%s', volume=%.1fL,"
+                    " est_duration=%ds, deficit=%.1fmm, timeout=%ds",
                     zone_name,
                     zone.delivery_mode,
                     zone.volume_liters,
+                    zone.duration_s,
                     zone._zone_deficit,
                     zone.delivery_timeout,
                 )
@@ -635,7 +657,7 @@ class IrrigationController:
         zone.set_irrigating(True)
         zone.async_write_ha_state()
 
-        elapsed = await self._wait_with_stop_check(duration)
+        elapsed = await self._wait_with_stop_check(duration, valve_entity=zone.valve)
 
         await self._close_valve(zone.valve)
         zone.set_irrigating(False)
@@ -958,15 +980,25 @@ class IrrigationController:
             context={"entity_id": entity_id, "reason": reason},
         )
 
-    async def _wait_with_stop_check(self, duration_s: int) -> int:
+    async def _wait_with_stop_check(self, duration_s: int, valve_entity: str | None = None) -> int:
         """Wait for duration, checking for stop requests every second.
 
         Returns the number of seconds actually elapsed, which may be less
-        than ``duration_s`` when a stop is requested mid-wait.
+        than ``duration_s`` when a stop is requested or the valve is closed
+        externally.
         """
         for elapsed in range(duration_s):
             if self._stop_requested:
                 return elapsed
+            if valve_entity is not None:
+                state = self._hass.states.get(valve_entity)
+                if state is not None and state.state == "off":
+                    _LOGGER.info(
+                        "Valve '%s' closed externally after %ds — aborting estimated_flow wait",
+                        valve_entity,
+                        elapsed,
+                    )
+                    return elapsed
             await asyncio.sleep(1)
         return duration_s
 
@@ -1004,7 +1036,11 @@ class IrrigationController:
             if self._active_valve == entity_id:
                 self._active_valve = None
             return True
-        result = await operator.close()
+        self._controller_closing.add(entity_id)
+        try:
+            result = await operator.close()
+        finally:
+            self._controller_closing.discard(entity_id)
         if self._active_valve == entity_id:
             self._active_valve = None
         if result.status != OperationStatus.OK:
@@ -1099,6 +1135,8 @@ class IrrigationController:
             )
 
         elif old_state.state == "on" and new_state.state == "off":
+            if entity_id in self._controller_closing:
+                return  # NeverDry-initiated close — not a manual event
             # Cancel the safety watchdog: the user (or the watchdog itself)
             # already closed the valve.
             task = self._manual_safety_tasks.pop(entity_id, None)

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.event import (
 
 from .const import (
     ANOMALY_DEFICIT_MULTIPLIER,
+    ATTR_DEFICIT_MM,
     ATTR_ZONE_NAME,
     DEFAULT_BATTERY_LOW_THRESHOLD,
     DEFAULT_INTER_ZONE_DELAY,
@@ -43,6 +44,7 @@ from .const import (
     SERVICE_MARK_IRRIGATED,
     SERVICE_RESET,
     SERVICE_RESET_VALVE,
+    SERVICE_SET_DEFICIT,
     SERVICE_STOP,
 )
 from .valve_fsm import ValveState
@@ -145,6 +147,7 @@ class IrrigationController:
         self._hass.services.async_register(DOMAIN, SERVICE_STOP, self._handle_stop)
         self._hass.services.async_register(DOMAIN, SERVICE_MARK_IRRIGATED, self._handle_mark_irrigated)
         self._hass.services.async_register(DOMAIN, SERVICE_RESET_VALVE, self._handle_reset_valve)
+        self._hass.services.async_register(DOMAIN, SERVICE_SET_DEFICIT, self._handle_set_deficit)
 
         # Monitor valve state changes to detect manual irrigation
         valve_entities = [v for v in self._valve_to_zone if v]
@@ -336,6 +339,25 @@ class IrrigationController:
         for zs in self._zones.values():
             zs.reset_deficit("service_reset")
             zs.async_write_ha_state()
+
+    async def _handle_set_deficit(self, call: ServiceCall) -> None:
+        """Set deficit to a specific value [mm] — for testing and manual correction."""
+        deficit_mm = float(call.data.get(ATTR_DEFICIT_MM, 0.0))
+        zone_name = call.data.get(ATTR_ZONE_NAME)
+        if zone_name:
+            zone = self._zones.get(zone_name)
+            if zone is None:
+                _LOGGER.error("set_deficit: zone '%s' not found. Available: %s", zone_name, list(self._zones.keys()))
+                return
+            zone.set_deficit_mm(deficit_mm)
+            zone.async_write_ha_state()
+        else:
+            self._dryness.set_deficit_mm(deficit_mm)
+            self._dryness.async_write_ha_state()
+            for zs in self._zones.values():
+                zs.set_deficit_mm(deficit_mm)
+                zs.async_write_ha_state()
+        _LOGGER.info("set_deficit: zone=%s deficit=%.2f mm", zone_name or "all", deficit_mm)
 
     async def _handle_irrigate_zone(self, call: ServiceCall) -> None:
         """Irrigate a single zone by name."""

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -18,10 +18,19 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfArea,
+    UnitOfLength,
+    UnitOfTime,
+    UnitOfVolume,
+    UnitOfVolumeFlowRate,
+    UnitOfVolumetricFlux,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -441,7 +450,8 @@ class ETSensor(SensorEntity):
     _attr_has_entity_name = True
     _attr_name = "ET Hourly Estimate"
     _attr_unique_id = "et_hourly_estimate"
-    _attr_native_unit_of_measurement = "mm/h"
+    _attr_device_class = SensorDeviceClass.PRECIPITATION_INTENSITY
+    _attr_native_unit_of_measurement = UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:sun-thermometer"
 
@@ -495,7 +505,8 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
     _attr_has_entity_name = True
     _attr_name = "Dryness Index"
     _attr_unique_id = "never_dry"
-    _attr_native_unit_of_measurement = "mm"
+    _attr_device_class = SensorDeviceClass.PRECIPITATION
+    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-percent-alert"
 
@@ -778,6 +789,11 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         self._deficit = 0.0
         self._last_update = datetime.now()
 
+    def set_deficit_mm(self, value: float) -> None:
+        """Set deficit to an arbitrary value [mm] — intended for testing/debugging."""
+        self._deficit = max(0.0, min(float(value), self._d_max))
+        self._last_update = datetime.now()
+
     @property
     def native_value(self) -> float:
         return round(self._deficit, 2)
@@ -799,8 +815,9 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     """
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "L"
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_icon = "mdi:sprinkler-variant"
 
     def __init__(
@@ -1020,6 +1037,10 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             self._session_water_delivered = 0.0
         self._irrigating = state
 
+    def set_deficit_mm(self, value: float) -> None:
+        """Set zone deficit to an arbitrary value [mm] — intended for testing/debugging."""
+        self._zone_deficit = max(0.0, min(float(value), self._d_max))
+
     def reset_deficit(self, source: str = "unknown") -> None:
         """Reset this zone's deficit to zero (called after irrigation)."""
         self._last_irrigation_source = source
@@ -1115,8 +1136,9 @@ class ZoneDeficitSensor(SensorEntity):
     """
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.PRECIPITATION
     _attr_name = "Deficit"
-    _attr_native_unit_of_measurement = "mm"
+    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-percent-alert"
 
@@ -1165,8 +1187,9 @@ class ZoneRainSensor(SensorEntity):
     """Cumulative rain received by this zone [mm]."""
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.PRECIPITATION
     _attr_name = "Rain"
-    _attr_native_unit_of_measurement = "mm"
+    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:weather-rainy"
 
@@ -1204,8 +1227,9 @@ class ZoneSessionWaterSensor(SensorEntity):
     """
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
     _attr_name = "Session water"
-    _attr_native_unit_of_measurement = "L"
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-pump"
 
@@ -1243,8 +1267,9 @@ class ZoneYearlyWaterSensor(SensorEntity):
     """
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
     _attr_name = "Yearly water"
-    _attr_native_unit_of_measurement = "L"
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:calendar-clock"
 
@@ -1279,8 +1304,9 @@ class ZoneDurationSensor(SensorEntity):
     """Planned irrigation duration for the next session [s]."""
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.DURATION
     _attr_name = "Duration"
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:timer"
     _attr_should_poll = False
@@ -1310,8 +1336,9 @@ class ZoneLastDurationSensor(SensorEntity):
     """Actual duration of the last completed irrigation session [s]."""
 
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.DURATION
     _attr_name = "Last duration"
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:timer"
     _attr_should_poll = False
@@ -1409,7 +1436,8 @@ class ZoneLastSourceSensor(_ZoneTextSensor):
 class ZoneFlowRateSensor(_ZoneTextSensor):
     """Configured flow rate for this zone [L/min]."""
 
-    _attr_native_unit_of_measurement = "L/min"
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
+    _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.LITERS_PER_MINUTE
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(
@@ -1428,7 +1456,8 @@ class ZoneFlowRateSensor(_ZoneTextSensor):
 class ZoneLastVolumeSensor(_ZoneTextSensor):
     """Volume delivered in the last irrigation."""
 
-    _attr_native_unit_of_measurement = "L"
+    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(
@@ -1483,7 +1512,8 @@ class ZoneIrrigationTimeSensor(_ZoneTextSensor):
 class ZoneThresholdSensor(_ZoneTextSensor):
     """Configured irrigation threshold."""
 
-    _attr_native_unit_of_measurement = "mm"
+    _attr_device_class = SensorDeviceClass.PRECIPITATION
+    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(
@@ -1503,7 +1533,8 @@ class ZoneThresholdSensor(_ZoneTextSensor):
 class ZoneAreaSensor(_ZoneTextSensor):
     """Configured zone area."""
 
-    _attr_native_unit_of_measurement = "m²"
+    _attr_device_class = SensorDeviceClass.AREA
+    _attr_native_unit_of_measurement = UnitOfArea.SQUARE_METERS
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -423,6 +423,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
     controller = _setup_controller(hass, config, di_sensor, zone_sensors)
     hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][f"_controller_{entry.entry_id}"] = controller
     hass.data[DOMAIN][f"_operators_{entry.entry_id}"] = controller.valve_operators
 
 

--- a/custom_components/never_dry/services.yaml
+++ b/custom_components/never_dry/services.yaml
@@ -45,6 +45,32 @@ mark_irrigated:
       selector:
         text:
 
+set_deficit:
+  name: Set deficit
+  description: >
+    Set the soil water deficit to a specific value in mm.
+    Intended for testing, debugging, and manual correction of the water balance.
+    If zone_name is omitted, all zones and the reference sensor are updated.
+  fields:
+    deficit_mm:
+      name: Deficit (mm)
+      description: Target deficit value in mm. Must be >= 0.
+      required: true
+      example: 5.0
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 0.1
+          unit_of_measurement: mm
+    zone_name:
+      name: Zone name
+      description: The zone to update. Leave empty to update all zones.
+      required: false
+      example: "Orto"
+      selector:
+        text:
+
 reset_valve:
   name: Reset valve (unlock maintenance)
   description: >

--- a/custom_components/never_dry/valve_operator.py
+++ b/custom_components/never_dry/valve_operator.py
@@ -387,32 +387,28 @@ class ValveOperator:
     # ── Notifier bridging ────────────────────────────────────────────
 
     async def _notify_failure(self, kind: FailureKind) -> None:
-        """Surface a FailureKind via the notifier (or log if none configured)."""
+        """Surface a FailureKind via the notifier (or log if none configured).
+
+        CLOSE_LEAK is intentionally suppressed here: close() will attempt
+        recovery first, and _escalate_stuck_open() sends CRITICAL only if
+        recovery fails.  Sending CRITICAL before recovery is known causes
+        spurious "Valve stuck open" alerts.
+        """
         _LOGGER.error("Valve '%s' failure: %s", self._zone_name, kind.name)
         if self._notifier is None:
             return
-        severity = (
-            Severity.CRITICAL
-            if kind in (FailureKind.CLOSE_LEAK, FailureKind.CLOSE_VERIFICATION_FAILED)
-            else Severity.WARNING
-        )
         if kind == FailureKind.CLOSE_LEAK:
-            await self._notifier.notify(
-                self._zone_name,
-                NotificationKind.STUCK_OPEN,
-                severity,
-                context={"flow": "still positive after close command"},
-            )
-        else:
-            await self._notifier.notify(
-                self._zone_name,
-                NotificationKind.COMMAND_FAILED,
-                severity,
-                context={
-                    "operation": _OPERATION_FOR_FAILURE[kind],
-                    "error_detail": kind.value,
-                },
-            )
+            return
+        severity = Severity.CRITICAL if kind == FailureKind.CLOSE_VERIFICATION_FAILED else Severity.WARNING
+        await self._notifier.notify(
+            self._zone_name,
+            NotificationKind.COMMAND_FAILED,
+            severity,
+            context={
+                "operation": _OPERATION_FOR_FAILURE[kind],
+                "error_detail": kind.value,
+            },
+        )
 
     async def _attempt_leak_recovery(self) -> bool:
         """Last-resort recovery from ``CLOSE_LEAK``: re-issue turn_off, re-check.

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -324,6 +324,52 @@ python3 -m pytest tests/ -v
 
 Async controller tests require `pytest-asyncio` (skipped if not installed).
 
+### 7.1 E2E smoke tests (pre-release, against live HA)
+
+One-shot integration tests that hit a real Home Assistant instance via the REST API.
+Run them manually before cutting a release — they are **not** executed in CI.
+
+**Setup:**
+
+```bash
+cd sw_artifacts
+cp tests/e2e/.env.example tests/e2e/.env
+# edit tests/e2e/.env with your values
+```
+
+`.env` fields:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `HA_URL` | `http://homeassistant.local:8123` | Base URL of your HA instance |
+| `HA_TOKEN` | `eyJ0eXAi...` | Long-lived access token (HA → Profile → Security) |
+| `ZONE_NAME` | `Giardino_Ortensia` | Exact zone name as configured in NeverDry |
+
+The `.env` file is git-ignored and never committed.
+
+**Run:**
+
+```bash
+# All tests except valve control (safe to run anytime)
+python tests/e2e/smoke.py --no-valves
+
+# Full suite including irrigation cycle (opens real valves for ~3s)
+python tests/e2e/smoke.py
+```
+
+**Tests included:**
+
+| Test | Valve HW | What it checks |
+|------|----------|----------------|
+| `ha_reachable` | — | HA REST API responds |
+| `integration_loaded` | — | Config entry present and state=loaded |
+| `entities_present` | — | neverdry entities exist in state machine |
+| `et_sensor_valid` | — | ET sensor has a numeric, non-negative value |
+| `zone_entities_present` | — | Entities for the configured zone exist |
+| `irrigate_zone_and_stop` | yes | `irrigate_zone` changes sensor; `stop` completes |
+| `reset_deficit` | — | `reset` service completes without error |
+| `config_reload` | — | Config entry reloads and comes back loaded |
+
 ## 8. Adding a new ET tier
 
 To add a new ET calculation method (e.g., Hargreaves-Samani):
@@ -382,7 +428,8 @@ Releases are automated via GitHub Actions (`.github/workflows/release.yml`):
 
 ### Pre-release checklist
 
-- [ ] All tests pass (`python3 -m pytest tests/ -v`)
+- [ ] All unit tests pass (`python3 -m pytest tests/ -v`)
+- [ ] E2E smoke tests pass (`python tests/e2e/smoke.py --no-valves`, then full run if valves available)
 - [ ] No uncommitted changes
 - [ ] `HACS` validation passes locally or in CI
 - [ ] Changelog / release notes drafted (GitHub auto-generates from PR titles)

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -324,6 +324,11 @@
                 <h3>Works without valves too</h3>
                 <p>No hardware? NeverDry sends you a notification when watering is needed and by how much. Monitoring mode with zero hardware requirements.</p>
             </div>
+            <div class="feature-card">
+                <div class="icon">🌍</div>
+                <h3>Metric &amp; imperial</h3>
+                <p>All sensors declare the correct Home Assistant device class — deficit in mm or inches, volumes in litres or gallons, flow rate in L/min or gal/min. Units follow your HA system preference automatically.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/info.md
+++ b/info.md
@@ -7,6 +7,7 @@ NeverDry is a custom integration that calculates a real-time **soil water defici
 - **Per-zone crop coefficient (Kc)** with 10 plant families and seasonal variation
 - **Direct valve control** with sequential multi-zone irrigation
 - **Rain-aware** — skips irrigation automatically on rainy days
+- **Metric & imperial** — all sensors carry HA device classes; units follow your HA system preference automatically
 - **Monitoring mode** — works without smart valves (notification alerts)
 - **UI config flow** — no YAML needed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,16 @@ def _create_ha_stubs():
         MEASUREMENT = "measurement"
         TOTAL_INCREASING = "total_increasing"
 
+    class SensorDeviceClass:
+        AREA = "area"
+        DURATION = "duration"
+        PRECIPITATION = "precipitation"
+        PRECIPITATION_INTENSITY = "precipitation_intensity"
+        VOLUME_FLOW_RATE = "volume_flow_rate"
+        VOLUME_STORAGE = "volume_storage"
+
     sensor_mod.SensorStateClass = SensorStateClass
+    sensor_mod.SensorDeviceClass = SensorDeviceClass
 
     # homeassistant.core
     core_mod = ModuleType("homeassistant.core")
@@ -125,7 +134,34 @@ def _create_ha_stubs():
         DIAGNOSTIC = "diagnostic"
         CONFIG = "config"
 
+    class UnitOfArea:
+        SQUARE_METERS = "m²"
+
+    class UnitOfLength:
+        MILLIMETERS = "mm"
+        INCHES = "in"
+
+    class UnitOfTime:
+        SECONDS = "s"
+
+    class UnitOfVolume:
+        LITERS = "L"
+        GALLONS = "gal"
+
+    class UnitOfVolumeFlowRate:
+        LITERS_PER_MINUTE = "L/min"
+
+    class UnitOfVolumetricFlux:
+        MILLIMETERS_PER_HOUR = "mm/h"
+        INCHES_PER_HOUR = "in/h"
+
     const_mod.EntityCategory = EntityCategory
+    const_mod.UnitOfArea = UnitOfArea
+    const_mod.UnitOfLength = UnitOfLength
+    const_mod.UnitOfTime = UnitOfTime
+    const_mod.UnitOfVolume = UnitOfVolume
+    const_mod.UnitOfVolumeFlowRate = UnitOfVolumeFlowRate
+    const_mod.UnitOfVolumetricFlux = UnitOfVolumetricFlux
 
     # Register all stubs
     helpers_mod = ModuleType("homeassistant.helpers")

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill in your values (never commit .env)
+HA_URL=http://homeassistant.local:8123
+HA_TOKEN=your_long_lived_token_here
+ZONE_NAME=Orto
+VALVE_ENTITY=switch.your_valve_entity   # required only for --interactive tests

--- a/tests/e2e/ha_client.py
+++ b/tests/e2e/ha_client.py
@@ -1,0 +1,79 @@
+"""Thin HTTP client for Home Assistant REST API."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+
+class HAClient:
+    def __init__(self, url: str, token: str, timeout: int = 10) -> None:
+        self._base = url.rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        self._timeout = timeout
+
+    # ── read ──────────────────────────────────────────────────────────────
+
+    def get_state(self, entity_id: str) -> dict[str, Any]:
+        r = requests.get(
+            f"{self._base}/api/states/{entity_id}",
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def list_states(self) -> list[dict[str, Any]]:
+        r = requests.get(
+            f"{self._base}/api/states",
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def get_config_entries(self) -> list[dict[str, Any]]:
+        r = requests.get(
+            f"{self._base}/api/config/config_entries/entry",
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    # ── write ─────────────────────────────────────────────────────────────
+
+    def call_service(self, domain: str, service: str, data: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        r = requests.post(
+            f"{self._base}/api/services/{domain}/{service}",
+            headers=self._headers,
+            json=data or {},
+            timeout=self._timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    def wait_for_state(self, entity_id: str, expected: str, timeout_s: float = 30, poll_s: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                state = self.get_state(entity_id)["state"]
+                if state == expected:
+                    return True
+            except Exception:  # noqa: S110
+                pass
+            time.sleep(poll_s)
+        return False
+
+    def find_entries(self, domain: str) -> list[dict[str, Any]]:
+        return [e for e in self.get_config_entries() if e.get("domain") == domain]
+
+    def states_for_domain(self, domain: str) -> list[dict[str, Any]]:
+        return [s for s in self.list_states() if s["entity_id"].startswith(f"{domain}.")]

--- a/tests/e2e/smoke.py
+++ b/tests/e2e/smoke.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+NeverDry pre-release smoke tests — run against a live Home Assistant instance.
+
+Usage:
+    export HA_URL=http://homeassistant.local:8123
+    export HA_TOKEN=<long-lived token>
+    export ZONE_NAME="Giardino_Ortensia"   # zone name as configured in NeverDry
+    export VALVE_ENTITY=switch.ortensia    # physical valve switch (required for --interactive)
+    python tests/e2e/smoke.py
+    python tests/e2e/smoke.py --no-valves       # skip tests that open valves
+    python tests/e2e/smoke.py --interactive     # also run tests requiring manual actions
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+
+def _load_dotenv() -> None:
+    env_file = Path(__file__).parent / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_dotenv()
+
+from ha_client import HAClient  # noqa: E402
+
+DOMAIN = "never_dry"
+INTERACTIVE_TIMEOUT_S = 15
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+CYAN = "\033[96m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+# ── test registry ─────────────────────────────────────────────────────────────
+
+_tests: list[tuple[str, bool, bool]] = []  # (name, needs_valves, interactive)
+
+
+def smoke(needs_valves: bool = False, interactive: bool = False):
+    def decorator(fn):
+        _tests.append((fn.__name__, needs_valves, interactive))
+        return fn
+
+    return decorator
+
+
+def _zone_alphanum(zone: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", zone.lower())
+
+
+def _zone_entity(states: list, zone: str, keyword: str):
+    za = _zone_alphanum(zone)
+    return next(
+        (
+            s
+            for s in states
+            if za in re.sub(r"[^a-z0-9]", "", s["entity_id"])
+            and keyword in s["entity_id"]
+            and s["state"] not in ("unknown", "unavailable")
+        ),
+        None,
+    )
+
+
+# ── non-valve tests ───────────────────────────────────────────────────────────
+
+
+@smoke()
+def test_ha_reachable(ha: HAClient, zone: str) -> None:
+    """HA responds on the REST API."""
+    import requests
+
+    r = requests.get(f"{ha._base}/api/", headers=ha._headers, timeout=5)
+    assert r.status_code == 200, f"HTTP {r.status_code}"
+
+
+@smoke()
+def test_integration_loaded(ha: HAClient, zone: str) -> None:
+    """NeverDry config entry is present and loaded."""
+    entries = ha.find_entries(DOMAIN)
+    assert entries, "No never_dry config entry found"
+    loaded = [e for e in entries if e.get("state") == "loaded"]
+    assert loaded, f"Entry found but state={entries[0].get('state')!r} (expected 'loaded')"
+
+
+@smoke()
+def test_entities_present(ha: HAClient, zone: str) -> None:
+    """Core never_dry entities exist in HA state machine."""
+    states = ha.list_states()
+    nd = [s["entity_id"] for s in states if "neverdry" in s["entity_id"] or "never_dry" in s["entity_id"]]
+    assert nd, "No neverdry/never_dry entities found in HA state machine"
+
+
+@smoke()
+def test_et_sensor_valid(ha: HAClient, zone: str) -> None:
+    """ET sensor has a numeric, non-negative value."""
+    states = ha.list_states()
+    et = next((s for s in states if "et_hourly" in s["entity_id"] or "et_estimate" in s["entity_id"]), None)
+    assert et, "ET sensor entity not found"
+    assert et["state"] not in ("unknown", "unavailable"), f"ET sensor state={et['state']!r}"
+    assert float(et["state"]) >= 0, f"ET value negative: {et['state']}"
+
+
+@smoke()
+def test_zone_entities_present(ha: HAClient, zone: str) -> None:
+    """Entities for the configured zone exist."""
+    za = _zone_alphanum(zone)
+    states = ha.list_states()
+    found = [s for s in states if za in re.sub(r"[^a-z0-9]", "", s["entity_id"])]
+    assert found, f"No entities found for zone '{zone}' (slug: '{za}'). Check ZONE_NAME."
+
+
+@smoke()
+def test_no_stray_notifications(ha: HAClient, zone: str) -> None:
+    """No active NeverDry CRITICAL persistent notifications."""
+    states = ha.list_states()
+    critical = [
+        s
+        for s in states
+        if s["entity_id"].startswith("persistent_notification.")
+        and "never_dry" in s.get("attributes", {}).get("notification_id", "")
+        and "CRITICAL" in s.get("attributes", {}).get("title", "").upper()
+        and s["state"] == "notifying"
+    ]
+    assert not critical, "Active CRITICAL NeverDry notifications: " + ", ".join(
+        s["attributes"].get("title", s["entity_id"]) for s in critical
+    )
+
+
+@smoke()
+def test_reset_deficit(ha: HAClient, zone: str) -> None:
+    """reset zeros the deficit; set_deficit restores the prior value."""
+    states = ha.list_states()
+    ent = _zone_entity(states, zone, "deficit")
+    pre = float(ent["state"]) if ent else 0.0
+
+    ha.call_service(DOMAIN, "reset")
+    time.sleep(1)
+
+    if ent:
+        after = float(ha.get_state(ent["entity_id"])["state"])
+        assert after < 0.5, f"Deficit not zeroed after reset (got {after} mm)"
+
+    ha.call_service(DOMAIN, "set_deficit", {"zone_name": zone, "deficit_mm": pre})
+    time.sleep(1)
+
+
+@smoke()
+def test_config_reload(ha: HAClient, zone: str) -> None:
+    """Config entry reloads and comes back loaded."""
+    entries = ha.find_entries(DOMAIN)
+    assert entries, "No never_dry config entry found"
+    ha.call_service("homeassistant", "reload_config_entry", {"entry_id": entries[0]["entry_id"]})
+    time.sleep(4)
+    loaded = [e for e in ha.find_entries(DOMAIN) if e.get("state") == "loaded"]
+    assert loaded, "Entry not loaded after reload"
+
+
+# ── valve tests ───────────────────────────────────────────────────────────────
+
+
+@smoke(needs_valves=True)
+def test_irrigate_zone_and_stop(ha: HAClient, zone: str) -> None:
+    """irrigate_zone + stop complete without error; integration stays loaded."""
+    ha.call_service(DOMAIN, "set_deficit", {"zone_name": zone, "deficit_mm": 5.0})
+    time.sleep(1)
+    ha.call_service(DOMAIN, "irrigate_zone", {"zone_name": zone})
+    time.sleep(8)
+    ha.call_service(DOMAIN, "stop")
+    time.sleep(6)
+
+    loaded = [e for e in ha.find_entries(DOMAIN) if e.get("state") == "loaded"]
+    assert loaded, "Integration not loaded after irrigate+stop cycle"
+
+
+@smoke(needs_valves=True)
+def test_deficit_reduces_after_irrigation(ha: HAClient, zone: str) -> None:
+    """After irrigation, zone deficit is lower than the pre-irrigation value."""
+    time.sleep(12)  # ensure MIN_SERVICE_INTERVAL_S (10s) has passed since previous irrigate_zone
+    states = ha.list_states()
+    ent = _zone_entity(states, zone, "deficit")
+    assert ent, f"No deficit entity found for zone '{zone}'"
+
+    target = 5.0
+    ha.call_service(DOMAIN, "set_deficit", {"zone_name": zone, "deficit_mm": target})
+    time.sleep(1)
+
+    ha.call_service(DOMAIN, "irrigate_zone", {"zone_name": zone})
+    time.sleep(8)
+    ha.call_service(DOMAIN, "stop")
+    time.sleep(6)
+
+    after = float(ha.get_state(ent["entity_id"])["state"])
+    assert after < target, f"Deficit did not reduce: was {target} mm, now {after} mm"
+
+
+@smoke(needs_valves=True)
+def test_emergency_stop_all_zones(ha: HAClient, zone: str) -> None:
+    """irrigate_all followed by immediate stop leaves integration loaded."""
+    ha.call_service(DOMAIN, "irrigate_all")
+    time.sleep(2)
+    ha.call_service(DOMAIN, "stop")
+    time.sleep(3)
+
+    loaded = [e for e in ha.find_entries(DOMAIN) if e.get("state") == "loaded"]
+    assert loaded, "Integration not loaded after emergency stop"
+
+
+# ── interactive tests ─────────────────────────────────────────────────────────
+
+
+@smoke(needs_valves=True, interactive=True)
+def test_external_zha_close_aborts_session(ha: HAClient, zone: str) -> None:
+    """Close valve from ZHA while irrigating → session aborts, last_irrigated updates."""
+    valve_entity = os.environ.get("VALVE_ENTITY", "")
+    assert valve_entity, "VALVE_ENTITY env var not set — required for interactive tests"
+
+    za = _zone_alphanum(zone)
+    states = ha.list_states()
+    li_ent = next(
+        (s for s in states if za in re.sub(r"[^a-z0-9]", "", s["entity_id"]) and "last_irrigated" in s["entity_id"]),
+        None,
+    )
+    pre_li = li_ent["state"] if li_ent else None
+
+    ha.call_service(DOMAIN, "set_deficit", {"zone_name": zone, "deficit_mm": 5.0})
+    time.sleep(1)
+    ha.call_service(DOMAIN, "irrigate_zone", {"zone_name": zone})
+    time.sleep(2)
+
+    print(
+        f"\n  {CYAN}ACTION{RESET}  Close '{valve_entity}' from ZHA/Zigbee within {INTERACTIVE_TIMEOUT_S}s", flush=True
+    )
+
+    closed = ha.wait_for_state(valve_entity, "off", timeout_s=INTERACTIVE_TIMEOUT_S)
+    assert closed, f"Valve {valve_entity} did not close within {INTERACTIVE_TIMEOUT_S}s"
+
+    time.sleep(3)
+    ha.call_service(DOMAIN, "stop")  # safety net
+
+    if li_ent:
+        after_li = ha.get_state(li_ent["entity_id"])["state"]
+        assert after_li != pre_li, f"last_irrigated did not update after external close (still {pre_li!r})"
+
+
+@smoke(needs_valves=True, interactive=True)
+def test_manual_valve_open_detected(ha: HAClient, zone: str) -> None:
+    """Open and close the valve manually → NeverDry detects it as manual irrigation."""
+    valve_entity = os.environ.get("VALVE_ENTITY", "")
+    assert valve_entity, "VALVE_ENTITY env var not set — required for interactive tests"
+
+    za = _zone_alphanum(zone)
+    states = ha.list_states()
+    li_ent = next(
+        (s for s in states if za in re.sub(r"[^a-z0-9]", "", s["entity_id"]) and "last_irrigated" in s["entity_id"]),
+        None,
+    )
+    pre_li = li_ent["state"] if li_ent else None
+
+    print(
+        f"\n  {CYAN}ACTION{RESET}  Open '{valve_entity}' manually from HA (switch.turn_on), wait 10s, then close it.",
+        flush=True,
+    )
+    print(f"         You have {INTERACTIVE_TIMEOUT_S}s to open it.", flush=True)
+
+    opened = ha.wait_for_state(valve_entity, "on", timeout_s=INTERACTIVE_TIMEOUT_S)
+    assert opened, f"Valve {valve_entity} was not opened within {INTERACTIVE_TIMEOUT_S}s"
+
+    print(f"  {CYAN}ACTION{RESET}  Now close '{valve_entity}' within {INTERACTIVE_TIMEOUT_S}s.", flush=True)
+    closed = ha.wait_for_state(valve_entity, "off", timeout_s=INTERACTIVE_TIMEOUT_S)
+    assert closed, f"Valve {valve_entity} was not closed within {INTERACTIVE_TIMEOUT_S}s"
+
+    time.sleep(3)
+
+    if li_ent:
+        after_li = ha.get_state(li_ent["entity_id"])["state"]
+        assert after_li != pre_li, f"NeverDry did not detect manual irrigation (last_irrigated still {pre_li!r})"
+
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="NeverDry pre-release smoke tests")
+    parser.add_argument("--no-valves", action="store_true", help="Skip tests that open real valves")
+    parser.add_argument("--interactive", action="store_true", help="Enable interactive tests requiring manual actions")
+    args = parser.parse_args()
+
+    url = os.environ.get("HA_URL", "").rstrip("/")
+    token = os.environ.get("HA_TOKEN", "")
+    zone = os.environ.get("ZONE_NAME", "")
+
+    if not url or not token or not zone:
+        print(f"{RED}Missing env vars. Set HA_URL, HA_TOKEN, ZONE_NAME.{RESET}")
+        return 1
+
+    ha = HAClient(url, token)
+
+    print(f"\n{BOLD}NeverDry smoke tests → {url}{RESET}")
+    flags = []
+    if args.no_valves:
+        flags.append("valves SKIPPED")
+    if args.interactive:
+        flags.append("interactive ENABLED")
+    print(f"Zone: {zone!r}  |  {', '.join(flags) or 'standard run'}\n")
+
+    # Snapshot deficit before any test modifies it
+    za = _zone_alphanum(zone)
+    try:
+        all_states = ha.list_states()
+        snap_ent = next(
+            (
+                s
+                for s in all_states
+                if za in re.sub(r"[^a-z0-9]", "", s["entity_id"])
+                and "deficit" in s["entity_id"]
+                and s["state"] not in ("unknown", "unavailable")
+            ),
+            None,
+        )
+        pre_run_deficit = float(snap_ent["state"]) if snap_ent else None
+    except Exception:
+        pre_run_deficit = None
+
+    fn_map = {
+        fn.__name__: fn
+        for fn in [
+            test_ha_reachable,
+            test_integration_loaded,
+            test_entities_present,
+            test_et_sensor_valid,
+            test_zone_entities_present,
+            test_no_stray_notifications,
+            test_reset_deficit,
+            test_config_reload,
+            test_irrigate_zone_and_stop,
+            test_deficit_reduces_after_irrigation,
+            test_emergency_stop_all_zones,
+            test_external_zha_close_aborts_session,
+            test_manual_valve_open_detected,
+        ]
+    }
+
+    passed = failed = skipped = 0
+
+    for name, needs_valves, interactive in _tests:
+        fn = fn_map[name]
+        label = name.replace("test_", "").replace("_", " ")
+
+        if needs_valves and args.no_valves:
+            print(f"  {YELLOW}SKIP{RESET}  {label}")
+            skipped += 1
+            continue
+        if interactive and not args.interactive:
+            print(f"  {YELLOW}SKIP{RESET}  {label}  (pass --interactive to enable)")
+            skipped += 1
+            continue
+
+        try:
+            fn(ha, zone)
+            print(f"  {GREEN}PASS{RESET}  {label}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  {RED}FAIL{RESET}  {label}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  {RED}ERROR{RESET} {label}: {type(e).__name__}: {e}")
+            failed += 1
+
+    total = passed + failed + skipped
+    color = GREEN if failed == 0 else RED
+    print(f"\n{color}{BOLD}{passed}/{total - skipped} passed{RESET}", end="")
+    if skipped:
+        print(f"  {YELLOW}({skipped} skipped){RESET}", end="")
+    print()
+
+    if pre_run_deficit is not None:
+        try:
+            ha.call_service(DOMAIN, "set_deficit", {"zone_name": zone, "deficit_mm": pre_run_deficit})
+            print(f"\n  {YELLOW}teardown{RESET}  deficit restored → {pre_run_deficit:.2f} mm")
+        except Exception as e:
+            print(f"\n  {RED}teardown WARN{RESET}  could not restore deficit: {e}")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -35,7 +35,7 @@ class TestIrrigateSingleZone:
         """Controller should open valve, wait, close valve."""
         zone_orto._zone_deficit = 5.0
 
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -50,7 +50,7 @@ class TestIrrigateSingleZone:
     async def test_resets_zone_deficit_after_irrigation(self, controller, di_sensor, zone_orto):
         """Zone deficit should be reset to zero after successful irrigation."""
         zone_orto._zone_deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -85,7 +85,7 @@ class TestIrrigateSingleZone:
     async def test_skips_zone_with_zero_duration(self, controller, di_sensor):
         """Zone with zero deficit should be skipped."""
         di_sensor._deficit = 0.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -99,7 +99,7 @@ class TestIrrigateSingleZone:
         zone_orto._zone_deficit = 5.0
         irrigating_states = []
 
-        async def capture_state(duration):
+        async def capture_state(duration, **kwargs):
             irrigating_states.append(zone_orto.is_irrigating)
             return 0
 
@@ -121,7 +121,7 @@ class TestIrrigateAllZones:
         """All zones should be irrigated in order."""
         zone_orto._zone_deficit = 10.0
         zone_prato._zone_deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto", "Prato"])
 
@@ -135,7 +135,7 @@ class TestIrrigateAllZones:
         zone_orto._zone_deficit = 10.0
         zone_prato._zone_deficit = 10.0
         di_sensor._deficit = 10.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto", "Prato"])
 
@@ -174,7 +174,7 @@ class TestEmergencyStop:
         zone_orto._zone_deficit = 10.0
         zone_prato._zone_deficit = 10.0
 
-        async def stop_during_wait(duration):
+        async def stop_during_wait(duration, **kwargs):
             controller._stop_requested = True
             return 0
 
@@ -806,7 +806,7 @@ class TestIrrigationEvent:
     async def test_event_fired_on_zone_completion(self, controller, hass_mock, zone_orto):
         """Event should be fired when a zone completes irrigation."""
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await controller._irrigate_zones(["Orto"])
 
@@ -823,7 +823,7 @@ class TestIrrigationEvent:
         the caller (button, scheduled, reactive) rather than collapsing
         every commanded cycle into the generic 'automatic'."""
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
         controller._current_source = source
 
         await controller._irrigate_zones(["Orto"])
@@ -836,7 +836,7 @@ class TestIrrigationEvent:
         """No event should fire if irrigation is stopped."""
         zone_orto._zone_deficit = 10.0
 
-        async def stop_during_wait(duration):
+        async def stop_during_wait(duration, **kwargs):
             controller._stop_requested = True
             return 0
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -24,7 +24,7 @@ class TestControllerState:
 
     def test_register_services(self, controller, hass_mock):
         controller.register_services()
-        assert hass_mock.services.async_register.call_count == 6
+        assert hass_mock.services.async_register.call_count == 7
 
 
 class TestIrrigateSingleZone:

--- a/tests/test_controller_session_result.py
+++ b/tests/test_controller_session_result.py
@@ -109,7 +109,7 @@ class TestSessionResultIntegration:
     @pytest.mark.asyncio
     async def test_auto_cycle_emits_session_result(self, controller, zone_orto, caplog):
         zone_orto._zone_deficit = 5.0
-        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        controller._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         with caplog.at_level(logging.INFO, logger="never_dry.controller"):
             await controller._irrigate_zones(["Orto"])

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -44,7 +44,7 @@ class TestEstimatedFlowDelivery:
         zone = _make_zone(hass_mock, di_sensor)
         zone._zone_deficit = 5.0
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
-        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         await ctrl._deliver_estimated_flow(zone)
 
@@ -320,7 +320,7 @@ class TestDeliveryModeDispatch:
         zone = _make_zone(hass_mock, di_sensor)
         zone._zone_deficit = 5.0
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
-        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d: d)
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda d, **kwargs: d)
 
         result = await ctrl._deliver_water(zone)
 


### PR DESCRIPTION
## Summary

Six targeted fixes hardening the integration lifecycle and valve event handling, identified during field testing on 2026-06-19/20.

- **Logger level persistence** (`__init__.py`): HA resets the logger to WARNING on every reload; explicit `setLevel(DEBUG)` in setup and `setLevel(NOTSET)` in teardown preserve activity log output. Version string added to startup log line.
- **Controller lifecycle** (`__init__.py`, `sensor.py`): controller reference stored in `hass.data` and retrieved in `async_unload_entry`; graceful `async_stop()` (await, not cancel) ensures the valve is closed and `SESSION_RESULT` is written before the new controller starts. Eliminates duplicate controller instances across reloads.
- **External close detection in `estimated_flow` mode** (`controller.py`): `_wait_with_stop_check` now polls the valve entity state every second and exits early if the valve is closed externally. Correct partial volume is returned to the caller.
- **Spurious "Manual irrigation detected"** (`controller.py`): `_controller_closing` set tracks NeverDry-initiated closes; the valve-state listener skips the off-event while a controller close is in flight, eliminating the FSM→HA state-change race condition.
- **Config flow spurious reloads** (`config_flow.py`): all four `async_update_entry` call sites now guarded with `if new_data != dict(entry.data)`. Saves without changes no longer trigger a reload that aborts active irrigation.
- **Spurious CRITICAL on CLOSE_LEAK recovery** (`valve_operator.py`): `_notify_failure(CLOSE_LEAK)` was sending CRITICAL before recovery was attempted. CLOSE_LEAK is now silent in `_notify_failure`; only `_escalate_stuck_open()` (called when recovery fails) sends the CRITICAL notification.

## Test plan

- [ ] J.1 — Config save without changes does not trigger reload
- [ ] J.2 — No duplicate controller instances after reload during active irrigation
- [ ] J.3 — `estimated_flow` zone: manual close mid-session reports correct partial volume
- [ ] J.4 — `est_duration` appears in irrigation start log
- [ ] J.5 — No "Manual irrigation detected" after NeverDry-initiated close
- [ ] J.6 — CLOSE_LEAK recovery success generates no CRITICAL notification
- [ ] Activity log continues writing after reload (no WARNING level reset)
- [ ] NeverDry version visible in startup log line after HA restart