### PR TITLE
test: resolve translation_key options passed via local variable

### DIFF
--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -27,12 +27,31 @@ _CONFIG_FLOW = _COMPONENT / "config_flow.py"
 _EN_JSON = _COMPONENT / "translations" / "en.json"
 
 
-def _resolve_options(node: ast.AST) -> set[str] | None:
+def _resolve_options(node: ast.AST, assignments: dict[str, ast.AST] | None = None) -> set[str] | None:
     """Resolve a SelectSelectorConfig ``options=`` argument to its string values.
+
+    Accepts the options written either **inline** (``options=[...]``,
+    ``options=list(DICT.keys())``) or **via a local variable**
+    (``dm_opts = [...]`` then ``options=dm_opts``). In the variable case the
+    name is looked up in ``assignments`` (name -> assigned value node, collected
+    from the module) and resolved recursively.
 
     Returns ``None`` when the expression cannot be resolved statically, so the
     caller can fail loudly rather than pass a false negative.
     """
+    assignments = assignments or {}
+    # options=dm_opts -> follow the variable assignment and resolve its value.
+    if isinstance(node, ast.Name):
+        # A bare name may be a constant from const (e.g. a list/dict)...
+        if hasattr(const, node.id):
+            resolved = getattr(const, node.id)
+            if isinstance(resolved, dict):
+                return set(resolved.keys())
+            if isinstance(resolved, (list, tuple, set)):
+                return set(resolved)
+        # ...or a local/module variable assigned an inline expression.
+        target = assignments.get(node.id)
+        return _resolve_options(target, assignments) if target is not None else None
     # options=[CONST_A, CONST_B] or [SelectOptionDict(value=CONST, ...), ...]
     if isinstance(node, ast.List):
         values: set[str] = set()
@@ -72,8 +91,23 @@ def _resolve_options(node: ast.AST) -> set[str] | None:
     return None
 
 
+def _collect_assignments(tree: ast.AST) -> dict[str, ast.AST]:
+    """Map ``name -> assigned value node`` for simple ``name = <expr>`` statements.
+
+    Lets ``_resolve_options`` follow ``options=dm_opts`` back to ``dm_opts = [...]``.
+    Module-wide, last assignment wins — enough for the option-list variables the
+    config flow uses (each assigned once inside its step).
+    """
+    assignments: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            assignments[node.targets[0].id] = node.value
+    return assignments
+
+
 def _collect_translation_keyed_selectors() -> list[tuple[str, set[str] | None]]:
     tree = ast.parse(_CONFIG_FLOW.read_text())
+    assignments = _collect_assignments(tree)
     out: list[tuple[str, set[str] | None]] = []
     for node in ast.walk(tree):
         if not (
@@ -86,7 +120,7 @@ def _collect_translation_keyed_selectors() -> list[tuple[str, set[str] | None]]:
         if tk_kw is None or not isinstance(tk_kw.value, ast.Constant):
             continue
         opt_kw = next((kw for kw in node.keywords if kw.arg == "options"), None)
-        options = _resolve_options(opt_kw.value) if opt_kw is not None else None
+        options = _resolve_options(opt_kw.value, assignments) if opt_kw is not None else None
         out.append((tk_kw.value.value, options))
     return out
 
@@ -119,3 +153,44 @@ def test_translation_keys_have_matching_options_in_en_json():
             errors.append(f"translation_key '{translation_key}' missing option labels in en.json: {sorted(missing)}")
 
     assert not errors, "Selector translation inconsistencies:\n  " + "\n  ".join(errors)
+
+
+def _options_of(src: str) -> set[str] | None:
+    """Resolve the ``options=`` of the first SelectSelectorConfig in a snippet."""
+    tree = ast.parse(src)
+    assignments = _collect_assignments(tree)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "SelectSelectorConfig"
+        ):
+            opt = next((kw for kw in node.keywords if kw.arg == "options"), None)
+            return _resolve_options(opt.value, assignments) if opt is not None else None
+    return None
+
+
+class TestResolveOptionsFromVariable:
+    """_resolve_options must follow options passed via a local variable."""
+
+    def test_variable_holding_const_list(self):
+        src = (
+            "dm_opts = [DELIVERY_MODE_ESTIMATED_FLOW, DELIVERY_MODE_FLOW_METER]\n"
+            "selector.SelectSelectorConfig(options=dm_opts, translation_key='delivery_mode')\n"
+        )
+        assert _options_of(src) == {const.DELIVERY_MODE_ESTIMATED_FLOW, const.DELIVERY_MODE_FLOW_METER}
+
+    def test_variable_holding_dict_keys_call(self):
+        src = (
+            "pf_opts = list(PLANT_FAMILIES.keys())\n"
+            "selector.SelectSelectorConfig(options=pf_opts, translation_key='plant_family')\n"
+        )
+        assert _options_of(src) == set(const.PLANT_FAMILIES.keys())
+
+    def test_inline_list_still_resolves(self):
+        src = "selector.SelectSelectorConfig(options=[DELIVERY_MODE_FLOW_METER], translation_key='x')\n"
+        assert _options_of(src) == {const.DELIVERY_MODE_FLOW_METER}
+
+    def test_unknown_variable_returns_none(self):
+        src = "selector.SelectSelectorConfig(options=mystery, translation_key='x')\n"
+        assert _options_of(src) is None


### PR DESCRIPTION
## Why

The translation-consistency guard (`tests/test_translation_consistency.py`, added in #83) statically resolves each `SelectSelectorConfig(translation_key=…)` selector's `options=` and checks the labels exist in `en.json`. Its `_resolve_options()` could only resolve options written **inline** — a list literal or `list(DICT.keys())`. When the options are assigned to a **local variable** first and then referenced (`dm_opts = […]` → `options=dm_opts`), it returned `None` and failed loudly with *"extend _resolve_options() in this test"*, even though the selector is perfectly valid.

This blocked legitimate config-flow refactors (e.g. **#88**, which migrates selector labels to `translation_key` and passes the option lists via `dm_opts` / `st_opts` / `pf_opts` in the options flow).

## What

- `_collect_assignments()`: build a `name -> assigned value node` map from the module.
- `_resolve_options()`: follow an `ast.Name` back to its assignment (or to a list/dict constant) and resolve recursively. Still returns `None` for genuinely unresolvable names, so the guard keeps failing loudly on real gaps.
- Added unit tests: variable-holding-const-list, variable-holding-`list(DICT.keys())`, inline (regression), and unresolvable-name cases.

## Validation

- Full suite green (**593 passed**), `ruff format`/`check` clean.
- Verified the updated resolver against **#88**'s actual `config_flow.py` + `en.json`: all **9** `translation_key` selectors (including the previously-unresolvable `delivery_mode` / `system_type` / `plant_family` in the options flow) now resolve **and** match the translations.

## Note

This is a test-only change. Once merged, #88 needs to merge/rebase `main` to pick it up and go green — it is otherwise consistent (uniform `translation_key` + plain value lists, no leftover inline labels).