### PR TITLE
docs: HACS Default badge + simplified install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://github.com/drake69/NeverDry/actions/workflows/release.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/release.yml)
 [![Security](https://github.com/drake69/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/security.yml)
 [![Lint](https://github.com/drake69/NeverDry/actions/workflows/lint.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/lint.yml)
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5)](https://github.com/hacs/integration)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
 [![GitHub stars](https://img.shields.io/github/stars/drake69/NeverDry?style=social)](https://github.com/drake69/NeverDry/stargazers)
@@ -95,12 +95,14 @@ You can also set a **manual Kc override** per zone (0.1–2.0) if you know the e
 
 ### HACS (recommended)
 
+[![Open your Home Assistant instance and open NeverDry in HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration)
+
+Or manually:
+
 1. Open **HACS** in Home Assistant
-2. Go to **Integrations** > **Custom repositories**
-3. Add `https://github.com/drake69/NeverDry` — category **Integration**
-4. Search for **NeverDry** and install
-5. Restart Home Assistant
-6. **Settings** > **Devices & Services** > **Add Integration** > search **NeverDry**
+2. Go to **Integrations** and search for **NeverDry**
+3. Click Install, then restart Home Assistant
+4. **Settings** > **Devices & Services** > **Add Integration** > search **NeverDry**
 
 ### Manual
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -80,7 +80,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub-Repository</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentation</a>
@@ -190,8 +190,7 @@
             </div>
             <h3>&Uuml;ber HACS (manuelle Schritte)</h3>
             <ol>
-                <li>HACS aufmachen &rarr; Integrationen &rarr; <strong>Benutzerdefinierte Repositories</strong></li>
-                <li><code>https://github.com/drake69/NeverDry</code> als <strong>Integration</strong> hinzuf&uuml;gen</li>
+                <li>HACS aufmachen &rarr; Integrationen</li>
                 <li>Nach <strong>NeverDry</strong> suchen und installieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Einstellungen &rarr; Ger&auml;te &amp; Dienste &rarr; <strong>Integration hinzuf&uuml;gen</strong> &rarr; NeverDry</li>

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -93,7 +93,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub-Repository</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentation</a>
@@ -203,8 +203,7 @@
             </div>
             <h3>&Uuml;ber HACS (manuelle Schritte)</h3>
             <ol>
-                <li>HACS &ouml;ffnen &rarr; Integrationen &rarr; <strong>Benutzerdefinierte Repositories</strong></li>
-                <li><code>https://github.com/drake69/NeverDry</code> als <strong>Integration</strong> hinzuf&uuml;gen</li>
+                <li>HACS &ouml;ffnen &rarr; Integrationen</li>
                 <li>Nach <strong>NeverDry</strong> suchen und installieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Einstellungen &rarr; Ger&auml;te &amp; Dienste &rarr; <strong>Integration hinzuf&uuml;gen</strong> &rarr; NeverDry</li>

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -88,7 +88,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">Repositorio GitHub</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentaci&oacute;n</a>
@@ -198,9 +198,8 @@
             </div>
             <h3>V&iacute;a HACS (pasos manuales)</h3>
             <ol>
-                <li>Abrir HACS &rarr; Integraciones &rarr; <strong>Repositorios personalizados</strong></li>
-                <li>A&ntilde;adir <code>https://github.com/drake69/NeverDry</code> como <strong>Integraci&oacute;n</strong></li>
-                <li>Buscar <strong>NeverDry</strong> e instalar</li>
+                <li>Abrir HACS &rarr; Integraciones</li>
+                <li>Buscar <strong>NeverDry</strong> y hacer clic en Instalar</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>Ajustes &rarr; Dispositivos y Servicios &rarr; <strong>A&ntilde;adir Integraci&oacute;n</strong> &rarr; NeverDry</li>
             </ol>

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -93,7 +93,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">D&eacute;p&ocirc;t GitHub</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentation</a>
@@ -203,9 +203,8 @@
             </div>
             <h3>Via HACS (&eacute;tapes manuelles)</h3>
             <ol>
-                <li>Ouvrir HACS &rarr; Int&eacute;grations &rarr; <strong>D&eacute;p&ocirc;ts personnalis&eacute;s</strong></li>
-                <li>Ajouter <code>https://github.com/drake69/NeverDry</code> comme <strong>Int&eacute;gration</strong></li>
-                <li>Rechercher <strong>NeverDry</strong> et installer</li>
+                <li>Ouvrir HACS &rarr; Int&eacute;grations</li>
+                <li>Rechercher <strong>NeverDry</strong> et cliquer sur Installer</li>
                 <li>Red&eacute;marrer Home Assistant</li>
                 <li>Param&egrave;tres &rarr; Appareils et Services &rarr; <strong>Ajouter une int&eacute;gration</strong> &rarr; NeverDry</li>
             </ol>

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -80,7 +80,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repozitorij</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentacija</a>
@@ -190,9 +190,8 @@
             </div>
             <h3>Putem HACS-a (ru&ccaron;ni koraci)</h3>
             <ol>
-                <li>Otvorite HACS &rarr; Integracije &rarr; <strong>Prilagođeni repozitoriji</strong></li>
-                <li>Dodajte <code>https://github.com/drake69/NeverDry</code> kao <strong>Integraciju</strong></li>
-                <li>Potražite <strong>NeverDry</strong> i instalirajte</li>
+                <li>Otvorite HACS &rarr; Integracije</li>
+                <li>Potražite <strong>NeverDry</strong> i kliknite Instaliraj</li>
                 <li>Ponovo pokrenite Home Assistant</li>
                 <li>Postavke &rarr; Uređaji i Usluge &rarr; <strong>Dodaj Integraciju</strong> &rarr; NeverDry</li>
             </ol>

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -80,7 +80,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repository</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokument&aacute;ci&oacute;</a>
@@ -190,9 +190,8 @@
             </div>
             <h3>HACS-on kereszt&uuml;l (manu&aacute;lis l&eacute;p&eacute;sek)</h3>
             <ol>
-                <li>HACS megnyit&aacute;sa &rarr; Integr&aacute;ci&oacute;k &rarr; <strong>Egyedi repositoryk</strong></li>
-                <li><code>https://github.com/drake69/NeverDry</code> hozz&aacute;ad&aacute;sa <strong>Integr&aacute;ci&oacute;</strong>k&eacute;nt</li>
-                <li><strong>NeverDry</strong> keres&eacute;se &eacute;s telep&iacute;t&eacute;s</li>
+                <li>HACS megnyit&aacute;sa &rarr; Integr&aacute;ci&oacute;k</li>
+                <li><strong>NeverDry</strong> keres&eacute;se &eacute;s Telep&iacute;t&eacute;s kattint&aacute;s</li>
                 <li>Home Assistant &uacute;jraind&iacute;t&aacute;sa</li>
                 <li>Be&aacute;ll&iacute;t&aacute;sok &rarr; Eszk&ouml;z&ouml;k &eacute;s Szolg&aacute;ltat&aacute;sok &rarr; <strong>Integr&aacute;ci&oacute; hozz&aacute;ad&aacute;sa</strong> &rarr; NeverDry</li>
             </ol>

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -260,7 +260,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repository</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentation</a>
@@ -388,9 +388,8 @@
             </div>
             <h3>Via HACS (manual steps)</h3>
             <ol>
-                <li>Open HACS &rarr; Integrations &rarr; <strong>Custom repositories</strong></li>
-                <li>Add <code>https://github.com/drake69/NeverDry</code> as <strong>Integration</strong></li>
-                <li>Search for <strong>NeverDry</strong> and install</li>
+                <li>Open HACS &rarr; Integrations</li>
+                <li>Search for <strong>NeverDry</strong> and click Install</li>
                 <li>Restart Home Assistant</li>
                 <li>Go to Settings &rarr; Devices &amp; Services &rarr; <strong>Add Integration</strong> &rarr; NeverDry</li>
             </ol>
@@ -408,12 +407,19 @@
 <!-- What's new -->
 <section class="how-it-works">
     <div class="container">
-        <h2>What's new in v0.10.1</h2>
-        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-06-21</p>
+        <h2>What's new in v0.10.2</h2>
+        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-06-24</p>
         <ul style="max-width: 680px; margin: 0 auto; text-align: left; line-height: 2;">
-            <li><strong>Fahrenheit temperature input</strong> — NeverDry now auto-converts °F→°C when your HA system is configured in imperial units; no template sensor needed.</li>
+            <li><strong>Official HACS listing</strong> — NeverDry is now in the HACS default repository list; install with one click, no custom repository needed.</li>
+            <li><strong>Delivery mode guard</strong> — if the sensor entity linked to a zone is removed, NeverDry automatically downgrades the delivery mode to avoid an invalid configuration.</li>
         </ul>
-        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.1">Full release notes on GitHub →</a></p>
+        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.2">Full release notes on GitHub →</a></p>
+        <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
+            <summary style="cursor: pointer;">v0.10.1 — 2026-06-21</summary>
+            <ul style="line-height: 2; margin-top: 0.5em;">
+                <li><strong>Fahrenheit temperature input</strong> — NeverDry now auto-converts °F→°C when your HA system is configured in imperial units; no template sensor needed.</li>
+            </ul>
+        </details>
         <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
             <summary style="cursor: pointer;">v0.10.0 — 2026-06-20</summary>
             <ul style="line-height: 2; margin-top: 0.5em;">

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -93,7 +93,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">Repository GitHub</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentazione</a>
@@ -203,9 +203,8 @@
             </div>
             <h3>Tramite HACS (passaggi manuali)</h3>
             <ol>
-                <li>Apri HACS &rarr; Integrazioni &rarr; <strong>Repository personalizzati</strong>.</li>
-                <li>Aggiungi <code>https://github.com/drake69/NeverDry</code> come <strong>integrazione</strong>.</li>
-                <li>Cerca <strong>NeverDry</strong> e procedi con l'installazione.</li>
+                <li>Apri HACS &rarr; Integrazioni.</li>
+                <li>Cerca <strong>NeverDry</strong> e clicca su Installa.</li>
                 <li>Riavvia Home Assistant.</li>
                 <li>Apri Impostazioni &rarr; Dispositivi e servizi &rarr; <strong>Aggiungi integrazione</strong> &rarr; NeverDry.</li>
             </ol>

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -88,7 +88,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/badge/HACS-Custom-41BDF5?style=flat-square" alt="HACS">
+        <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <a class="cta" href="https://github.com/drake69/NeverDry">Reposit&oacute;rio GitHub</a>
     <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documenta&ccedil;&atilde;o</a>
@@ -198,9 +198,8 @@
             </div>
             <h3>Via HACS (passos manuais)</h3>
             <ol>
-                <li>Abrir HACS &rarr; Integra&ccedil;&otilde;es &rarr; <strong>Reposit&oacute;rios personalizados</strong></li>
-                <li>Adicionar <code>https://github.com/drake69/NeverDry</code> como <strong>Integra&ccedil;&atilde;o</strong></li>
-                <li>Procurar <strong>NeverDry</strong> e instalar</li>
+                <li>Abrir HACS &rarr; Integra&ccedil;&otilde;es</li>
+                <li>Procurar <strong>NeverDry</strong> e clicar em Instalar</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>Defini&ccedil;&otilde;es &rarr; Dispositivos e Servi&ccedil;os &rarr; <strong>Adicionar Integra&ccedil;&atilde;o</strong> &rarr; NeverDry</li>
             </ol>

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -122,12 +122,10 @@ You can use one mode, the other, or both together.
 ### Option B: Via HACS
 
 1. In Home Assistant, go to **HACS → Integrations**
-2. Click the **⋮** menu → **Custom repositories**
-3. Add the repository URL (`https://github.com/drake69/NeverDry`), select category **Integration**
-4. Search for **NeverDry** and click **Install**
-5. Restart Home Assistant
-6. Go to **Settings → Devices & Services → Add Integration**
-7. Search for **NeverDry** and follow the setup wizard (see Section 5)
+2. Search for **NeverDry** and click **Install**
+3. Restart Home Assistant
+4. Go to **Settings → Devices & Services → Add Integration**
+5. Search for **NeverDry** and follow the setup wizard (see Section 5)
 
 ## 5. Configuration (UI setup wizard)
 


### PR DESCRIPTION
## Summary

- **Badge**: `HACS-Custom` → `HACS-Default` in README and all 9 gh-pages language variants
- **Install instructions**: removed "Custom repositories" step everywhere — NeverDry is now searchable directly in HACS
- **README**: added one-click install button (`my.home-assistant.io` redirect)
- **index.html What's new**: bumped to v0.10.2, archived v0.10.1 entry
- **user_manual.md**: simplified Option B from 7 steps to 5

## Test plan

- [ ] CI passes
- [ ] Badge shows "HACS Default" in README preview
- [ ] No remaining "Custom repositories" or "HACS-Custom" references in docs