### PR TITLE
chore: bump version to 0.10.5

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/drake69/NeverDry/issues",
     "requirements": [],
-    "version": "0.10.4"
+    "version": "0.10.5"
 }


### PR DESCRIPTION
Release **0.10.5**.

Since `v0.10.4`, main has accumulated:
- **Italian translations** (`it.json`) + `translation_key`-based selector labels for the config flow (#88)
- Variable-aware translation-consistency test helper (#89)
- CI action bumps: `actions/checkout` v7, `actions/setup-python` v6.3.0, `softprops/action-gh-release` v3.0.1 (#84, #85, #86)

This PR only bumps `manifest.json` to `0.10.5` so the tag/release pipeline (which verifies manifest == tag) can publish.