### PR TITLE
fix: register Zone Card as Lovelace resource so it loads reliably

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -102,12 +102,45 @@ _STATIC_URL = f"/{DOMAIN}_static"
 _CARD_URL = f"{_STATIC_URL}/{_CARD_FILENAME}"
 
 
+async def _async_register_lovelace_resource(hass: HomeAssistant, url: str) -> bool:
+    """Register (or version-refresh) the card as a Lovelace resource.
+
+    Lovelace resources are fetched dynamically by the frontend, so they keep
+    working even when the service worker serves a stale cached index.html —
+    the failure mode that makes frontend.add_extra_js_url unreliable after
+    install/upgrade (GH issue #96). Only possible in storage mode; returns
+    False for YAML-managed dashboards so the caller can fall back to
+    add_extra_js_url.
+    """
+    lovelace = hass.data.get("lovelace")
+    if lovelace is None or getattr(lovelace, "mode", None) != "storage":
+        return False
+
+    resources = lovelace.resources
+    if not resources.loaded:
+        await resources.async_load()
+        resources.loaded = True
+
+    for item in resources.async_items():
+        if item.get("url", "").partition("?")[0] == _CARD_URL:
+            if item["url"] != url:  # stale ?v= from a previous version: bust the browser cache
+                await resources.async_update_item(item["id"], {"url": url})
+                _LOGGER.info("NeverDry Zone Card Lovelace resource updated to %s", url)
+            return True
+
+    await resources.async_create_item({"res_type": "module", "url": url})
+    _LOGGER.info("NeverDry Zone Card added to Lovelace resources (%s)", url)
+    return True
+
+
 async def _async_register_frontend(hass: HomeAssistant) -> None:
     """Serve and auto-load the NeverDry Zone Lovelace card.
 
-    Registers the bundled www/ folder as a static path and adds the card to the
-    frontend's extra module URLs so it appears in the "Add card" picker without
-    the user having to add a Lovelace resource manually. Runs once per HA instance.
+    Registers the bundled www/ folder as a static path, then exposes the card
+    JS to the frontend so it appears in the "Add card" picker without manual
+    resource setup. Storage-mode dashboards get a real Lovelace resource
+    (robust against the service-worker-cached index, GH #96); YAML-mode
+    dashboards fall back to add_extra_js_url. Runs once per HA instance.
     """
     if hass.data[DOMAIN].get(_FRONTEND_REGISTERED):
         return
@@ -120,9 +153,10 @@ async def _async_register_frontend(hass: HomeAssistant) -> None:
         _LOGGER.info("NeverDry: registering static path %s -> %s", _STATIC_URL, www_dir)
         await hass.http.async_register_static_paths([StaticPathConfig(_STATIC_URL, www_dir, cache_headers=False)])
 
-        from homeassistant.components import frontend
+        if not await _async_register_lovelace_resource(hass, url):
+            from homeassistant.components import frontend
 
-        frontend.add_extra_js_url(hass, url)
+            frontend.add_extra_js_url(hass, url)
         hass.data[DOMAIN][_FRONTEND_REGISTERED] = True
         _LOGGER.info("NeverDry Zone Card registered and auto-loaded (%s)", url)
     except Exception:  # never block integration setup on a frontend hiccup

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -4,10 +4,10 @@
     "after_dependencies": ["recorder"],
     "codeowners": ["@drake69"],
     "config_flow": true,
-    "dependencies": ["http"],
+    "dependencies": ["http", "lovelace"],
     "documentation": "https://github.com/drake69/NeverDry",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/drake69/NeverDry/issues",
     "requirements": [],
-    "version": "0.10.7"
+    "version": "0.10.8"
 }

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -19,7 +19,7 @@
  * localized friendly_name; values via formatEntityState (language + units).
  */
 
-const CARD_VERSION = "0.1.6";
+const CARD_VERSION = "0.1.7";
 
 // Static UI strings that are NOT backed by an entity (everything else is read
 // from the entity's localized friendly_name / formatEntityState, so it follows
@@ -554,7 +554,8 @@ function escapeHtml(s) {
   return String(s)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function barColor(pct) {
@@ -653,7 +654,7 @@ class NeverDryZoneCardEditor extends HTMLElement {
     const options = devices
       .map(
         (d) =>
-          `<option value="${d.id}" ${d.id === current ? "selected" : ""}>${d.name}</option>`
+          `<option value="${escapeHtml(d.id)}" ${d.id === current ? "selected" : ""}>${escapeHtml(d.name)}</option>`
       )
       .join("");
     this.innerHTML = `

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -418,17 +418,24 @@
 <!-- What's new -->
 <section class="how-it-works">
     <div class="container">
-        <h2>What's new in v0.10.7</h2>
-        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-06-27</p>
+        <h2>What's new in v0.10.8</h2>
+        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-07-04</p>
         <ul style="max-width: 680px; margin: 0 auto; text-align: left; line-height: 2;">
-            <li><strong>NeverDry Zone Card</strong> — a built-in Lovelace card that shows every zone at a glance: deficit, status chips, next watering, and flow rate. Bundled with the integration and registered automatically — no manual resource setup.</li>
-            <li><strong>Flow rate in L/h (gal/h imperial)</strong> — display and enter zone flow rate in litres per hour; converts automatically to US-customary units.</li>
-            <li><strong>Full SI &amp; imperial support</strong> — units convert consistently across the config flow and at runtime, including rain in inches.</li>
-            <li><strong>Per-zone valve stop</strong> — stop a single zone on demand, with proper handling when a valve is closed externally or by hardware.</li>
-            <li><strong>More accurate water accounting</strong> — fixed volume/deficit accounting and rain-event de-duplication.</li>
-            <li><strong>Clean uninstall</strong> — zone devices are removed on deletion, unblocking integration uninstall.</li>
+            <li><strong>Zone Card loads reliably</strong> — the card is now registered as a real Lovelace resource, fixing "Custom element doesn't exist: never-dry-zone-card" after install or upgrade (no more manual cache clearing).</li>
+            <li><strong>Card editor hardening</strong> — zone names are now HTML-escaped in the card editor.</li>
         </ul>
-        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.7">Full release notes on GitHub →</a></p>
+        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.8">Full release notes on GitHub →</a></p>
+        <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
+            <summary style="cursor: pointer;">v0.10.7 — 2026-06-27</summary>
+            <ul style="line-height: 2; margin-top: 0.5em;">
+                <li><strong>NeverDry Zone Card</strong> — a built-in Lovelace card that shows every zone at a glance: deficit, status chips, next watering, and flow rate. Bundled with the integration and registered automatically — no manual resource setup.</li>
+                <li><strong>Flow rate in L/h (gal/h imperial)</strong> — display and enter zone flow rate in litres per hour; converts automatically to US-customary units.</li>
+                <li><strong>Full SI &amp; imperial support</strong> — units convert consistently across the config flow and at runtime, including rain in inches.</li>
+                <li><strong>Per-zone valve stop</strong> — stop a single zone on demand, with proper handling when a valve is closed externally or by hardware.</li>
+                <li><strong>More accurate water accounting</strong> — fixed volume/deficit accounting and rain-event de-duplication.</li>
+                <li><strong>Clean uninstall</strong> — zone devices are removed on deletion, unblocking integration uninstall.</li>
+            </ul>
+        </details>
         <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
             <summary style="cursor: pointer;">v0.10.2 — 2026-06-24</summary>
             <ul style="line-height: 2; margin-top: 0.5em;">

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -1,7 +1,7 @@
 """Tests for the Lovelace card frontend registration in __init__.py."""
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -83,3 +83,91 @@ async def test_does_not_raise_on_failure(frontend_stubs):
     await _async_register_frontend(hass)
 
     assert hass.data[DOMAIN].get(_FRONTEND_REGISTERED) is not True
+
+
+def _make_resources(items=None, loaded=True):
+    """Fake lovelace ResourceStorageCollection."""
+    resources = SimpleNamespace(loaded=loaded)
+    resources._items = items or []
+    resources.async_items = lambda: resources._items
+    resources.async_load = AsyncMock()
+    resources.async_create_item = AsyncMock()
+    resources.async_update_item = AsyncMock()
+    return resources
+
+
+def _with_lovelace(hass, mode="storage", resources=None):
+    hass.data["lovelace"] = SimpleNamespace(mode=mode, resources=resources or _make_resources())
+    return hass.data["lovelace"].resources
+
+
+async def test_storage_mode_creates_lovelace_resource(frontend_stubs):
+    """Storage mode: the card is registered as a real Lovelace resource, not extra_js_url."""
+    add_extra_js_url = frontend_stubs
+    hass = _make_hass()
+    resources = _with_lovelace(hass)
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_awaited_once()
+    created = resources.async_create_item.call_args.args[0]
+    assert created["res_type"] == "module"
+    assert created["url"].startswith(f"{_CARD_URL}?v=")
+    add_extra_js_url.assert_not_called()
+    assert hass.data[DOMAIN][_FRONTEND_REGISTERED] is True
+
+
+async def test_storage_mode_refreshes_stale_resource_version(frontend_stubs):
+    """An existing resource with an old ?v= cache-buster is updated in place."""
+    hass = _make_hass()
+    stale = {"id": "abc123", "url": f"{_CARD_URL}?v=0.0.1"}
+    resources = _with_lovelace(hass, resources=_make_resources(items=[stale]))
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_not_awaited()
+    resources.async_update_item.assert_awaited_once()
+    item_id, updates = resources.async_update_item.call_args.args
+    assert item_id == "abc123"
+    assert updates["url"].startswith(f"{_CARD_URL}?v=")
+    assert updates["url"] != stale["url"]
+
+
+async def test_storage_mode_leaves_current_resource_untouched(frontend_stubs):
+    """A resource already pointing at the current version is neither duplicated nor updated."""
+    from never_dry import _INTEGRATION_VERSION
+
+    hass = _make_hass()
+    current = {"id": "abc123", "url": f"{_CARD_URL}?v={_INTEGRATION_VERSION}"}
+    resources = _with_lovelace(hass, resources=_make_resources(items=[current]))
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_not_awaited()
+    resources.async_update_item.assert_not_awaited()
+    assert hass.data[DOMAIN][_FRONTEND_REGISTERED] is True
+
+
+async def test_storage_mode_loads_resources_when_not_loaded(frontend_stubs):
+    """The resource collection is loaded on demand before being inspected."""
+    hass = _make_hass()
+    resources = _with_lovelace(hass, resources=_make_resources(loaded=False))
+
+    await _async_register_frontend(hass)
+
+    resources.async_load.assert_awaited_once()
+    assert resources.loaded is True
+    resources.async_create_item.assert_awaited_once()
+
+
+async def test_yaml_mode_falls_back_to_extra_js_url(frontend_stubs):
+    """YAML-managed dashboards (read-only resources) fall back to add_extra_js_url."""
+    add_extra_js_url = frontend_stubs
+    hass = _make_hass()
+    resources = _with_lovelace(hass, mode="yaml")
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_not_awaited()
+    add_extra_js_url.assert_called_once()
+    assert hass.data[DOMAIN][_FRONTEND_REGISTERED] is True


### PR DESCRIPTION
## Problem

On a fresh install or upgrade, the Zone Card fails to load with:

```
Custom element doesn't exist: never-dry-zone-card
```

even though the backend logs show the static path and the card URL registered correctly (#96).

**Root cause:** the card was exposed only via `frontend.add_extra_js_url`, which injects the module into the frontend `index.html`. Home Assistant's service worker serves a **cached** index after install/upgrade, so the browser never fetches the new module until the user manually clears the frontend cache on every device.

## Fix

- **Storage mode (default):** register the card as a real **Lovelace resource** (`/never_dry_static/never-dry-zone-card.js?v=<version>`). Resources are loaded dynamically by the frontend, so they are immune to the cached index, and are visible/manageable under Settings → Dashboards → Resources. On upgrade the existing resource entry is updated in place, so the new `?v=` busts the browser cache automatically.
- **YAML mode:** dashboards with read-only resources keep the previous `add_extra_js_url` fallback.
- `lovelace` added to manifest `dependencies` to guarantee setup order.

## Hardening (from a security pass on the card)

- Device name and id are now HTML-escaped in the card editor (the only unescaped interpolation in the file); `escapeHtml` also escapes double quotes for attribute context.

## Housekeeping

- Integration `0.10.7 → 0.10.8`, card `0.1.6 → 0.1.7`, gh-pages What's new updated.
- 5 new tests: resource create / stale-version update / current-version no-op / lazy collection load / YAML fallback. Full suite: 622 passed.

Closes #96