### PR TITLE
feat: full SI/imperial unit support in config flow and runtime

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -67,187 +67,249 @@ from .const import (
     SYSTEM_TYPE_MICRO_SPRINKLER,
     SYSTEM_TYPE_SPRINKLER,
 )
+from .unit_convert import (
+    LPM_TO_GPM,
+    M2_TO_FT2,
+    MM_TO_IN,
+    c_to_f,
+    sensors_input_to_metric,
+    zone_input_to_metric,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_SENSORS_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_TEMP_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain="sensor", device_class="temperature")
-        ),
-        vol.Required(CONF_RAIN_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
-        vol.Optional(CONF_RAIN_SENSOR_TYPE, default=DEFAULT_RAIN_SENSOR_TYPE): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(
-                        value=RAIN_TYPE_EVENT,
-                        label="Event-based (mm per event — tipping bucket)",
-                    ),
-                    selector.SelectOptionDict(
-                        value=RAIN_TYPE_DAILY_TOTAL,
-                        label="Daily total (cumulative mm since midnight)",
-                    ),
-                ],
-                mode="dropdown",
-            )
-        ),
-        vol.Optional(CONF_ALPHA, default=DEFAULT_ALPHA): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.05,
-                max=1.0,
-                step=0.01,
-                mode="box",
-                unit_of_measurement="mm/°C/day",
-            )
-        ),
-        vol.Optional(CONF_T_BASE, default=DEFAULT_T_BASE): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=-5.0,
-                max=20.0,
-                step=0.5,
-                mode="box",
-                unit_of_measurement="°C",
-            )
-        ),
-        vol.Optional(CONF_D_MAX, default=DEFAULT_D_MAX): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=10.0,
-                max=500.0,
-                step=10.0,
-                mode="box",
-                unit_of_measurement="mm",
-            )
-        ),
-        vol.Optional(CONF_VWC_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
-    }
-)
+# Unit-conversion helpers live in a HA-free module so they stay unit-testable.
+# Aliased here to keep the call sites below terse.
+_MM_TO_IN = MM_TO_IN
+_M2_TO_FT2 = M2_TO_FT2
+_LPM_TO_GPM = LPM_TO_GPM
+_c_to_f = c_to_f
+_sensors_input_to_metric = sensors_input_to_metric
+_zone_input_to_metric = zone_input_to_metric
 
-STEP_ZONE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_ZONE_NAME): selector.TextSelector(),
-        vol.Optional(CONF_ZONE_VALVE): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
-        vol.Optional(CONF_ZONE_DELIVERY_MODE, default=DEFAULT_DELIVERY_MODE): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(
-                        value=DELIVERY_MODE_ESTIMATED_FLOW,
-                        label="Simple on/off — timer-based (default)",
-                    ),
-                    selector.SelectOptionDict(
-                        value=DELIVERY_MODE_FLOW_METER,
-                        label="Valve with flow meter sensor",
-                    ),
-                    selector.SelectOptionDict(
-                        value=DELIVERY_MODE_VOLUME_PRESET,
-                        label="Smart valve with volume dosing",
-                    ),
-                ],
-                mode="dropdown",
-            )
-        ),
-        vol.Required(CONF_ZONE_AREA): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.1,
-                max=10000.0,
-                step=0.1,
-                mode="box",
-                unit_of_measurement="m²",
-            )
-        ),
-        vol.Required(CONF_ZONE_SYSTEM_TYPE): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(value=SYSTEM_TYPE_DRIP, label="Drip irrigation (η=0.92)"),
-                    selector.SelectOptionDict(value=SYSTEM_TYPE_MICRO_SPRINKLER, label="Micro-sprinklers (η=0.80)"),
-                    selector.SelectOptionDict(value=SYSTEM_TYPE_SPRINKLER, label="Pop-up sprinklers (η=0.68)"),
-                    selector.SelectOptionDict(value=SYSTEM_TYPE_MANUAL, label="Manual / hose (η=0.55)"),
-                ],
-                mode="dropdown",
-            )
-        ),
-        vol.Optional(CONF_ZONE_EFFICIENCY): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.1,
-                max=1.0,
-                step=0.05,
-                mode="slider",
-            )
-        ),
-        vol.Optional(CONF_ZONE_PLANT_FAMILY): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(value=key, label=data["label"]) for key, data in PLANT_FAMILIES.items()
-                ],
-                mode="dropdown",
-            )
-        ),
-        vol.Optional(CONF_ZONE_KC): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.1,
-                max=2.0,
-                step=0.05,
-                mode="box",
-            )
-        ),
-        vol.Optional(CONF_ZONE_FLOW_RATE): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.1,
-                max=200.0,
-                step=0.1,
-                mode="box",
-                unit_of_measurement="L/min",
-            )
-        ),
-        vol.Optional(CONF_ZONE_FLOW_METER_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain="sensor")
-        ),
-        vol.Optional(CONF_ZONE_VOLUME_ENTITY): selector.EntitySelector(selector.EntitySelectorConfig(domain="number")),
-        vol.Optional(CONF_ZONE_DELIVERY_TIMEOUT, default=DEFAULT_DELIVERY_TIMEOUT_S): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=60,
-                max=7200,
-                step=60,
-                mode="box",
-                unit_of_measurement="s",
-            )
-        ),
-        vol.Optional(
-            CONF_ZONE_IRRIGATION_MODE,
-            default=DEFAULT_IRRIGATION_MODE,
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(
-                        value=IRRIGATION_MODE_MANUAL,
-                        label="Manual only (button / service call)",
-                    ),
-                    selector.SelectOptionDict(
-                        value=IRRIGATION_MODE_REACTIVE,
-                        label="Reactive (irrigate when deficit > threshold)",
-                    ),
-                    selector.SelectOptionDict(
-                        value=IRRIGATION_MODE_SCHEDULED,
-                        label="Scheduled (check daily at set time)",
-                    ),
-                ],
-                mode="dropdown",
-            )
-        ),
-        vol.Optional(CONF_ZONE_THRESHOLD, default=DEFAULT_THRESHOLD): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=1.0,
-                max=100.0,
-                step=1.0,
-                mode="box",
-                unit_of_measurement="mm",
-            )
-        ),
-        vol.Optional(
-            CONF_ZONE_IRRIGATION_TIME,
-            default=DEFAULT_IRRIGATION_TIME,
-        ): selector.TimeSelector(),
-    }
-)
+
+def _is_imperial(hass) -> bool:
+    from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+    return hass.config.units is US_CUSTOMARY_SYSTEM
+
+
+def _sensors_schema(is_imperial: bool) -> vol.Schema:
+    """Sensors + ET parameters form for initial setup, unit-aware."""
+    t_unit = "°F" if is_imperial else "°C"
+    d_unit = "in" if is_imperial else "mm"
+    t_base_default = _c_to_f(DEFAULT_T_BASE) if is_imperial else DEFAULT_T_BASE
+    d_max_default = round(DEFAULT_D_MAX * _MM_TO_IN, 1) if is_imperial else DEFAULT_D_MAX
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_TEMP_SENSOR): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="sensor", device_class="temperature")
+            ),
+            vol.Required(CONF_RAIN_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
+            vol.Optional(CONF_RAIN_SENSOR_TYPE, default=DEFAULT_RAIN_SENSOR_TYPE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(
+                            value=RAIN_TYPE_EVENT,
+                            label="Event-based (per event — tipping bucket)",
+                        ),
+                        selector.SelectOptionDict(
+                            value=RAIN_TYPE_DAILY_TOTAL,
+                            label="Daily total (cumulative since midnight)",
+                        ),
+                    ],
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(CONF_ALPHA, default=DEFAULT_ALPHA): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.05,
+                    max=1.0,
+                    step=0.01,
+                    mode="box",
+                    unit_of_measurement="mm/°C/day",
+                )
+            ),
+            vol.Optional(CONF_T_BASE, default=t_base_default): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=23.0 if is_imperial else -5.0,
+                    max=68.0 if is_imperial else 20.0,
+                    step=1.0 if is_imperial else 0.5,
+                    mode="box",
+                    unit_of_measurement=t_unit,
+                )
+            ),
+            vol.Optional(CONF_D_MAX, default=d_max_default): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.5 if is_imperial else 10.0,
+                    max=20.0 if is_imperial else 500.0,
+                    step=0.5 if is_imperial else 10.0,
+                    mode="box",
+                    unit_of_measurement=d_unit,
+                )
+            ),
+            vol.Optional(CONF_VWC_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
+        }
+    )
+
+
+def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
+    """ET parameters form for options flow, with stored metric values pre-filled."""
+    t_unit = "°F" if is_imperial else "°C"
+    d_unit = "in" if is_imperial else "mm"
+    t_stored = current.get(CONF_T_BASE, DEFAULT_T_BASE)
+    d_stored = current.get(CONF_D_MAX, DEFAULT_D_MAX)
+    t_display = _c_to_f(t_stored) if is_imperial else t_stored
+    d_display = round(d_stored * _MM_TO_IN, 1) if is_imperial else d_stored
+
+    return vol.Schema(
+        {
+            vol.Optional(CONF_ALPHA, default=current.get(CONF_ALPHA, DEFAULT_ALPHA)): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.05,
+                    max=1.0,
+                    step=0.01,
+                    mode="box",
+                    unit_of_measurement="mm/°C/day",
+                )
+            ),
+            vol.Optional(CONF_T_BASE, default=t_display): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=23.0 if is_imperial else -5.0,
+                    max=68.0 if is_imperial else 20.0,
+                    step=1.0 if is_imperial else 0.5,
+                    mode="box",
+                    unit_of_measurement=t_unit,
+                )
+            ),
+            vol.Optional(CONF_D_MAX, default=d_display): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.5 if is_imperial else 10.0,
+                    max=20.0 if is_imperial else 500.0,
+                    step=0.5 if is_imperial else 10.0,
+                    mode="box",
+                    unit_of_measurement=d_unit,
+                )
+            ),
+        }
+    )
+
+
+def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
+    """Zone form for initial setup and add_zone options flow (no pre-existing values)."""
+    area_unit = "ft²" if is_imperial else "m²"
+    flow_unit = "gal/min" if is_imperial else "L/min"
+    depth_unit = "in" if is_imperial else "mm"
+    threshold_default = round(DEFAULT_THRESHOLD * _MM_TO_IN, 1) if is_imperial else DEFAULT_THRESHOLD
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_ZONE_NAME): selector.TextSelector(),
+            vol.Optional(CONF_ZONE_VALVE): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+            vol.Optional(CONF_ZONE_DELIVERY_MODE, default=DEFAULT_DELIVERY_MODE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(
+                            value=DELIVERY_MODE_ESTIMATED_FLOW,
+                            label="Simple on/off — timer-based (default)",
+                        ),
+                        selector.SelectOptionDict(
+                            value=DELIVERY_MODE_FLOW_METER,
+                            label="Valve with flow meter sensor",
+                        ),
+                        selector.SelectOptionDict(
+                            value=DELIVERY_MODE_VOLUME_PRESET,
+                            label="Smart valve with volume dosing",
+                        ),
+                    ],
+                    mode="dropdown",
+                )
+            ),
+            vol.Required(CONF_ZONE_AREA): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1.0 if is_imperial else 0.1,
+                    max=107000.0 if is_imperial else 10000.0,
+                    step=1.0 if is_imperial else 0.1,
+                    mode="box",
+                    unit_of_measurement=area_unit,
+                )
+            ),
+            vol.Required(CONF_ZONE_SYSTEM_TYPE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(value=SYSTEM_TYPE_DRIP, label="Drip irrigation (η=0.92)"),
+                        selector.SelectOptionDict(value=SYSTEM_TYPE_MICRO_SPRINKLER, label="Micro-sprinklers (η=0.80)"),
+                        selector.SelectOptionDict(value=SYSTEM_TYPE_SPRINKLER, label="Pop-up sprinklers (η=0.68)"),
+                        selector.SelectOptionDict(value=SYSTEM_TYPE_MANUAL, label="Manual / hose (η=0.55)"),
+                    ],
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(CONF_ZONE_EFFICIENCY): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=0.1, max=1.0, step=0.05, mode="slider")
+            ),
+            vol.Optional(CONF_ZONE_PLANT_FAMILY): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(value=key, label=data["label"])
+                        for key, data in PLANT_FAMILIES.items()
+                    ],
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(CONF_ZONE_KC): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=0.1, max=2.0, step=0.05, mode="box")
+            ),
+            vol.Optional(CONF_ZONE_FLOW_RATE): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.03 if is_imperial else 0.1,
+                    max=53.0 if is_imperial else 200.0,
+                    step=0.01 if is_imperial else 0.1,
+                    mode="box",
+                    unit_of_measurement=flow_unit,
+                )
+            ),
+            vol.Optional(CONF_ZONE_FLOW_METER_SENSOR): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="sensor")
+            ),
+            vol.Optional(CONF_ZONE_VOLUME_ENTITY): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="number")
+            ),
+            vol.Optional(CONF_ZONE_DELIVERY_TIMEOUT, default=DEFAULT_DELIVERY_TIMEOUT_S): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=60, max=7200, step=60, mode="box", unit_of_measurement="s")
+            ),
+            vol.Optional(CONF_ZONE_IRRIGATION_MODE, default=DEFAULT_IRRIGATION_MODE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(
+                            value=IRRIGATION_MODE_MANUAL,
+                            label="Manual only (button / service call)",
+                        ),
+                        selector.SelectOptionDict(
+                            value=IRRIGATION_MODE_REACTIVE,
+                            label="Reactive (irrigate when deficit > threshold)",
+                        ),
+                        selector.SelectOptionDict(
+                            value=IRRIGATION_MODE_SCHEDULED,
+                            label="Scheduled (check daily at set time)",
+                        ),
+                    ],
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(CONF_ZONE_THRESHOLD, default=threshold_default): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.1 if is_imperial else 1.0,
+                    max=4.0 if is_imperial else 100.0,
+                    step=0.1 if is_imperial else 1.0,
+                    mode="box",
+                    unit_of_measurement=depth_unit,
+                )
+            ),
+            vol.Optional(CONF_ZONE_IRRIGATION_TIME, default=DEFAULT_IRRIGATION_TIME): selector.TimeSelector(),
+        }
+    )
 
 
 def _coerce_delivery_mode(user_input: dict) -> dict:
@@ -273,17 +335,19 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Step 1: Select sensors and ET model parameters."""
+        imperial = _is_imperial(self.hass)
         if user_input is not None:
-            self._data = user_input
+            self._data = _sensors_input_to_metric(user_input, imperial)
             return await self.async_step_zone()
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_SENSORS_SCHEMA,
+            data_schema=_sensors_schema(imperial),
         )
 
     async def async_step_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Step 2: Add an irrigation zone."""
+        imperial = _is_imperial(self.hass)
         errors: dict[str, str] = {}
         if user_input is not None:
             name = user_input.get(CONF_ZONE_NAME, "")
@@ -299,12 +363,12 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
                 errors[CONF_ZONE_VOLUME_ENTITY] = "volume_entity_required"
             else:
-                self._zones.append(user_input)
+                self._zones.append(_zone_input_to_metric(user_input, imperial))
                 return await self.async_step_add_another()
 
         return self.async_show_form(
             step_id="zone",
-            data_schema=STEP_ZONE_SCHEMA,
+            data_schema=_zone_schema_initial(imperial),
             errors=errors,
             description_placeholders={
                 "zone_count": str(len(self._zones)),
@@ -364,7 +428,9 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Edit ET model parameters."""
+        imperial = _is_imperial(self.hass)
         if user_input is not None:
+            user_input = _sensors_input_to_metric(user_input, imperial)
             new_data = {**self._config_entry.data, **user_input}
             if new_data != dict(self._config_entry.data):
                 changed = [k for k in new_data if new_data[k] != self._config_entry.data.get(k)]
@@ -372,54 +438,16 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
             return self.async_create_entry(data={})
 
-        current = self._config_entry.data
         return self.async_show_form(
             step_id="model_params",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_ALPHA,
-                        default=current.get(CONF_ALPHA, DEFAULT_ALPHA),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=0.05,
-                            max=1.0,
-                            step=0.01,
-                            mode="box",
-                            unit_of_measurement="mm/°C/day",
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_T_BASE,
-                        default=current.get(CONF_T_BASE, DEFAULT_T_BASE),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=-5.0,
-                            max=20.0,
-                            step=0.5,
-                            mode="box",
-                            unit_of_measurement="°C",
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_D_MAX,
-                        default=current.get(CONF_D_MAX, DEFAULT_D_MAX),
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=10.0,
-                            max=500.0,
-                            step=10.0,
-                            mode="box",
-                            unit_of_measurement="mm",
-                        )
-                    ),
-                }
-            ),
+            data_schema=_model_params_schema(imperial, self._config_entry.data),
         )
 
     async def async_step_add_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Add a new irrigation zone."""
+        imperial = _is_imperial(self.hass)
         if user_input is not None:
+            user_input = _zone_input_to_metric(user_input, imperial)
             user_input = _coerce_delivery_mode(user_input)
             new_data = dict(self._config_entry.data)
             zones = list(new_data.get(CONF_ZONES, []))
@@ -429,7 +457,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             if new_name in existing_names:
                 return self.async_show_form(
                     step_id="add_zone",
-                    data_schema=STEP_ZONE_SCHEMA,
+                    data_schema=_zone_schema_initial(imperial),
                     errors={"base": "zone_already_exists"},
                 )
             zones.append(user_input)
@@ -441,7 +469,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="add_zone",
-            data_schema=STEP_ZONE_SCHEMA,
+            data_schema=_zone_schema_initial(imperial),
         )
 
     async def async_step_edit_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
@@ -481,7 +509,9 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             {},
         )
 
+        imperial = _is_imperial(self.hass)
         if user_input is not None:
+            user_input = _zone_input_to_metric(user_input, imperial)
             user_input = _coerce_delivery_mode(user_input)
             new_data = dict(self._config_entry.data)
             new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
@@ -495,9 +525,27 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 )
             return self.async_create_entry(data={})
 
+        area_unit = "ft²" if imperial else "m²"
+        flow_unit = "gal/min" if imperial else "L/min"
+        depth_unit = "in" if imperial else "mm"
+
         # Helper to get current value or UNDEFINED
         def _d(key, fallback=vol.UNDEFINED):
             return cur.get(key, fallback)
+
+        def _d_area(fallback):
+            v = cur.get(CONF_ZONE_AREA, fallback)
+            return round(v * _M2_TO_FT2, 1) if (imperial and v is not None) else v
+
+        def _d_flow():
+            v = cur.get(CONF_ZONE_FLOW_RATE)
+            if v is None:
+                return vol.UNDEFINED
+            return round(v * _LPM_TO_GPM, 2) if imperial else v
+
+        def _d_threshold(fallback):
+            v = cur.get(CONF_ZONE_THRESHOLD, fallback)
+            return round(v * _MM_TO_IN, 1) if (imperial and v is not None) else v
 
         dm_opts = [
             selector.SelectOptionDict(
@@ -557,14 +605,14 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Required(
                     CONF_ZONE_AREA,
-                    default=_d(CONF_ZONE_AREA, 10.0),
+                    default=_d_area(10.0),
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=0.1,
-                        max=10000.0,
-                        step=0.1,
+                        min=1.0 if imperial else 0.1,
+                        max=107000.0 if imperial else 10000.0,
+                        step=1.0 if imperial else 0.1,
                         mode="box",
-                        unit_of_measurement="m²",
+                        unit_of_measurement=area_unit,
                     )
                 ),
                 vol.Required(
@@ -609,14 +657,14 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_ZONE_FLOW_RATE,
-                    default=_d(CONF_ZONE_FLOW_RATE),
+                    default=_d_flow(),
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=0.1,
-                        max=200.0,
-                        step=0.1,
+                        min=0.03 if imperial else 0.1,
+                        max=53.0 if imperial else 200.0,
+                        step=0.01 if imperial else 0.1,
                         mode="box",
-                        unit_of_measurement="L/min",
+                        unit_of_measurement=flow_unit,
                     )
                 ),
                 vol.Optional(
@@ -669,14 +717,14 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_ZONE_THRESHOLD,
-                    default=_d(CONF_ZONE_THRESHOLD, DEFAULT_THRESHOLD),
+                    default=_d_threshold(DEFAULT_THRESHOLD),
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(
-                        min=1.0,
-                        max=100.0,
-                        step=1.0,
+                        min=0.1 if imperial else 1.0,
+                        max=4.0 if imperial else 100.0,
+                        step=0.1 if imperial else 1.0,
                         mode="box",
-                        unit_of_measurement="mm",
+                        unit_of_measurement=depth_unit,
                     )
                 ),
                 vol.Optional(

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -53,6 +53,7 @@ from .valve_operator import OperationStatus, ValveOperator
 
 MONITORING_INTERVAL = 6 * 3600  # 6 hours in seconds
 AUTO_OPEN_GRACE_S = 3.0  # volume_preset: wait this long for smart-valve auto-open
+_GALLON_TO_LITER = 3.785411784  # US liquid gallon → liters
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -811,8 +812,8 @@ class IrrigationController:
             # Flow rate mode: accumulate volume from rate readings
             return await self._deliver_flow_rate(zone, meter_entity, volume_target)
 
-        # Cumulative volume mode: read difference
-        initial_reading = self._read_flow_meter(meter_entity)
+        # Cumulative volume mode: read difference (normalized to liters)
+        initial_reading = self._read_volume_liters(meter_entity)
         if initial_reading is None:
             _LOGGER.error(
                 "Flow meter '%s' unavailable for zone '%s', skipping",
@@ -839,7 +840,7 @@ class IrrigationController:
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
 
-            current_reading = self._read_flow_meter(meter_entity)
+            current_reading = self._read_volume_liters(meter_entity)
             if current_reading is None:
                 _LOGGER.warning(
                     "Flow meter '%s' became unavailable during irrigation of zone '%s'",
@@ -913,15 +914,11 @@ class IrrigationController:
             if rate is None or rate < 0:
                 continue
 
-            # Convert rate to L per poll interval
+            # Normalize rate to L/min (handles metric + imperial), then
+            # integrate over the poll interval.
             unit = self._get_flow_meter_unit(meter_entity)
-            if unit in ("L/min", "l/min"):
-                delivered += rate / 60 * FLOW_METER_POLL_INTERVAL_S
-            elif unit in ("m³/h",):
-                delivered += rate * 1000 / 3600 * FLOW_METER_POLL_INTERVAL_S
-            else:
-                # L/h or default
-                delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
+            lpm = self._rate_to_lpm(rate, unit)
+            delivered += lpm / 60 * FLOW_METER_POLL_INTERVAL_S
 
             # Real-time deficit update (snapshot-based — idempotent with settle).
             self._update_deficit_realtime(zone, delivered)
@@ -948,9 +945,20 @@ class IrrigationController:
         return delivered
 
     def _is_flow_rate_sensor(self, entity_id: str) -> bool:
-        """Check if the sensor reports a flow rate (not cumulative volume)."""
-        unit = self._get_flow_meter_unit(entity_id)
-        return unit in ("L/h", "l/h", "L/min", "l/min", "m³/h")
+        """Check if the sensor reports a flow rate (not cumulative volume).
+
+        Recognizes both metric (L/h, L/min, m³/h) and imperial (gal/min,
+        gal/h) units. When Home Assistant runs in US-customary mode, ZHA
+        flow sensors are exposed in gallons, so these must be detected too.
+        """
+        unit = (self._get_flow_meter_unit(entity_id) or "").lower()
+        return unit in (
+            "l/h",
+            "l/min",
+            "m³/h",
+            "gal/min",
+            "gal/h",
+        )
 
     def _get_flow_meter_unit(self, entity_id: str) -> str | None:
         """Get the unit of measurement of a flow meter sensor."""
@@ -968,6 +976,58 @@ class IrrigationController:
             return float(state.state)
         except (ValueError, TypeError):
             return None
+
+    def _read_volume_liters(self, entity_id: str) -> float | None:
+        """Read a cumulative-volume sensor and normalize to liters in one fetch.
+
+        Reads value and unit from a single ``states.get`` so the result is
+        consistent and imperial (gallons) readings are converted to liters.
+        """
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None
+        try:
+            value = float(state.state)
+        except (ValueError, TypeError):
+            return None
+        return self._volume_to_liters(value, state.attributes.get("unit_of_measurement"))
+
+    @staticmethod
+    def _rate_to_lpm(rate: float, unit: str | None) -> float:
+        """Normalize a flow-rate reading to liters per minute.
+
+        Handles metric (L/min, L/h, m³/h) and imperial (gal/min, gal/h)
+        units. When HA runs in US-customary mode the underlying ZHA sensor
+        is exposed in gallons, so the raw value must be converted before it
+        is integrated into a delivered volume.
+        """
+        u = (unit or "").lower()
+        if u == "l/min":
+            return rate
+        if u == "l/h":
+            return rate / 60.0
+        if u == "m³/h":
+            return rate * 1000.0 / 60.0
+        if u == "gal/min":
+            return rate * _GALLON_TO_LITER
+        if u == "gal/h":
+            return rate * _GALLON_TO_LITER / 60.0
+        # Unknown unit: assume already L/h (legacy default).
+        return rate / 60.0
+
+    @staticmethod
+    def _volume_to_liters(value: float, unit: str | None) -> float:
+        """Normalize a cumulative-volume reading to liters.
+
+        Converts gallons → liters when the sensor is exposed in US-customary
+        units; passes metric volumes through unchanged.
+        """
+        u = (unit or "").lower()
+        if u in ("gal", "gallon", "gallons"):
+            return value * _GALLON_TO_LITER
+        if u == "m³":
+            return value * 1000.0
+        return value
 
     # ── Deficit live-update helper ────────────────────────
 
@@ -1142,8 +1202,8 @@ class IrrigationController:
                     # For rate sensors, record open timestamp
                     self._manual_valve_open[entity_id] = time.monotonic()
                 else:
-                    # For cumulative sensors, record current reading
-                    self._manual_valve_open[entity_id] = self._read_flow_meter(zone.flow_meter_sensor)
+                    # For cumulative sensors, record current reading (in liters)
+                    self._manual_valve_open[entity_id] = self._read_volume_liters(zone.flow_meter_sensor)
             else:
                 self._manual_valve_open[entity_id] = None
             # Snapshot for the SESSION_RESULT log emitted at manual close.
@@ -1186,17 +1246,13 @@ class IrrigationController:
                     current_rate = self._read_flow_meter(zone.flow_meter_sensor)
                     if current_rate is not None and current_rate > 0:
                         unit = self._get_flow_meter_unit(zone.flow_meter_sensor)
-                        if unit in ("L/min", "l/min"):
-                            delivered_liters = current_rate / 60 * duration_s
-                        elif unit in ("m³/h",):
-                            delivered_liters = current_rate * 1000 / 3600 * duration_s
-                        else:  # L/h or default
-                            delivered_liters = current_rate / 3600 * duration_s
+                        lpm = self._rate_to_lpm(current_rate, unit)
+                        delivered_liters = lpm / 60 * duration_s
                     else:
                         delivered_liters = 0.0
                 else:
-                    # Cumulative: simple difference
-                    flow_end = self._read_flow_meter(zone.flow_meter_sensor)
+                    # Cumulative: simple difference (baseline already in liters)
+                    flow_end = self._read_volume_liters(zone.flow_meter_sensor)
                     delivered_liters = max(0.0, flow_end - baseline) if flow_end is not None else 0.0
 
                 if delivered_liters > 0 and zone._area > 0:
@@ -1357,12 +1413,8 @@ class IrrigationController:
                 rate = self._read_flow_meter(meter)
                 if rate is None or rate < 0:
                     continue
-                if unit in ("L/min", "l/min"):
-                    delivered += rate / 60 * FLOW_METER_POLL_INTERVAL_S
-                elif unit in ("m³/h",):
-                    delivered += rate * 1000 / 3600 * FLOW_METER_POLL_INTERVAL_S
-                else:
-                    delivered += rate / 3600 * FLOW_METER_POLL_INTERVAL_S
+                lpm = self._rate_to_lpm(rate, unit)
+                delivered += lpm / 60 * FLOW_METER_POLL_INTERVAL_S
                 if delivered >= volume_target:
                     _LOGGER.info(
                         "Manual valve '%s' reached target (%.1fL of %.1fL) via flow rate",
@@ -1380,7 +1432,7 @@ class IrrigationController:
             )
             return
 
-        initial = self._read_flow_meter(meter)
+        initial = self._read_volume_liters(meter)
         if initial is None:
             _LOGGER.warning(
                 "Manual valve '%s': flow meter unavailable at open, falling back to timeout=%ds",
@@ -1392,7 +1444,7 @@ class IrrigationController:
         while elapsed < timeout_s:
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
-            current = self._read_flow_meter(meter)
+            current = self._read_volume_liters(meter)
             if current is None:
                 continue
             delivered = current - initial

--- a/custom_components/never_dry/unit_convert.py
+++ b/custom_components/never_dry/unit_convert.py
@@ -1,0 +1,62 @@
+"""Pure unit-conversion helpers for the config flow.
+
+NeverDry always stores and computes in metric (mm, m², L, L/min, °C). When
+Home Assistant runs in US-customary mode the config flow shows imperial labels
+and must convert user input back to metric before persisting it. These helpers
+are deliberately free of any Home Assistant import so they can be unit-tested
+in isolation.
+"""
+
+from __future__ import annotations
+
+from .const import (
+    CONF_D_MAX,
+    CONF_T_BASE,
+    CONF_ZONE_AREA,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_THRESHOLD,
+)
+
+# ── Conversion factors ─────────────────────────────────────
+MM_TO_IN = 1.0 / 25.4
+IN_TO_MM = 25.4
+M2_TO_FT2 = 10.7639
+FT2_TO_M2 = 1.0 / 10.7639
+LPM_TO_GPM = 0.264172
+GPM_TO_LPM = 1.0 / 0.264172
+
+
+def c_to_f(celsius: float) -> float:
+    """Celsius → Fahrenheit, rounded to 0.1°."""
+    return round(celsius * 9 / 5 + 32, 1)
+
+
+def f_to_c(fahrenheit: float) -> float:
+    """Fahrenheit → Celsius."""
+    return (fahrenheit - 32) * 5 / 9
+
+
+def sensors_input_to_metric(user_input: dict, is_imperial: bool) -> dict:
+    """Convert T_base °F→°C and D_max in→mm when the form was shown in imperial."""
+    if not is_imperial:
+        return user_input
+    out = dict(user_input)
+    if out.get(CONF_T_BASE) is not None:
+        out[CONF_T_BASE] = f_to_c(out[CONF_T_BASE])
+    if out.get(CONF_D_MAX) is not None:
+        out[CONF_D_MAX] = out[CONF_D_MAX] * IN_TO_MM
+    return out
+
+
+def zone_input_to_metric(user_input: dict, is_imperial: bool) -> dict:
+    """Convert area ft²→m², flow_rate gal/min→L/min, threshold in→mm when imperial."""
+    if not is_imperial:
+        return user_input
+    out = dict(user_input)
+    if out.get(CONF_ZONE_AREA) is not None:
+        out[CONF_ZONE_AREA] = out[CONF_ZONE_AREA] * FT2_TO_M2
+    if out.get(CONF_ZONE_FLOW_RATE) is not None:
+        out[CONF_ZONE_FLOW_RATE] = out[CONF_ZONE_FLOW_RATE] * GPM_TO_LPM
+    if out.get(CONF_ZONE_THRESHOLD) is not None:
+        out[CONF_ZONE_THRESHOLD] = out[CONF_ZONE_THRESHOLD] * IN_TO_MM
+    return out

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -1,0 +1,121 @@
+"""Consistency guard: every ``translation_key`` used by a SelectSelector in
+``config_flow.py`` must have matching entries in ``translations/en.json``.
+
+Home Assistant lets a SelectSelector replace inline option labels with a
+``translation_key`` that resolves human-readable text from the translation
+files (``selector.<key>.options.<value>``). If the key is referenced but the
+translation file lacks the corresponding ``selector`` entries, the dropdown
+silently shows the raw option values (e.g. ``estimated_flow``) instead of a
+label — a UX regression that no other test catches.
+
+This test parses ``config_flow.py`` statically (via ``ast``, no HA import) and
+fails when a referenced ``translation_key`` is missing options in ``en.json``.
+It is intentionally a no-op while the config flow uses inline labels; it
+activates the moment someone migrates a selector to ``translation_key``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from never_dry import const
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry"
+_CONFIG_FLOW = _COMPONENT / "config_flow.py"
+_EN_JSON = _COMPONENT / "translations" / "en.json"
+
+
+def _resolve_options(node: ast.AST) -> set[str] | None:
+    """Resolve a SelectSelectorConfig ``options=`` argument to its string values.
+
+    Returns ``None`` when the expression cannot be resolved statically, so the
+    caller can fail loudly rather than pass a false negative.
+    """
+    # options=[CONST_A, CONST_B] or [SelectOptionDict(value=CONST, ...), ...]
+    if isinstance(node, ast.List):
+        values: set[str] = set()
+        for elt in node.elts:
+            if isinstance(elt, ast.Name):
+                values.add(getattr(const, elt.id))
+            elif isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                values.add(elt.value)
+            elif isinstance(elt, ast.Call):
+                # SelectOptionDict(value=..., label=...)
+                value_kw = next((kw for kw in elt.keywords if kw.arg == "value"), None)
+                if value_kw is None:
+                    return None
+                if isinstance(value_kw.value, ast.Name):
+                    values.add(getattr(const, value_kw.value.id))
+                elif isinstance(value_kw.value, ast.Constant):
+                    values.add(value_kw.value.value)
+                else:
+                    return None
+            else:
+                return None
+        return values
+    # options=list(PLANT_FAMILIES.keys()) / list(PLANT_FAMILIES) etc.
+    if isinstance(node, ast.Call):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and hasattr(const, sub.id):
+                resolved = getattr(const, sub.id)
+                if isinstance(resolved, dict):
+                    return set(resolved.keys())
+    # options=[SelectOptionDict(value=k, ...) for k, v in PLANT_FAMILIES.items()]
+    if isinstance(node, ast.ListComp):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and hasattr(const, sub.id):
+                resolved = getattr(const, sub.id)
+                if isinstance(resolved, dict):
+                    return set(resolved.keys())
+    return None
+
+
+def _collect_translation_keyed_selectors() -> list[tuple[str, set[str] | None]]:
+    tree = ast.parse(_CONFIG_FLOW.read_text())
+    out: list[tuple[str, set[str] | None]] = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "SelectSelectorConfig"
+        ):
+            continue
+        tk_kw = next((kw for kw in node.keywords if kw.arg == "translation_key"), None)
+        if tk_kw is None or not isinstance(tk_kw.value, ast.Constant):
+            continue
+        opt_kw = next((kw for kw in node.keywords if kw.arg == "options"), None)
+        options = _resolve_options(opt_kw.value) if opt_kw is not None else None
+        out.append((tk_kw.value.value, options))
+    return out
+
+
+def test_translation_keys_have_matching_options_in_en_json():
+    """Each translation_key selector must have all its options translated."""
+    selectors = _collect_translation_keyed_selectors()
+    if not selectors:
+        # Config flow uses inline labels — nothing to validate (guard is dormant).
+        return
+
+    en = json.loads(_EN_JSON.read_text())
+    selector_section = en.get("selector", {})
+
+    errors: list[str] = []
+    for translation_key, options in selectors:
+        entry = selector_section.get(translation_key)
+        if entry is None:
+            errors.append(f"translation_key '{translation_key}' missing from en.json 'selector' section")
+            continue
+        translated = set(entry.get("options", {}).keys())
+        if options is None:
+            errors.append(
+                f"translation_key '{translation_key}': options could not be resolved statically — "
+                "extend _resolve_options() in this test"
+            )
+            continue
+        missing = options - translated
+        if missing:
+            errors.append(f"translation_key '{translation_key}' missing option labels in en.json: {sorted(missing)}")
+
+    assert not errors, "Selector translation inconsistencies:\n  " + "\n  ".join(errors)

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -1,0 +1,161 @@
+"""Unit-system conversion tests for the config flow (UI ↔ metric storage) and
+the controller (imperial flow/volume sensor readings → liters).
+
+NeverDry always stores and computes in metric. When Home Assistant runs in
+US-customary mode the config flow must show imperial labels and convert user
+input back to metric, and the controller must convert imperial sensor readings
+(gal/min, gal) into liters before integrating them into delivered volume.
+"""
+
+import pytest
+from never_dry.const import (
+    CONF_D_MAX,
+    CONF_T_BASE,
+    CONF_ZONE_AREA,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_THRESHOLD,
+)
+from never_dry.controller import IrrigationController
+from never_dry.unit_convert import (
+    c_to_f as _c_to_f,
+)
+from never_dry.unit_convert import (
+    f_to_c as _f_to_c,
+)
+from never_dry.unit_convert import (
+    sensors_input_to_metric as _sensors_input_to_metric,
+)
+from never_dry.unit_convert import (
+    zone_input_to_metric as _zone_input_to_metric,
+)
+
+
+class TestTemperatureConversion:
+    def test_c_to_f_freezing(self):
+        assert _c_to_f(0.0) == 32.0
+
+    def test_c_to_f_body(self):
+        assert _c_to_f(25.0) == 77.0
+
+    def test_f_to_c_roundtrip(self):
+        assert _f_to_c(_c_to_f(9.0)) == pytest.approx(9.0, abs=0.01)
+
+    def test_f_to_c_freezing(self):
+        assert _f_to_c(32.0) == pytest.approx(0.0, abs=0.01)
+
+
+class TestSensorsInputToMetric:
+    def test_metric_passthrough(self):
+        data = {CONF_T_BASE: 9.0, CONF_D_MAX: 100.0}
+        assert _sensors_input_to_metric(data, is_imperial=False) == data
+
+    def test_t_base_fahrenheit_converted(self):
+        out = _sensors_input_to_metric({CONF_T_BASE: 77.0}, is_imperial=True)
+        assert out[CONF_T_BASE] == pytest.approx(25.0, abs=0.01)
+
+    def test_d_max_inches_converted(self):
+        out = _sensors_input_to_metric({CONF_D_MAX: 4.0}, is_imperial=True)
+        assert out[CONF_D_MAX] == pytest.approx(101.6, abs=0.01)
+
+    def test_none_values_untouched(self):
+        out = _sensors_input_to_metric({CONF_T_BASE: None}, is_imperial=True)
+        assert out[CONF_T_BASE] is None
+
+    def test_does_not_mutate_input(self):
+        data = {CONF_T_BASE: 77.0}
+        _sensors_input_to_metric(data, is_imperial=True)
+        assert data[CONF_T_BASE] == 77.0
+
+
+class TestZoneInputToMetric:
+    def test_metric_passthrough(self):
+        data = {CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 8.0, CONF_ZONE_THRESHOLD: 20.0}
+        assert _zone_input_to_metric(data, is_imperial=False) == data
+
+    def test_area_ft2_to_m2(self):
+        out = _zone_input_to_metric({CONF_ZONE_AREA: 107.639}, is_imperial=True)
+        assert out[CONF_ZONE_AREA] == pytest.approx(10.0, abs=0.01)
+
+    def test_flow_rate_gpm_to_lpm(self):
+        out = _zone_input_to_metric({CONF_ZONE_FLOW_RATE: 1.0}, is_imperial=True)
+        # 1 gal/min ≈ 3.785 L/min
+        assert out[CONF_ZONE_FLOW_RATE] == pytest.approx(3.785, abs=0.01)
+
+    def test_threshold_in_to_mm(self):
+        out = _zone_input_to_metric({CONF_ZONE_THRESHOLD: 1.0}, is_imperial=True)
+        assert out[CONF_ZONE_THRESHOLD] == pytest.approx(25.4, abs=0.01)
+
+    def test_does_not_mutate_input(self):
+        data = {CONF_ZONE_AREA: 100.0}
+        _zone_input_to_metric(data, is_imperial=True)
+        assert data[CONF_ZONE_AREA] == 100.0
+
+
+class TestControllerRateToLpm:
+    def test_lpm_passthrough(self):
+        assert IrrigationController._rate_to_lpm(10.0, "L/min") == 10.0
+
+    def test_lph_to_lpm(self):
+        assert IrrigationController._rate_to_lpm(60.0, "L/h") == pytest.approx(1.0)
+
+    def test_m3h_to_lpm(self):
+        # 1 m³/h = 1000 L / 60 min ≈ 16.667 L/min
+        assert IrrigationController._rate_to_lpm(1.0, "m³/h") == pytest.approx(16.667, abs=0.01)
+
+    def test_gpm_to_lpm(self):
+        # 1 gal/min ≈ 3.785 L/min
+        assert IrrigationController._rate_to_lpm(1.0, "gal/min") == pytest.approx(3.785, abs=0.01)
+
+    def test_gph_to_lpm(self):
+        # 60 gal/h = 1 gal/min ≈ 3.785 L/min
+        assert IrrigationController._rate_to_lpm(60.0, "gal/h") == pytest.approx(3.785, abs=0.01)
+
+    def test_case_insensitive(self):
+        assert IrrigationController._rate_to_lpm(10.0, "GAL/MIN") == pytest.approx(37.854, abs=0.01)
+
+    def test_unknown_unit_defaults_to_lph(self):
+        # Legacy default: treat unknown as L/h
+        assert IrrigationController._rate_to_lpm(60.0, "weird") == pytest.approx(1.0)
+
+
+class TestControllerVolumeToLiters:
+    def test_liters_passthrough(self):
+        assert IrrigationController._volume_to_liters(50.0, "L") == 50.0
+
+    def test_none_unit_passthrough(self):
+        assert IrrigationController._volume_to_liters(50.0, None) == 50.0
+
+    def test_gallons_to_liters(self):
+        assert IrrigationController._volume_to_liters(1.0, "gal") == pytest.approx(3.785, abs=0.01)
+
+    def test_gallons_plural(self):
+        assert IrrigationController._volume_to_liters(2.0, "gallons") == pytest.approx(7.571, abs=0.01)
+
+    def test_cubic_meters_to_liters(self):
+        assert IrrigationController._volume_to_liters(1.0, "m³") == 1000.0
+
+    def test_case_insensitive(self):
+        assert IrrigationController._volume_to_liters(1.0, "GAL") == pytest.approx(3.785, abs=0.01)
+
+
+class TestImperialFlowMeterIsRate:
+    """The controller must recognize imperial flow-rate units as rate sensors."""
+
+    def _make_ctrl(self, hass_mock, di_sensor, unit):
+        from unittest.mock import MagicMock
+
+        state = MagicMock(state="5.0", attributes={"unit_of_measurement": unit})
+        hass_mock.states.get = MagicMock(return_value=state)
+        return IrrigationController(hass_mock, di_sensor, [], inter_zone_delay=0)
+
+    def test_gal_min_detected_as_rate(self, hass_mock, di_sensor):
+        ctrl = self._make_ctrl(hass_mock, di_sensor, "gal/min")
+        assert ctrl._is_flow_rate_sensor("sensor.flow") is True
+
+    def test_gal_h_detected_as_rate(self, hass_mock, di_sensor):
+        ctrl = self._make_ctrl(hass_mock, di_sensor, "gal/h")
+        assert ctrl._is_flow_rate_sensor("sensor.flow") is True
+
+    def test_gallons_cumulative_not_rate(self, hass_mock, di_sensor):
+        ctrl = self._make_ctrl(hass_mock, di_sensor, "gal")
+        assert ctrl._is_flow_rate_sensor("sensor.flow") is False


### PR DESCRIPTION
## Problem
A user running Home Assistant in US-customary mode saw **metric-only fields** in the NeverDry config flow (mm, m², L/min), forcing mental conversion. Worse, at runtime a flow meter exposed in **gal/min** was misread as cumulative volume, corrupting the delivered-volume calculation by a factor of ~3.8.

## Approach
NeverDry keeps its **metric-internal** convention (FAO-56 / Hargreaves–Samani are metric, hot path stays conversion-free). Imperial support is added **only at the edges**:

### Config flow UI (`config_flow.py` + new `unit_convert.py`)
- Detects `hass.config.units`; in US-customary mode renders imperial labels and bounds (°F, in, ft², gal/min) for `T_base`, `D_max`, area, flow_rate, threshold.
- Edit forms pre-fill by converting stored metric → display unit; input is converted back to metric on submit.
- **No config-entry migration needed** — storage stays metric regardless of the user's unit system.
- Pure conversion helpers extracted into a HA-free `unit_convert.py` so they're unit-testable in isolation.

### Controller runtime (`controller.py`)
- `_is_flow_rate_sensor` now recognizes `gal/min` / `gal/h` as rate sensors.
- New `_rate_to_lpm` / `_volume_to_liters` normalize imperial readings to L/min and L across **all** delivery paths (commanded, manual, external monitor).
- `_read_volume_liters` reads value + unit in a single `states.get` for consistency (gallons ×3.785, m³ ×1000).

## Tests
- New `tests/test_unit_conversions.py` — 30 tests covering every conversion helper and imperial flow-sensor recognition.
- Full suite: **580 passing**, ruff check + format clean.

## Docs
Engineering doc `documents/04_software_engineering/01_never_dry.tex` gains a *"Unit System Handling (SI / Imperial)"* section (committed separately in the documents repo).

## Note
Independent of #82 (SI/imperial regression tests); both branch off `main` and can merge in any order.