### PR TITLE
fix: clean up zone device on deletion to unblock uninstall

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -7,6 +7,8 @@ water balance model.  Directly controls irrigation valves.
 Supports both YAML configuration and UI-based config flow.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import logging.handlers
@@ -15,9 +17,25 @@ import pathlib
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONFIG_VERSION, DOMAIN
+from .const import CONF_ZONE_NAME, CONF_ZONES, CONFIG_VERSION, DOMAIN
+
+
+def zone_slug(zone_name: str) -> str:
+    """Slug used to build a zone device identifier.
+
+    Must stay in sync with the slug used in sensor.py / button.py
+    DeviceInfo identifiers: ``(DOMAIN, f"{entry_id}_{slug}")``.
+    """
+    return zone_name.lower().replace(" ", "_")
+
+
+def zone_device_identifier(entry_id: str, zone_name: str) -> tuple[str, str]:
+    """Device-registry identifier for a zone device."""
+    return (DOMAIN, f"{entry_id}_{zone_slug(zone_name)}")
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,3 +164,23 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         hass.data[DOMAIN].pop(f"_operators_{entry.entry_id}", None)
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device: dr.DeviceEntry,
+) -> bool:
+    """Allow manual deletion of stale zone devices from the UI.
+
+    Returning True re-enables the "Delete device" button in Home Assistant.
+    We allow removal of any device whose identifier no longer maps to a
+    currently configured zone (orphans left behind after a zone was removed).
+    The hub device and devices belonging to still-configured zones are kept.
+    """
+    valid_identifiers = {(DOMAIN, entry.entry_id)}  # hub device
+    for zone in entry.data.get(CONF_ZONES, []):
+        valid_identifiers.add(zone_device_identifier(entry.entry_id, zone[CONF_ZONE_NAME]))
+
+    # Removable only if NONE of the device identifiers match a live zone/hub.
+    return not any(identifier in valid_identifiers for identifier in device.identifiers)

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -14,8 +14,10 @@ from typing import Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import selector
 
+from . import zone_device_identifier
 from .const import (
     CONF_ALPHA,
     CONF_D_MAX,
@@ -743,6 +745,20 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             description_placeholders={"zone_name": self._edit_zone_name},
         )
 
+    def _remove_zone_device(self, zone_name: str) -> None:
+        """Remove the device registry entry for a deleted zone.
+
+        Without this the zone device lingers in the registry after its
+        entities are torn down on reload, leaving an undeletable orphan
+        that blocks a clean uninstall.
+        """
+        device_registry = dr.async_get(self.hass)
+        identifier = zone_device_identifier(self._config_entry.entry_id, zone_name)
+        device = device_registry.async_get_device(identifiers={identifier})
+        if device is not None:
+            _LOGGER.debug("Removing stale zone device %s (%s)", device.id, zone_name)
+            device_registry.async_remove_device(device.id)
+
     async def async_step_remove_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Remove an existing irrigation zone."""
         zones = list(self._config_entry.data.get(CONF_ZONES, []))
@@ -757,6 +773,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             new_data[CONF_ZONES] = [z for z in zones if z[CONF_ZONE_NAME] != name_to_remove]
             if new_data != dict(self._config_entry.data):
                 _LOGGER.debug("Config updated via remove_zone — zone removed: %s", name_to_remove)
+                self._remove_zone_device(name_to_remove)
                 self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
             return self.async_create_entry(data={})
 

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/drake69/NeverDry/issues",
     "requirements": [],
-    "version": "0.10.3"
+    "version": "0.10.4"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,19 @@ def _create_ha_stubs():
     config_entries_mod = ModuleType("homeassistant.config_entries")
     config_entries_mod.ConfigEntry = MagicMock
 
+    class _ConfigFlow:
+        """Subclassable stub accepting the ``domain=`` class kwarg."""
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+    class _OptionsFlow:
+        pass
+
+    config_entries_mod.ConfigFlow = _ConfigFlow
+    config_entries_mod.OptionsFlow = _OptionsFlow
+    config_entries_mod.ConfigFlowResult = dict
+
     # homeassistant.helpers.entity_platform
     entity_platform_mod = ModuleType("homeassistant.helpers.entity_platform")
     entity_platform_mod.AddEntitiesCallback = MagicMock
@@ -78,6 +91,9 @@ def _create_ha_stubs():
     # homeassistant.helpers.config_validation
     cv_mod = ModuleType("homeassistant.helpers.config_validation")
     cv_mod.config_entry_only_config_schema = lambda domain: {}
+
+    # homeassistant.helpers.selector (only attribute access at call time)
+    selector_mod = ModuleType("homeassistant.helpers.selector")
 
     # homeassistant.components.button
     button_mod = ModuleType("homeassistant.components.button")
@@ -168,7 +184,9 @@ def _create_ha_stubs():
     helpers_mod.config_validation = cv_mod
     helpers_mod.device_registry = device_registry_mod
     helpers_mod.entity_registry = entity_registry_mod
+    helpers_mod.selector = selector_mod
     mods = {
+        "voluptuous": ModuleType("voluptuous"),
         "homeassistant": ModuleType("homeassistant"),
         "homeassistant.components": ModuleType("homeassistant.components"),
         "homeassistant.components.button": button_mod,
@@ -178,6 +196,7 @@ def _create_ha_stubs():
         "homeassistant.core": core_mod,
         "homeassistant.helpers": helpers_mod,
         "homeassistant.helpers.config_validation": cv_mod,
+        "homeassistant.helpers.selector": selector_mod,
         "homeassistant.helpers.entity_platform": entity_platform_mod,
         "homeassistant.helpers.entity_registry": entity_registry_mod,
         "homeassistant.helpers.event": event_mod,

--- a/tests/test_zone_device_cleanup.py
+++ b/tests/test_zone_device_cleanup.py
@@ -1,0 +1,108 @@
+"""Tests for zone device-registry cleanup on zone deletion.
+
+Covers the bug where deleting a zone left an orphaned device in the
+registry (entities removed, device card lingering) which blocked a clean
+uninstall of the integration.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from never_dry import (
+    async_remove_config_entry_device,
+    zone_device_identifier,
+    zone_slug,
+)
+from never_dry.const import CONF_ZONE_NAME, CONF_ZONES, DOMAIN
+
+
+def _make_entry(entry_id: str, zone_names: list[str]) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.data = {CONF_ZONES: [{CONF_ZONE_NAME: n} for n in zone_names]}
+    return entry
+
+
+def _make_device(*identifiers: tuple[str, str]) -> SimpleNamespace:
+    return SimpleNamespace(id="dev1", identifiers=set(identifiers))
+
+
+class TestZoneSlug:
+    def test_lowercases_and_replaces_spaces(self):
+        assert zone_slug("Orto Grande") == "orto_grande"
+
+    def test_identifier_format(self):
+        assert zone_device_identifier("abc", "Orto Grande") == (DOMAIN, "abc_orto_grande")
+
+
+class TestAsyncRemoveConfigEntryDevice:
+    """async_remove_config_entry_device gates the UI delete button."""
+
+    @pytest.mark.asyncio
+    async def test_orphan_zone_device_is_removable(self, hass_mock):
+        """A device for a zone no longer in config can be deleted."""
+        entry = _make_entry("abc", ["Orto"])
+        # Device belongs to a zone "Prato" that was deleted from config.
+        device = _make_device(zone_device_identifier("abc", "Prato"))
+        assert await async_remove_config_entry_device(hass_mock, entry, device) is True
+
+    @pytest.mark.asyncio
+    async def test_configured_zone_device_is_kept(self, hass_mock):
+        """A device for a still-configured zone must NOT be removable."""
+        entry = _make_entry("abc", ["Orto", "Prato"])
+        device = _make_device(zone_device_identifier("abc", "Orto"))
+        assert await async_remove_config_entry_device(hass_mock, entry, device) is False
+
+    @pytest.mark.asyncio
+    async def test_hub_device_is_kept(self, hass_mock):
+        """The hub device (entry_id identifier) must NOT be removable."""
+        entry = _make_entry("abc", ["Orto"])
+        device = _make_device((DOMAIN, "abc"))
+        assert await async_remove_config_entry_device(hass_mock, entry, device) is False
+
+    @pytest.mark.asyncio
+    async def test_zone_with_spaces_in_name(self, hass_mock):
+        """Slug with spaces is matched correctly against config zones."""
+        entry = _make_entry("abc", ["Orto Grande"])
+        device = _make_device(zone_device_identifier("abc", "Orto Grande"))
+        assert await async_remove_config_entry_device(hass_mock, entry, device) is False
+
+
+class TestConfigFlowRemovesDevice:
+    """The options flow proactively removes the device on zone deletion."""
+
+    @pytest.mark.asyncio
+    async def test_remove_zone_device_calls_registry(self, hass_mock, monkeypatch):
+        import never_dry.config_flow as cf
+
+        entry = _make_entry("abc", ["Orto", "Prato"])
+
+        registry = MagicMock()
+        found_device = SimpleNamespace(id="dev-orto", identifiers={zone_device_identifier("abc", "Orto")})
+        registry.async_get_device.return_value = found_device
+        monkeypatch.setattr(cf.dr, "async_get", lambda hass: registry, raising=False)
+
+        flow = cf.NeverDryOptionsFlow(entry)
+        flow.hass = hass_mock
+
+        flow._remove_zone_device("Orto")
+
+        registry.async_get_device.assert_called_once_with(identifiers={zone_device_identifier("abc", "Orto")})
+        registry.async_remove_device.assert_called_once_with("dev-orto")
+
+    @pytest.mark.asyncio
+    async def test_remove_zone_device_noop_when_absent(self, hass_mock, monkeypatch):
+        import never_dry.config_flow as cf
+
+        entry = _make_entry("abc", ["Orto"])
+        registry = MagicMock()
+        registry.async_get_device.return_value = None
+        monkeypatch.setattr(cf.dr, "async_get", lambda hass: registry, raising=False)
+
+        flow = cf.NeverDryOptionsFlow(entry)
+        flow.hass = hass_mock
+
+        flow._remove_zone_device("Ghost")
+
+        registry.async_remove_device.assert_not_called()


### PR DESCRIPTION
## Problem

Deleting a zone via the options flow removed the zone's **entities** but left an **orphaned device** in the device registry — the device card kept showing the zone with no entities. Worse, since the integration did not implement `async_remove_config_entry_device`, Home Assistant kept the device's *Delete* button disabled (device "managed by NeverDry"), so the orphan could not be removed manually and the integration could not be uninstalled cleanly.

## Root cause

`async_step_remove_zone` updated the config entry data (triggering a reload that tears down entities) but never removed the zone **device**, and the integration had no `async_remove_config_entry_device` hook to re-enable manual deletion.

## Fix

- **`async_remove_config_entry_device`** in `__init__.py`: returns `True` for any device whose identifiers no longer map to a configured zone (orphans), `False` for the hub device and still-configured zones — re-enabling the UI *Delete device* button and unblocking uninstall.
- **`_remove_zone_device`** in `config_flow.py`: proactively removes the zone device from the registry the moment a zone is deleted, so no orphan is left behind.
- Extracted shared `zone_slug` / `zone_device_identifier` helpers (single source of truth for the device identifier, kept in sync with `sensor.py` / `button.py`).
- Version bump to `0.10.4`.

## Tests

- New `tests/test_zone_device_cleanup.py` (8 tests): removal gate (orphan removable; hub and live zones kept; spaced names) + config-flow cleanup path (registry called / no-op when absent).
- Added minimal `voluptuous` / `selector` / `ConfigFlow` stubs to `conftest.py` so `config_flow` is importable under the HA-free unit harness.
- Full suite green: **597 passed**. `ruff format` + `ruff check` clean.