### PR TITLE
chore: bump version to 0.10.2 — official HACS listing

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/drake69/NeverDry/issues",
     "requirements": [],
-    "version": "0.10.1"
+    "version": "0.10.2"
 }


### PR DESCRIPTION
## Summary

- Bump `manifest.json` version from `0.10.1` → `0.10.2`
- Marks the first official release after NeverDry was accepted into the [HACS default repository list](https://github.com/hacs/default/pull/6911)

## What changed since v0.10.1

- `fix(config_flow)`: auto-downgrade `delivery_mode` when sensor entity is removed (#77)
- `docs`: HACS one-click install CTA added to all gh-pages language versions
- `docs`: mention NeverDry Planner as Kc calculator in README

## Test plan

- [ ] CI passes
- [ ] `manifest.json` version is `0.10.2`
- [ ] GitHub Release v0.10.2 will be created after merge and tagged on main