### PR TITLE
fix: auto-convert °F temperature input to °C for ET calculation

### DIFF
--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -149,6 +149,23 @@ class SensorBuffer:
         return len(self._buf)
 
 
+def _to_celsius(state) -> float | None:
+    """Return temperature in °C from a HA State object.
+
+    Converts from °F if unit_of_measurement is '°F'. Returns None when the
+    state is unavailable or not numeric.
+    """
+    if state is None or state.state in ("unavailable", "unknown"):
+        return None
+    try:
+        value = float(state.state)
+    except (ValueError, TypeError):
+        return None
+    if state.attributes.get("unit_of_measurement") == "°F":
+        return (value - 32) * 5 / 9
+    return value
+
+
 # ══════════════════════════════════════════════════════════
 #  Kc computation
 # ══════════════════════════════════════════════════════════
@@ -474,13 +491,9 @@ class ETSensor(SensorEntity):
         new_state = event.data.get("new_state")
         if new_state is None:
             return
-        try:
-            t = float(new_state.state)
+        t = _to_celsius(new_state)
+        if t is not None:
             self._value = max(0.0, self._alpha * (t - self._t_base) / 24)
-        except (ValueError, TypeError):
-            # Temperature sensor not yet numeric (boot / unavailable):
-            # keep the previous self._value unchanged.
-            pass
         self.async_write_ha_state()
 
     @property
@@ -571,10 +584,10 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         else:
             rain_delta = self._compute_rain_delta()
 
-            # Push raw temp into the buffer; invalid/unavailable readings are
-            # rejected by the buffer (not zeroed), so the median stays stable.
+            # Push temp into the buffer (converted to °C if sensor reports °F);
+            # invalid/unavailable readings are rejected, median stays stable.
             raw_state = self._hass.states.get(self._temp_sensor)
-            self._temp_buffer.push(raw_state.state if raw_state is not None else None)
+            self._temp_buffer.push(_to_celsius(raw_state))
 
             t_median = self._temp_buffer.median(ET_BUFFER_MIN_READINGS)
             if t_median is None:
@@ -724,12 +737,9 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         events: list[tuple[datetime, str, float]] = []
 
         for s in temp_states:
-            if s.state in ("unknown", "unavailable"):
-                continue
-            try:
-                events.append((s.last_changed, "temp", float(s.state)))
-            except (ValueError, TypeError):
-                continue
+            t = _to_celsius(s)
+            if t is not None:
+                events.append((s.last_changed, "temp", t))
 
         for s in rain_states:
             if s.state in ("unknown", "unavailable"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,10 +215,11 @@ from never_dry.sensor import (  # noqa: E402
 )
 
 
-def _make_state(value):
+def _make_state(value, unit=None):
     """Create a mock HA state object."""
     state = MagicMock()
     state.state = str(value)
+    state.attributes = {"unit_of_measurement": unit} if unit else {}
     return state
 
 
@@ -333,9 +334,9 @@ def make_state():
 def make_event():
     """Factory for mock state change events."""
 
-    def _make(new_value):
+    def _make(new_value, unit=None):
         event = MagicMock()
-        event.data = {"new_state": _make_state(new_value)}
+        event.data = {"new_state": _make_state(new_value, unit=unit)}
         return event
 
     return _make

--- a/tests/test_et_sensor.py
+++ b/tests/test_et_sensor.py
@@ -91,6 +91,40 @@ class TestETEdgeCases:
         assert et_sensor.native_value == 0.0
 
 
+class TestETFahrenheit:
+    """Test that ETSensor correctly converts °F input to °C before the formula."""
+
+    def test_et_fahrenheit_equivalent(self, et_sensor, make_event):
+        """77°F == 25°C → same ET as 25°C test."""
+        et_sensor._on_temp_change(make_event(77.0, unit="°F"))
+        expected = round(0.22 * (25.0 - 9.0) / 24, 4)
+        assert et_sensor.native_value == expected
+
+    def test_et_fahrenheit_below_base(self, et_sensor, make_event):
+        """48.2°F == 9°C (T_base) → ET should be zero."""
+        et_sensor._on_temp_change(make_event(48.2, unit="°F"))
+        assert et_sensor.native_value == 0.0
+
+    def test_et_fahrenheit_cold(self, et_sensor, make_event):
+        """41°F == 5°C < T_base → ET should be zero."""
+        et_sensor._on_temp_change(make_event(41.0, unit="°F"))
+        assert et_sensor.native_value == 0.0
+
+    def test_et_no_unit_treated_as_celsius(self, et_sensor, make_event):
+        """Sensor without unit_of_measurement is treated as °C (backward compat)."""
+        et_sensor._on_temp_change(make_event(25.0))
+        expected = round(0.22 * (25.0 - 9.0) / 24, 4)
+        assert et_sensor.native_value == expected
+
+    def test_et_unavailable_fahrenheit_preserves_previous(self, et_sensor, make_event):
+        """Unavailable state with °F unit is gracefully ignored."""
+        et_sensor._on_temp_change(make_event(77.0, unit="°F"))
+        previous = et_sensor.native_value
+        assert previous > 0
+        et_sensor._on_temp_change(make_event("unavailable", unit="°F"))
+        assert et_sensor.native_value == previous
+
+
 class TestETAttributes:
     """Test sensor metadata."""
 


### PR DESCRIPTION
## Summary

- Add `_to_celsius(state)` helper that checks `unit_of_measurement` on the HA state object and converts `°F → °C` before the ET formula
- Applied in three places: `ETSensor._on_temp_change`, `DrynessIndexSensor._on_sensor_change` (buffer push), and `_replay_water_balance` (backfill)
- Sensors with no unit or already in `°C` are unaffected (backward compatible)
- Add 5 new tests in `TestETFahrenheit`; extend `_make_state` / `make_event` fixtures with optional `unit=` parameter

## Root cause

HA systems configured in imperial units automatically report temperature sensors in °F via `state.unit_of_measurement`. NeverDry was reading the raw float value and passing it directly to the Hargreaves formula, which assumes °C — causing the ET estimate to be wildly wrong (either hugely overestimated or clamped to zero by the `ET_TEMP_VALID_RANGE` guard at 70°C/158°F).

## Test plan

- [ ] `pytest tests/test_et_sensor.py` — 20 tests pass including 5 new `TestETFahrenheit` cases
- [ ] Full suite: `pytest tests/ --ignore=tests/e2e` — 531 passed
- [ ] Verify on a HA instance with system unit set to imperial: ET sensor should show reasonable values