### PR TITLE
test: SI/imperial unit regression tests + fix rain inches conversion

### DIFF
--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -626,9 +626,14 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         For 'event' type: the sensor value IS the delta (mm per event).
         For 'daily_total' type: compute delta from last reading, handling
         midnight rollover (rain_now < last_rain → new accumulation).
+        Converts inches to mm when the sensor reports in imperial units.
         """
         try:
-            rain_now = float(self._hass.states.get(self._rain_sensor).state)
+            state = self._hass.states.get(self._rain_sensor)
+            rain_now = float(state.state)
+            unit = (state.attributes.get("unit_of_measurement") or "").lower().strip()
+            if unit in ("in", "inch", "inches"):
+                rain_now *= 25.4
         except (TypeError, ValueError, AttributeError):
             return 0.0
 

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from never_dry.sensor import DrynessIndexSensor
 
 
 class TestDeficitAccumulation:
@@ -397,3 +398,89 @@ class TestRainDelta:
         di_sensor._last_update = datetime.now() - timedelta(seconds=1)
         di_sensor._on_sensor_change(MagicMock())
         assert di_sensor._deficit == 0.0
+
+
+class TestRainUnits:
+    """Rain sensor reporting in inches is converted to mm before deficit update."""
+
+    def test_rain_inches_converted_to_mm(self, di_sensor, hass_mock, make_state):
+        """1 inch of rain must reduce the deficit by 25.4 mm."""
+        di_sensor._deficit = 30.0
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(9.0),  # ET = 0
+            "sensor.rain": make_state(1.0, unit="in"),
+        }[eid]
+        di_sensor._last_update = datetime.now() - timedelta(hours=1)
+        di_sensor._on_sensor_change(MagicMock())
+        assert di_sensor._deficit == pytest.approx(30.0 - 25.4, abs=0.1)
+
+    def test_rain_mm_not_converted(self, di_sensor, hass_mock, make_state):
+        """Rain in mm must not be multiplied by the inches factor."""
+        di_sensor._deficit = 10.0
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(9.0),
+            "sensor.rain": make_state(5.0, unit="mm"),
+        }[eid]
+        di_sensor._last_update = datetime.now() - timedelta(hours=1)
+        di_sensor._on_sensor_change(MagicMock())
+        assert di_sensor._deficit == pytest.approx(5.0, abs=0.1)
+
+    def test_rain_no_unit_treated_as_mm(self, di_sensor, hass_mock, make_state):
+        """Rain sensor without unit_of_measurement is treated as mm (backward compat)."""
+        di_sensor._deficit = 8.0
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(9.0),
+            "sensor.rain": make_state(3.0),  # no unit
+        }[eid]
+        di_sensor._last_update = datetime.now() - timedelta(hours=1)
+        di_sensor._on_sensor_change(MagicMock())
+        assert di_sensor._deficit == pytest.approx(5.0, abs=0.1)
+
+    def test_half_inch_rain_converts_correctly(self, di_sensor, hass_mock, make_state):
+        """0.5 in rain == 12.7 mm."""
+        di_sensor._deficit = 20.0
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(9.0),
+            "sensor.rain": make_state(0.5, unit="in"),
+        }[eid]
+        di_sensor._last_update = datetime.now() - timedelta(hours=1)
+        di_sensor._on_sensor_change(MagicMock())
+        assert di_sensor._deficit == pytest.approx(20.0 - 12.7, abs=0.1)
+
+
+class TestTemperatureUnitsEndToEnd:
+    """Deficit update is identical whether temperature is in °C or °F."""
+
+    def test_celsius_and_fahrenheit_yield_same_deficit(self, hass_mock, base_config, make_state):
+        """25 °C and 77 °F must produce the same deficit after one hour."""
+        # sensor fed in Celsius
+        di_c = DrynessIndexSensor(hass_mock, base_config)
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(25.0, unit="°C"),
+            "sensor.rain": make_state(0.0),
+        }[eid]
+        di_c._last_update = datetime.now() - timedelta(hours=1)
+        di_c._on_sensor_change(MagicMock())
+
+        # sensor fed in Fahrenheit (same physical temperature)
+        di_f = DrynessIndexSensor(hass_mock, base_config)
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(77.0, unit="°F"),  # 77 °F == 25 °C
+            "sensor.rain": make_state(0.0),
+        }[eid]
+        di_f._last_update = datetime.now() - timedelta(hours=1)
+        di_f._on_sensor_change(MagicMock())
+
+        assert di_c._deficit == pytest.approx(di_f._deficit, abs=0.001)
+
+    def test_freezing_fahrenheit_yields_zero_deficit(self, hass_mock, base_config, make_state):
+        """32 °F == 0 °C < T_base → ET = 0, deficit stays unchanged."""
+        di = DrynessIndexSensor(hass_mock, base_config)
+        di._deficit = 5.0
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(32.0, unit="°F"),
+            "sensor.rain": make_state(0.0),
+        }[eid]
+        di._last_update = datetime.now() - timedelta(hours=1)
+        di._on_sensor_change(MagicMock())
+        assert di._deficit == pytest.approx(5.0, abs=0.01)

--- a/tests/test_sensor_device_classes.py
+++ b/tests/test_sensor_device_classes.py
@@ -1,0 +1,87 @@
+"""Regression tests: every sensor that participates in SI/imperial conversion
+must declare the correct device_class so that Home Assistant can auto-convert
+the displayed unit (mm→in, L→gal, L/min→gal/min, mm/h→in/h, m²→ft²).
+
+If a device_class is accidentally removed, HA silently stops converting units
+for users who have Home Assistant configured in imperial mode.
+"""
+
+from homeassistant.components.sensor import SensorDeviceClass
+from never_dry.sensor import (
+    ZoneAreaSensor,
+    ZoneDeficitSensor,
+    ZoneDurationSensor,
+    ZoneFlowRateSensor,
+    ZoneLastDurationSensor,
+    ZoneLastVolumeSensor,
+    ZoneRainSensor,
+    ZoneSessionWaterSensor,
+    ZoneThresholdSensor,
+    ZoneYearlyWaterSensor,
+)
+
+
+class TestDeviceClassDeclarations:
+    """Every sensor class must declare the device_class that drives unit conversion."""
+
+    def test_et_sensor_precipitation_intensity(self, et_sensor):
+        """ET rate [mm/h] → HA converts to [in/h] in imperial."""
+        assert et_sensor._attr_device_class == SensorDeviceClass.PRECIPITATION_INTENSITY
+
+    def test_dryness_index_precipitation(self, di_sensor):
+        """Global deficit [mm] → HA converts to [in] in imperial."""
+        assert di_sensor._attr_device_class == SensorDeviceClass.PRECIPITATION
+
+    def test_irrigation_zone_volume_storage(self, zone_orto):
+        """Zone volume sensor [L] → HA converts to [gal] in imperial."""
+        assert zone_orto._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
+
+    def test_zone_deficit_sensor_precipitation(self, di_sensor, zone_orto):
+        """Per-zone deficit [mm] → HA converts to [in] in imperial."""
+        deficit = ZoneDeficitSensor(zone_orto)
+        assert deficit._attr_device_class == SensorDeviceClass.PRECIPITATION
+
+    def test_zone_rain_sensor_precipitation(self, di_sensor, zone_orto):
+        """Zone cumulative rain [mm] → HA converts to [in] in imperial."""
+        rain = ZoneRainSensor(zone_orto)
+        assert rain._attr_device_class == SensorDeviceClass.PRECIPITATION
+
+    def test_zone_session_water_volume_storage(self, di_sensor, zone_orto):
+        """Session water delivered [L] → HA converts to [gal] in imperial."""
+        sensor = ZoneSessionWaterSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
+
+    def test_zone_yearly_water_volume_storage(self, di_sensor, zone_orto):
+        """Yearly water delivered [L] → HA converts to [gal] in imperial."""
+        sensor = ZoneYearlyWaterSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
+
+    def test_zone_duration_sensor_duration(self, di_sensor, zone_orto):
+        """Planned irrigation duration [s] — device_class=DURATION for correct display."""
+        sensor = ZoneDurationSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.DURATION
+
+    def test_zone_last_duration_sensor_duration(self, di_sensor, zone_orto):
+        """Last session duration [s] — device_class=DURATION."""
+        sensor = ZoneLastDurationSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.DURATION
+
+    def test_zone_flow_rate_volume_flow_rate(self, di_sensor, zone_orto):
+        """Flow rate [L/min] → HA converts to [gal/min] in imperial."""
+        sensor = ZoneFlowRateSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.VOLUME_FLOW_RATE
+
+    def test_zone_last_volume_volume_storage(self, di_sensor, zone_orto):
+        """Last irrigation volume [L] → HA converts to [gal] in imperial."""
+        sensor = ZoneLastVolumeSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
+
+    def test_zone_threshold_sensor_precipitation(self, di_sensor, zone_orto):
+        """Threshold [mm] → HA converts to [in] in imperial."""
+        sensor = ZoneThresholdSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.PRECIPITATION
+
+    def test_zone_area_sensor_area(self, di_sensor, zone_orto):
+        """Zone area [m²] → HA converts to [ft²] in imperial."""
+        sensor = ZoneAreaSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.AREA


### PR DESCRIPTION
## Summary
- Fix `_compute_rain_delta` in `sensor.py`: rain sensor values in inches were passed directly as mm, inflating the rain reading by 25.4×. Now converts `in`/`inch`/`inches` → mm (multiply by 25.4); mm and unitless sensors pass through unchanged.
- Add `TestRainUnits` (4 tests): covers inches→mm conversion, mm passthrough, unitless backward-compat, and 0.5in edge case.
- Add `TestTemperatureUnitsEndToEnd` (2 tests): verifies that 25°C and 77°F yield the same deficit, and that 32°F (= 0°C, below T_base) produces zero ET.
- Add `tests/test_sensor_device_classes.py` (13 tests): regression guard ensuring every sensor class declares the correct `_attr_device_class` (PRECIPITATION, VOLUME_STORAGE, DURATION, VOLUME_FLOW_RATE, AREA, PRECIPITATION_INTENSITY). A silent removal of any device_class would break imperial unit auto-conversion for users.

## Test plan
- [ ] All 45 tests pass (`python3 -m pytest tests/test_sensor_device_classes.py tests/test_never_dry_sensor.py -v`)
- [ ] CI green