### PR TITLE
aligned to the main

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -111,16 +111,8 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
             vol.Required(CONF_RAIN_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
             vol.Optional(CONF_RAIN_SENSOR_TYPE, default=DEFAULT_RAIN_SENSOR_TYPE): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[
-                        selector.SelectOptionDict(
-                            value=RAIN_TYPE_EVENT,
-                            label="Event-based (per event — tipping bucket)",
-                        ),
-                        selector.SelectOptionDict(
-                            value=RAIN_TYPE_DAILY_TOTAL,
-                            label="Daily total (cumulative since midnight)",
-                        ),
-                    ],
+                    options=[RAIN_TYPE_EVENT, RAIN_TYPE_DAILY_TOTAL],
+                    translation_key="rain_sensor_type",
                     mode="dropdown",
                 )
             ),
@@ -212,19 +204,11 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
             vol.Optional(CONF_ZONE_DELIVERY_MODE, default=DEFAULT_DELIVERY_MODE): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        selector.SelectOptionDict(
-                            value=DELIVERY_MODE_ESTIMATED_FLOW,
-                            label="Simple on/off — timer-based (default)",
-                        ),
-                        selector.SelectOptionDict(
-                            value=DELIVERY_MODE_FLOW_METER,
-                            label="Valve with flow meter sensor",
-                        ),
-                        selector.SelectOptionDict(
-                            value=DELIVERY_MODE_VOLUME_PRESET,
-                            label="Smart valve with volume dosing",
-                        ),
+                        DELIVERY_MODE_ESTIMATED_FLOW,
+                        DELIVERY_MODE_FLOW_METER,
+                        DELIVERY_MODE_VOLUME_PRESET,
                     ],
+                    translation_key="delivery_mode",
                     mode="dropdown",
                 )
             ),
@@ -240,11 +224,12 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
             vol.Required(CONF_ZONE_SYSTEM_TYPE): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        selector.SelectOptionDict(value=SYSTEM_TYPE_DRIP, label="Drip irrigation (η=0.92)"),
-                        selector.SelectOptionDict(value=SYSTEM_TYPE_MICRO_SPRINKLER, label="Micro-sprinklers (η=0.80)"),
-                        selector.SelectOptionDict(value=SYSTEM_TYPE_SPRINKLER, label="Pop-up sprinklers (η=0.68)"),
-                        selector.SelectOptionDict(value=SYSTEM_TYPE_MANUAL, label="Manual / hose (η=0.55)"),
+                        SYSTEM_TYPE_DRIP,
+                        SYSTEM_TYPE_MICRO_SPRINKLER,
+                        SYSTEM_TYPE_SPRINKLER,
+                        SYSTEM_TYPE_MANUAL,
                     ],
+                    translation_key="system_type",
                     mode="dropdown",
                 )
             ),
@@ -253,10 +238,8 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
             ),
             vol.Optional(CONF_ZONE_PLANT_FAMILY): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=[
-                        selector.SelectOptionDict(value=key, label=data["label"])
-                        for key, data in PLANT_FAMILIES.items()
-                    ],
+                    options=list(PLANT_FAMILIES.keys()),
+                    translation_key="plant_family",
                     mode="dropdown",
                 )
             ),
@@ -284,19 +267,11 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
             vol.Optional(CONF_ZONE_IRRIGATION_MODE, default=DEFAULT_IRRIGATION_MODE): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
-                        selector.SelectOptionDict(
-                            value=IRRIGATION_MODE_MANUAL,
-                            label="Manual only (button / service call)",
-                        ),
-                        selector.SelectOptionDict(
-                            value=IRRIGATION_MODE_REACTIVE,
-                            label="Reactive (irrigate when deficit > threshold)",
-                        ),
-                        selector.SelectOptionDict(
-                            value=IRRIGATION_MODE_SCHEDULED,
-                            label="Scheduled (check daily at set time)",
-                        ),
+                        IRRIGATION_MODE_MANUAL,
+                        IRRIGATION_MODE_REACTIVE,
+                        IRRIGATION_MODE_SCHEDULED,
                     ],
+                    translation_key="irrigation_mode",
                     mode="dropdown",
                 )
             ),
@@ -550,38 +525,17 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             return round(v * _MM_TO_IN, 1) if (imperial and v is not None) else v
 
         dm_opts = [
-            selector.SelectOptionDict(
-                value=DELIVERY_MODE_ESTIMATED_FLOW,
-                label="Simple on/off — timer-based",
-            ),
-            selector.SelectOptionDict(
-                value=DELIVERY_MODE_FLOW_METER,
-                label="Valve with flow meter sensor",
-            ),
-            selector.SelectOptionDict(
-                value=DELIVERY_MODE_VOLUME_PRESET,
-                label="Smart valve with volume dosing",
-            ),
+            DELIVERY_MODE_ESTIMATED_FLOW,
+            DELIVERY_MODE_FLOW_METER,
+            DELIVERY_MODE_VOLUME_PRESET,
         ]
         st_opts = [
-            selector.SelectOptionDict(
-                value=SYSTEM_TYPE_DRIP,
-                label="Drip (η=0.92)",
-            ),
-            selector.SelectOptionDict(
-                value=SYSTEM_TYPE_MICRO_SPRINKLER,
-                label="Micro-sprinklers (η=0.80)",
-            ),
-            selector.SelectOptionDict(
-                value=SYSTEM_TYPE_SPRINKLER,
-                label="Pop-up sprinklers (η=0.68)",
-            ),
-            selector.SelectOptionDict(
-                value=SYSTEM_TYPE_MANUAL,
-                label="Manual / hose (η=0.55)",
-            ),
+            SYSTEM_TYPE_DRIP,
+            SYSTEM_TYPE_MICRO_SPRINKLER,
+            SYSTEM_TYPE_SPRINKLER,
+            SYSTEM_TYPE_MANUAL,
         ]
-        pf_opts = [selector.SelectOptionDict(value=k, label=d["label"]) for k, d in PLANT_FAMILIES.items()]
+        pf_opts = list(PLANT_FAMILIES.keys())
         ent_sw = selector.EntitySelectorConfig(domain="switch")
         ent_sn = selector.EntitySelectorConfig(domain="sensor")
         ent_nr = selector.EntitySelectorConfig(domain="number")
@@ -602,6 +556,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=dm_opts,
+                        translation_key="delivery_mode",
                         mode="dropdown",
                     )
                 ),
@@ -623,6 +578,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=st_opts,
+                        translation_key="system_type",
                         mode="dropdown",
                     )
                 ),
@@ -643,6 +599,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=pf_opts,
+                        translation_key="plant_family",
                         mode="dropdown",
                     )
                 ),
@@ -701,19 +658,11 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=[
-                            selector.SelectOptionDict(
-                                value=IRRIGATION_MODE_MANUAL,
-                                label="Manual only",
-                            ),
-                            selector.SelectOptionDict(
-                                value=IRRIGATION_MODE_REACTIVE,
-                                label="Reactive",
-                            ),
-                            selector.SelectOptionDict(
-                                value=IRRIGATION_MODE_SCHEDULED,
-                                label="Scheduled",
-                            ),
+                            IRRIGATION_MODE_MANUAL,
+                            IRRIGATION_MODE_REACTIVE,
+                            IRRIGATION_MODE_SCHEDULED,
                         ],
+                        translation_key="irrigation_mode",
                         mode="dropdown",
                     )
                 ),

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -157,5 +157,49 @@
     "abort": {
       "no_zones": "No zones configured"
     }
+  },
+  "selector": {
+    "rain_sensor_type": {
+      "options": {
+        "event": "Event-based (per event — tipping bucket)",
+        "daily_total": "Daily total (cumulative since midnight)"
+      }
+    },
+    "irrigation_mode": {
+      "options": {
+        "manual": "Manual only (button / service call)",
+        "reactive": "Reactive (irrigate when deficit > threshold)",
+        "scheduled": "Scheduled (check daily at set time)"
+      }
+    },
+    "system_type": {
+      "options": {
+        "drip": "Drip irrigation (η=0.92)",
+        "micro_sprinkler": "Micro-sprinklers (η=0.80)",
+        "sprinkler": "Pop-up sprinklers (η=0.68)",
+        "manual": "Manual / hose (η=0.55)"
+      }
+    },
+    "plant_family": {
+      "options": {
+        "lawn": "Lawn / Turf grass",
+        "vegetables": "Vegetables (seasonal)",
+        "fruit_trees": "Fruit trees (deciduous)",
+        "ornamental_shrubs": "Ornamental shrubs",
+        "herbs": "Herbs (Mediterranean)",
+        "citrus": "Citrus / Evergreen fruit",
+        "roses": "Roses",
+        "succulents": "Succulents / Cacti",
+        "native_ground_cover": "Native ground cover",
+        "mixed_garden": "Mixed garden (default)"
+      }
+    },
+    "delivery_mode": {
+      "options": {
+        "estimated_flow": "Simple on/off — timer-based (default)",
+        "flow_meter": "Valve with flow meter sensor",
+        "volume_preset": "Smart valve with volume dosing"
+      }
+    }
   }
 }

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -157,5 +157,49 @@
     "abort": {
       "no_zones": "No zones configured"
     }
+  },
+  "selector": {
+    "rain_sensor_type": {
+      "options": {
+        "event": "Event-based (per event — tipping bucket)",
+        "daily_total": "Daily total (cumulative since midnight)"
+      }
+    },
+    "irrigation_mode": {
+      "options": {
+        "manual": "Manual only (button / service call)",
+        "reactive": "Reactive (irrigate when deficit > threshold)",
+        "scheduled": "Scheduled (check daily at set time)"
+      }
+    },
+    "system_type": {
+      "options": {
+        "drip": "Drip irrigation (η=0.92)",
+        "micro_sprinkler": "Micro-sprinklers (η=0.80)",
+        "sprinkler": "Pop-up sprinklers (η=0.68)",
+        "manual": "Manual / hose (η=0.55)"
+      }
+    },
+    "plant_family": {
+      "options": {
+        "lawn": "Lawn / Turf grass",
+        "vegetables": "Vegetables (seasonal)",
+        "fruit_trees": "Fruit trees (deciduous)",
+        "ornamental_shrubs": "Ornamental shrubs",
+        "herbs": "Herbs (Mediterranean)",
+        "citrus": "Citrus / Evergreen fruit",
+        "roses": "Roses",
+        "succulents": "Succulents / Cacti",
+        "native_ground_cover": "Native ground cover",
+        "mixed_garden": "Mixed garden (default)"
+      }
+    },
+    "delivery_mode": {
+      "options": {
+        "estimated_flow": "Simple on/off — timer-based (default)",
+        "flow_meter": "Valve with flow meter sensor",
+        "volume_preset": "Smart valve with volume dosing"
+      }
+    }
   }
 }

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -1,0 +1,205 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "NeverDry — Sensori e Modello",
+        "description": "Seleziona i tuoi sensori meteo e configura i parametri del modello di evapotraspirazione (ET).",
+        "data": {
+          "temperature_sensor": "Sensore di temperatura",
+          "rain_sensor": "Sensore di pioggia",
+          "rain_sensor_type": "Tipo di sensore di pioggia",
+          "alpha": "Coefficiente ET (α)",
+          "t_base": "Temperatura di base",
+          "d_max": "Limite massimo del deficit",
+          "vwc_sensor": "Sensore di umidità del suolo (opzionale)"
+        },
+        "data_description": {
+          "temperature_sensor": "Sensore di temperatura esterna in °C",
+          "rain_sensor": "Pluviometro o sensore di precipitazione della stazione meteo",
+          "rain_sensor_type": "Modalità di segnalazione delle precipitazioni del sensore di pioggia. Basato su eventi: mm per evento (pluviometro a vaschetta oscillante, consigliato). Totale giornaliero: mm cumulativi dalla mezzanotte (stazione meteo)",
+          "alpha": "Coefficiente di evapotraspirazione. Inizia con 0.22, regola dopo aver osservato il tuo giardino per una settimana",
+          "t_base": "Temperatura al di sotto della quale l'evapotraspirazione è zero (piante a riposo)",
+          "d_max": "Limite superiore per l'indice di deficit",
+          "vwc_sensor": "Se impostato, il deficit viene calcolato direttamente dall'umidità del suolo invece che dal modello ET"
+        }
+      },
+      "zone": {
+        "title": "Aggiungi zona di irrigazione",
+        "description": "Configura la zona #{zone_count}. Potrai aggiungere altre zone successivamente.",
+        "data": {
+          "name": "Nome della zona",
+          "valve": "Interruttore della valvola (opzionale)",
+          "delivery_mode": "Modalità di erogazione dell'acqua",
+          "area_m2": "Area irrigata",
+          "system_type": "Tipo di impianto di irrigazione",
+          "efficiency": "Efficienza personalizzata (sovrascrive il valore predefinito del tipo di impianto)",
+          "plant_family": "Famiglia di piante",
+          "kc": "Coefficiente colturale Kc personalizzato (sovrascrive la famiglia di piante)",
+          "flow_rate_lpm": "Portata della valvola (solo per estimated_flow)",
+          "flow_meter_sensor": "Sensore del flussometro (solo per flow_meter)",
+          "volume_entity": "Entità target del volume (solo per volume_preset)",
+          "delivery_timeout": "Timeout di sicurezza",
+          "irrigation_mode": "Modalità di irrigazione",
+          "threshold": "Soglia di irrigazione",
+          "irrigation_time": "Orario di irrigazione giornaliero"
+        },
+        "data_description": {
+          "name": "Nome visualizzato per questa zona (es. Orto, Prato)",
+          "valve": "L'entità interruttore (switch) che controlla la valvola di irrigazione di questa zona. Lascia vuoto per la modalità di solo monitoraggio (nessuna valvola)",
+          "delivery_mode": "Modalità di erogazione dell'acqua della valvola. Portata stimata (estimated flow): semplice valvola on/off, durata calcolata in base alla portata. Flussometro (flow meter): valvola con sensore di flusso, si chiude al raggiungimento del volume target. Volume preimpostato (volume preset): valvola intelligente che accetta un volume target e si chiude autonomamente.",
+          "area_m2": "Superficie di questa zona di irrigazione in metri quadrati",
+          "system_type": "Tipo di impianto di irrigazione — imposta l'efficienza predefinita",
+          "efficiency": "Lascia vuoto per utilizzare il valore predefinito del tipo di impianto. Imposta per sovrascriverlo",
+          "plant_family": "Seleziona il tipo di piante in questa zona. Imposta un coefficiente colturale stagionale (Kc) che adatta il fabbisogno idrico durante l'anno",
+          "kc": "Lascia vuoto per utilizzare il profil stagionale della famiglia di piante. Imposta per sovrascriverlo con un valore Kc fisso (0.1–2.0)",
+          "flow_rate_lpm": "Portata d'acqua della valvola in litri al minuto. Richiesto per la modalità estimated_flow. Misurala con un secchio e un cronometro",
+          "flow_meter_sensor": "Entità sensore che rileva i litri cumulativi erogati. Richiesto per la modalità flow_meter",
+          "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
+          "delivery_timeout": "Tempo massimo di attesa per l'erogazione con flow_meter o volume_preset prima di forzare la chiusura della valvola (limite di sicurezza)",
+          "threshold": "Livello di deficit (mm) che attiva l'irrigazione automatica per questa zona",
+          "irrigation_time": "Ora del giorno in cui NeverDry verifica il deficit e irriga se supera la soglia. Lascia vuoto per disabilitare la pianificazione automatica"
+        }
+      },
+      "add_another": {
+        "title": "Aggiungere un'altra zona?",
+        "description": "Hai configurato {zone_count} zona/e: {zone_names}.",
+        "data": {
+          "add_another": "Aggiungi un'altra zona di irrigazione"
+        }
+      }
+    },
+    "error": {
+      "zone_name_too_long": "Il nome della zona è troppo lungo (massimo 64 caratteri)",
+      "too_many_zones": "È stato raggiunto il numero massimo di zone (50)",
+      "flow_rate_required": "La portata è richiesta per la modalità di erogazione estimated_flow",
+      "flow_meter_required": "Il sensore del flussometro è richiesto per la modalità di erogazione flow_meter",
+      "volume_entity_required": "L'entità del volume è richiesta per la modalità di erogazione volume_preset",
+      "zone_already_exists": "Esiste già una zona con questo nome"
+    },
+    "abort": {
+      "already_configured": "NeverDry è già configurato"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "NeverDry — Opzioni",
+        "description": "Scegli cosa configurare.",
+        "menu_options": {
+          "model_params": "Modifica i parametri del modello (α, T_base, D_max)",
+          "add_zone": "Aggiungi una nuova zona di irrigazione",
+          "edit_zone": "Modifica una zona di irrigazione",
+          "remove_zone": "Rimuovi una zona di irrigazione"
+        }
+      },
+      "model_params": {
+        "title": "Parametri del Modello ET",
+        "description": "Regola il modello di evapotraspirazione. Le modifiche hanno effetto immediato.",
+        "data": {
+          "alpha": "Coefficiente ET (α)",
+          "t_base": "Temperatura di base",
+          "d_max": "Limite massimo del deficit"
+        }
+      },
+      "add_zone": {
+        "title": "Aggiungi zona di irrigazione",
+        "data": {
+          "name": "Nome della zona",
+          "valve": "Interruttore della valvola (opzionale)",
+          "delivery_mode": "Modalità di erogazione dell'acqua",
+          "area_m2": "Area irrigata",
+          "system_type": "Tipo di impianto di irrigazione",
+          "efficiency": "Efficienza personalizzata",
+          "plant_family": "Famiglia di piante",
+          "kc": "Coefficiente colturale Kc personalizzato",
+          "flow_rate_lpm": "Portata della valvola",
+          "flow_meter_sensor": "Sensore del flussometro",
+          "volume_entity": "Entità target del volume",
+          "delivery_timeout": "Timeout di sicurezza",
+          "irrigation_mode": "Modalità di irrigazione",
+          "threshold": "Soglia di irrigazione",
+          "irrigation_time": "Orario di irrigazione giornaliero"
+        }
+      },
+      "edit_zone": {
+        "title": "Modifica zona di irrigazione",
+        "data": {
+          "zone_to_edit": "Zona da modificare"
+        }
+      },
+      "edit_zone_detail": {
+        "title": "Modifica zona: {zone_name}",
+        "data": {
+          "name": "Nome della zona",
+          "valve": "Interruttore della valvola",
+          "delivery_mode": "Modalità di erogazione dell'acqua",
+          "area_m2": "Area irrigata",
+          "system_type": "Tipo di impianto di irrigazione",
+          "efficiency": "Efficienza personalizzata",
+          "plant_family": "Famiglia di piante",
+          "kc": "Coefficiente colturale Kc personalizzato",
+          "flow_rate_lpm": "Portata della valvola",
+          "flow_meter_sensor": "Sensore del flussometro",
+          "volume_entity": "Entità target del volume",
+          "delivery_timeout": "Timeout di sicurezza",
+          "irrigation_mode": "Modalità di irrigazione",
+          "threshold": "Soglia di irrigazione",
+          "irrigation_time": "Orario di irrigazione giornaliero"
+        }
+      },
+      "remove_zone": {
+        "title": "Rimuovi zona di irrigazione",
+        "data": {
+          "zone_to_remove": "Zona da rimuovere"
+        }
+      }
+    },
+    "abort": {
+      "no_zones": "Nessuna zona configurata"
+    }
+  },
+  "selector": {
+    "rain_sensor_type": {
+      "options": {
+        "event": "Basato su eventi (mm per evento — pluviometro a vaschetta)",
+        "daily_total": "Totale giornaliero (mm cumulativi dalla mezzanotte)"
+      }
+    },
+    "irrigation_mode": {
+      "options": {
+        "manual": "Solo manuale (pulsante o chiamata di servizio)",
+        "reactive": "Reattiva (irriga quando il deficit supera la soglia)",
+        "scheduled": "Pianificata (verifica giornaliera all'orario prestabilito)"
+      }
+    },
+    "system_type": {
+      "options": {
+        "drip": "Ala gocciolante / Manichetta",
+        "micro_sprinkler": "Micro-irrigatori",
+        "sprinkler": "Irrigatori a scomparsa (Pop-up)",
+        "manual": "Manuale / Gomma da giardino"
+      }
+    },
+    "plant_family": {
+      "options": {
+        "lawn": "Prato / Tappeto erboso",
+        "vegetables": "Orto / Verdure (stagionali)",
+        "fruit_trees": "Alberi da frutto (caducifoglie)",
+        "ornamental_shrubs": "Arbusti ornamentali",
+        "herbs": "Aromatiche (mediterranee)",
+        "citrus": "Agrumi / Fruttiferi sempreverdi",
+        "roses": "Rosai",
+        "succulents": "Piante grasse / Cacti",
+        "native_ground_cover": "Coprisuolo nativo",
+        "mixed_garden": "Giardino misto (predefinito)"
+      }
+    },
+    "delivery_mode": {
+      "options": {
+        "estimated_flow": "Semplice On/Off (calcolo del tempo in base alla portata)",
+        "flow_meter": "Valvola con sensore flussometro",
+        "volume_preset": "Valvola smart con dosaggio a volume"
+      }
+    }
+  }
+}

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -27,12 +27,17 @@ _CONFIG_FLOW = _COMPONENT / "config_flow.py"
 _EN_JSON = _COMPONENT / "translations" / "en.json"
 
 
-def _resolve_options(node: ast.AST) -> set[str] | None:
+def _resolve_options(node: ast.AST, assignments: dict[str, ast.AST] | None = None) -> set[str] | None:
     """Resolve a SelectSelectorConfig ``options=`` argument to its string values.
 
     Returns ``None`` when the expression cannot be resolved statically, so the
     caller can fail loudly rather than pass a false negative.
     """
+    if assignments is None:
+        assignments = {}
+    if isinstance(node, ast.Name):
+        if node.id in assignments:
+            return _resolve_options(assignments[node.id], assignments)
     # options=[CONST_A, CONST_B] or [SelectOptionDict(value=CONST, ...), ...]
     if isinstance(node, ast.List):
         values: set[str] = set()
@@ -74,6 +79,13 @@ def _resolve_options(node: ast.AST) -> set[str] | None:
 
 def _collect_translation_keyed_selectors() -> list[tuple[str, set[str] | None]]:
     tree = ast.parse(_CONFIG_FLOW.read_text())
+    assignments: dict[str, ast.AST] = {}
+    for subnode in ast.walk(tree):
+        if isinstance(subnode, ast.Assign):
+            for target in subnode.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = subnode.value
+
     out: list[tuple[str, set[str] | None]] = []
     for node in ast.walk(tree):
         if not (
@@ -86,7 +98,7 @@ def _collect_translation_keyed_selectors() -> list[tuple[str, set[str] | None]]:
         if tk_kw is None or not isinstance(tk_kw.value, ast.Constant):
             continue
         opt_kw = next((kw for kw in node.keywords if kw.arg == "options"), None)
-        options = _resolve_options(opt_kw.value) if opt_kw is not None else None
+        options = _resolve_options(opt_kw.value, assignments) if opt_kw is not None else None
         out.append((tk_kw.value.value, options))
     return out
 


### PR DESCRIPTION
I have implemented the requested changes:

Rebase & Integration: I successfully rebased on the latest main branch and resolved the conflicts with the new unit-aware schema from PR #83. The translation_key logic is now fully integrated with the new number selectors.

Selector Translations: I added the missing selector section to translations/en.json (and also to it.json for Italian support) including all the options for the new keys (rain_sensor_type, delivery_mode, system_type, plant_family, irrigation_mode). This should satisfy the test_translation_consistency.py CI check.