### PR TITLE
v0.10.9: fix stuck deficit on timeout, zone config guards, zone card on HA 2026.2+

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -113,7 +113,16 @@ async def _async_register_lovelace_resource(hass: HomeAssistant, url: str) -> bo
     add_extra_js_url.
     """
     lovelace = hass.data.get("lovelace")
-    if lovelace is None or getattr(lovelace, "mode", None) != "storage":
+    if lovelace is None:
+        _LOGGER.warning("NeverDry: Lovelace data not available, falling back to add_extra_js_url")
+        return False
+    # HA 2026.2 renamed LovelaceData.mode -> resource_mode; support both.
+    mode = getattr(lovelace, "resource_mode", None) or getattr(lovelace, "mode", None)
+    if mode != "storage":
+        _LOGGER.info(
+            "NeverDry: Lovelace resources managed in %s mode, falling back to add_extra_js_url",
+            mode,
+        )
         return False
 
     resources = lovelace.resources
@@ -126,6 +135,8 @@ async def _async_register_lovelace_resource(hass: HomeAssistant, url: str) -> bo
             if item["url"] != url:  # stale ?v= from a previous version: bust the browser cache
                 await resources.async_update_item(item["id"], {"url": url})
                 _LOGGER.info("NeverDry Zone Card Lovelace resource updated to %s", url)
+            else:
+                _LOGGER.debug("NeverDry Zone Card Lovelace resource already current (%s)", url)
             return True
 
     await resources.async_create_item({"res_type": "module", "url": url})
@@ -143,6 +154,7 @@ async def _async_register_frontend(hass: HomeAssistant) -> None:
     dashboards fall back to add_extra_js_url. Runs once per HA instance.
     """
     if hass.data[DOMAIN].get(_FRONTEND_REGISTERED):
+        _LOGGER.debug("NeverDry: frontend already registered, skipping")
         return
 
     www_dir = str(pathlib.Path(__file__).parent / "www")

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -68,6 +68,9 @@ from .const import (
     SYSTEM_TYPE_MANUAL,
     SYSTEM_TYPE_MICRO_SPRINKLER,
     SYSTEM_TYPE_SPRINKLER,
+    UNUSUAL_AREA_MIN_M2,
+    UNUSUAL_FLOW_MAX_LPM,
+    UNUSUAL_FLOW_MIN_LPM,
 )
 from .unit_convert import (
     LPM_TO_GPH,
@@ -293,6 +296,40 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
     )
 
 
+def _unusual_zone_values(zone: dict, imperial: bool) -> list[str]:
+    """Detect implausible zone values for the soft-confirm guard.
+
+    Takes a zone dict in metric storage units (area m², flow L/min) and
+    returns human-readable warning lines in the user's display units.
+    An empty list means all values look plausible.
+    """
+    warnings: list[str] = []
+    area = zone.get(CONF_ZONE_AREA)
+    if area is not None and area < UNUSUAL_AREA_MIN_M2:
+        if imperial:
+            warnings.append(f"area {area * _M2_TO_FT2:.1f} ft² < {UNUSUAL_AREA_MIN_M2 * _M2_TO_FT2:.0f} ft²")
+        else:
+            warnings.append(f"area {area:.1f} m² < {UNUSUAL_AREA_MIN_M2:.0f} m²")
+    flow = zone.get(CONF_ZONE_FLOW_RATE)
+    if flow is not None and flow > 0:
+        if imperial:
+            shown, unit = flow * _LPM_TO_GPH, "gal/h"
+            low, high = UNUSUAL_FLOW_MIN_LPM * _LPM_TO_GPH, UNUSUAL_FLOW_MAX_LPM * _LPM_TO_GPH
+        else:
+            shown, unit = flow * _LPM_TO_LPH, "L/h"
+            low, high = UNUSUAL_FLOW_MIN_LPM * _LPM_TO_LPH, UNUSUAL_FLOW_MAX_LPM * _LPM_TO_LPH
+        if flow < UNUSUAL_FLOW_MIN_LPM:
+            warnings.append(f"flow rate {shown:.1f} {unit} < {low:.1f} {unit}")
+        elif flow > UNUSUAL_FLOW_MAX_LPM:
+            warnings.append(f"flow rate {shown:.0f} {unit} > {high:.0f} {unit}")
+    return warnings
+
+
+def _confirm_zone_schema() -> vol.Schema:
+    """Checkbox form for the unusual-values confirmation step."""
+    return vol.Schema({vol.Required("confirm", default=False): bool})
+
+
 def _coerce_delivery_mode(user_input: dict) -> dict:
     """Downgrade delivery_mode to estimated_flow when the required sensor is missing."""
     dm = user_input.get(CONF_ZONE_DELIVERY_MODE)
@@ -313,6 +350,8 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._data: dict[str, Any] = {}
         self._zones: list[dict[str, Any]] = []
+        self._pending_zone: dict[str, Any] | None = None
+        self._pending_warnings: list[str] = []
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Step 1: Select sensors and ET model parameters."""
@@ -344,7 +383,12 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
                 errors[CONF_ZONE_VOLUME_ENTITY] = "volume_entity_required"
             else:
-                self._zones.append(_zone_input_to_metric(user_input, imperial))
+                zone_metric = _zone_input_to_metric(user_input, imperial)
+                self._pending_warnings = _unusual_zone_values(zone_metric, imperial)
+                if self._pending_warnings:
+                    self._pending_zone = zone_metric
+                    return await self.async_step_confirm_zone()
+                self._zones.append(zone_metric)
                 return await self.async_step_add_another()
 
         return self.async_show_form(
@@ -353,6 +397,33 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={
                 "zone_count": str(len(self._zones)),
+            },
+        )
+
+    async def async_step_confirm_zone(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Soft guard: unusual zone values need explicit confirmation.
+
+        Values outside the plausibility ranges (tiny area, flow rate that
+        smells like a L/min-vs-L/h mix-up) are confirmed, not rejected —
+        planter zones and sprinkler manifolds legitimately exceed them.
+        Declining returns to the zone form to re-enter the values.
+        """
+        if user_input is not None:
+            pending = self._pending_zone
+            self._pending_zone = None
+            if user_input.get("confirm") and pending is not None:
+                self._zones.append(pending)
+                return await self.async_step_add_another()
+            return await self.async_step_zone()
+
+        return self.async_show_form(
+            step_id="confirm_zone",
+            data_schema=_confirm_zone_schema(),
+            description_placeholders={
+                "zone_name": (self._pending_zone or {}).get(CONF_ZONE_NAME, ""),
+                "warnings": "\n".join(f"- {w}" for w in self._pending_warnings),
             },
         )
 
@@ -397,12 +468,15 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         self._config_entry = config_entry
+        self._pending_zone: dict[str, Any] | None = None
+        self._pending_warnings: list[str] = []
+        self._pending_action: str = ""
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Show menu: edit model params or manage zones."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["model_params", "add_zone", "edit_zone", "remove_zone"],
+            menu_options=["model_params", "add_zone", "edit_zone", "check_zones", "remove_zone"],
         )
 
     async def async_step_model_params(
@@ -441,17 +515,28 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                     data_schema=_zone_schema_initial(imperial),
                     errors={"base": "zone_already_exists"},
                 )
-            zones.append(user_input)
-            new_data[CONF_ZONES] = zones
-            if new_data != dict(self._config_entry.data):
-                _LOGGER.debug("Config updated via add_zone — zone added: %s", user_input.get("zone_name"))
-                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
-            return self.async_create_entry(data={})
+            self._pending_warnings = _unusual_zone_values(user_input, imperial)
+            if self._pending_warnings:
+                self._pending_zone = user_input
+                self._pending_action = "add"
+                return await self.async_step_confirm_zone()
+            return self._save_added_zone(user_input)
 
         return self.async_show_form(
             step_id="add_zone",
             data_schema=_zone_schema_initial(imperial),
         )
+
+    def _save_added_zone(self, zone: dict[str, Any]) -> config_entries.ConfigFlowResult:
+        """Append a new zone to the config entry and finish the flow."""
+        new_data = dict(self._config_entry.data)
+        zones = list(new_data.get(CONF_ZONES, []))
+        zones.append(zone)
+        new_data[CONF_ZONES] = zones
+        if new_data != dict(self._config_entry.data):
+            _LOGGER.debug("Config updated via add_zone — zone added: %s", zone.get(CONF_ZONE_NAME))
+            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+        return self.async_create_entry(data={})
 
     async def async_step_edit_zone(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Select a zone to edit."""
@@ -494,17 +579,12 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             user_input = _zone_input_to_metric(user_input, imperial)
             user_input = _coerce_delivery_mode(user_input)
-            new_data = dict(self._config_entry.data)
-            new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
-            new_zones.append(user_input)
-            new_data[CONF_ZONES] = new_zones
-            if new_data != dict(self._config_entry.data):
-                _LOGGER.debug("Config updated via edit_zone — zone edited: %s", self._edit_zone_name)
-                self.hass.config_entries.async_update_entry(
-                    self._config_entry,
-                    data=new_data,
-                )
-            return self.async_create_entry(data={})
+            self._pending_warnings = _unusual_zone_values(user_input, imperial)
+            if self._pending_warnings:
+                self._pending_zone = user_input
+                self._pending_action = "edit"
+                return await self.async_step_confirm_zone()
+            return self._save_edited_zone(user_input)
 
         area_unit = "ft²" if imperial else "m²"
         flow_unit = "gal/h" if imperial else "L/h"
@@ -697,6 +777,73 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             step_id="edit_zone_detail",
             data_schema=schema,
             description_placeholders={"zone_name": self._edit_zone_name},
+        )
+
+    def _save_edited_zone(self, zone: dict[str, Any]) -> config_entries.ConfigFlowResult:
+        """Replace the zone being edited in the config entry and finish the flow."""
+        zones = list(self._config_entry.data.get(CONF_ZONES, []))
+        new_data = dict(self._config_entry.data)
+        new_zones = [z for z in zones if z[CONF_ZONE_NAME] != self._edit_zone_name]
+        new_zones.append(zone)
+        new_data[CONF_ZONES] = new_zones
+        if new_data != dict(self._config_entry.data):
+            _LOGGER.debug("Config updated via edit_zone — zone edited: %s", self._edit_zone_name)
+            self.hass.config_entries.async_update_entry(
+                self._config_entry,
+                data=new_data,
+            )
+        return self.async_create_entry(data={})
+
+    async def async_step_confirm_zone(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Soft guard: unusual zone values need explicit confirmation.
+
+        Same semantics as the initial-setup guard: confirm saves the zone
+        as entered, declining returns to the add/edit form.
+        """
+        if user_input is not None:
+            pending = self._pending_zone
+            self._pending_zone = None
+            if user_input.get("confirm") and pending is not None:
+                if self._pending_action == "edit":
+                    return self._save_edited_zone(pending)
+                return self._save_added_zone(pending)
+            if self._pending_action == "edit":
+                return await self.async_step_edit_zone_detail()
+            return await self.async_step_add_zone()
+
+        return self.async_show_form(
+            step_id="confirm_zone",
+            data_schema=_confirm_zone_schema(),
+            description_placeholders={
+                "zone_name": (self._pending_zone or {}).get(CONF_ZONE_NAME, ""),
+                "warnings": "\n".join(f"- {w}" for w in self._pending_warnings),
+            },
+        )
+
+    async def async_step_check_zones(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Audit all configured zones against the plausibility guards.
+
+        Read-only report for installations configured before the guards
+        existed — nothing is modified; fixes go through 'Edit zone'.
+        """
+        if user_input is not None:
+            return self.async_create_entry(data={})
+
+        imperial = _is_imperial(self.hass)
+        zones = self._config_entry.data.get(CONF_ZONES, [])
+        findings = []
+        for z in zones:
+            findings.extend(f"- {z[CONF_ZONE_NAME]}: {w}" for w in _unusual_zone_values(z, imperial))
+        return self.async_show_form(
+            step_id="check_zones",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "zone_count": str(len(zones)),
+                "findings_count": str(len(findings)),
+                "report": "\n".join(findings) if findings else "✓",
+            },
         )
 
     def _remove_zone_device(self, zone_name: str) -> None:

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -139,3 +139,12 @@ ET_TEMP_VALID_RANGE = (-50.0, 70.0)  # °C physical bounds
 MAX_ZONES = 50
 MAX_ZONE_NAME_LENGTH = 64
 MIN_SERVICE_INTERVAL_S = 10  # minimum seconds between service calls
+
+# ── Zone config plausibility guards (soft-confirm, not blocking) ──
+# Values outside these ranges are almost always unit mistakes (e.g. flow
+# entered in L/min instead of L/h). The config flow asks for confirmation
+# instead of rejecting, since tiny planter zones and high-flow sprinkler
+# manifolds do legitimately exist.
+UNUSUAL_AREA_MIN_M2 = 5.0
+UNUSUAL_FLOW_MIN_LPM = 10.0 / 60.0  # 10 L/h
+UNUSUAL_FLOW_MAX_LPM = 30.0  # 1800 L/h — same bound as the runtime warning in sensor.py

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -741,6 +741,40 @@ class IrrigationController:
         state = self._hass.states.get(zone.valve)
         return state is not None and state.state == "off"
 
+    def _fallback_volume_estimate(self, zone, elapsed_s: float, measured: float) -> float:
+        """Estimate delivered volume when the flow sensor measured nothing.
+
+        A session that ends (delivery timeout, hardware auto-close, stop)
+        with the valve open for ``elapsed_s`` but zero measured flow is far
+        more likely a dead/stale flow sensor than a dry pipe. Returning the
+        raw 0.0 would skip the deficit settle entirely: the deficit would
+        survive up to an hour of real watering and the scheduler would
+        immediately re-irrigate on the next cycle. Fall back to the zone's
+        configured nominal flow rate so the water is still credited.
+        """
+        if measured > 0 or elapsed_s <= 0:
+            return measured
+        if zone._flow_rate <= 0:
+            _LOGGER.warning(
+                "Zone '%s': flow sensor measured 0 L after %.0fs with the valve open"
+                " and no flow_rate configured — cannot estimate delivered volume,"
+                " deficit will NOT be adjusted",
+                zone.zone_name,
+                elapsed_s,
+            )
+            return measured
+        estimate = zone._flow_rate * elapsed_s / 60.0
+        _LOGGER.warning(
+            "Zone '%s': flow sensor measured 0 L after %.0fs with the valve open —"
+            " crediting estimated %.1fL from configured flow_rate (%.2f L/min) so"
+            " the deficit is settled",
+            zone.zone_name,
+            elapsed_s,
+            estimate,
+            zone._flow_rate,
+        )
+        return estimate
+
     async def _deliver_estimated_flow(self, zone) -> float:
         """Open valve, wait calculated duration, close valve."""
         duration = zone.duration_s
@@ -829,7 +863,9 @@ class IrrigationController:
                 await self._hass.services.async_call("switch", "turn_off", {"entity_id": zone.valve})
                 zone.set_irrigating(False)
                 zone.async_write_ha_state()
-                return 0.0
+                # Credit the water dispensed before the stop — the smart valve
+                # was dosing at its nominal rate, capped at the armed volume.
+                return min(volume, self._fallback_volume_estimate(zone, elapsed, 0.0))
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
 
@@ -898,7 +934,7 @@ class IrrigationController:
                 await self._close_valve(zone.valve)
                 zone.set_irrigating(False)
                 zone.async_write_ha_state()
-                return delivered
+                return self._fallback_volume_estimate(zone, elapsed, delivered)
 
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
@@ -948,7 +984,7 @@ class IrrigationController:
         await self._close_valve(zone.valve)
         zone.set_irrigating(False)
         zone.async_write_ha_state()
-        return delivered
+        return self._fallback_volume_estimate(zone, elapsed, delivered)
 
     async def _deliver_flow_rate(
         self,
@@ -981,7 +1017,7 @@ class IrrigationController:
                 await self._close_valve(zone.valve)
                 zone.set_irrigating(False)
                 zone.async_write_ha_state()
-                return delivered
+                return self._fallback_volume_estimate(zone, elapsed, delivered)
 
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
@@ -1031,7 +1067,7 @@ class IrrigationController:
         await self._close_valve(zone.valve)
         zone.set_irrigating(False)
         zone.async_write_ha_state()
-        return delivered
+        return self._fallback_volume_estimate(zone, elapsed, delivered)
 
     def _is_flow_rate_sensor(self, entity_id: str) -> bool:
         """Check if the sensor reports a flow rate (not cumulative volume).

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/drake69/NeverDry/issues",
     "requirements": [],
-    "version": "0.10.8"
+    "version": "0.10.9"
 }

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -91,6 +91,7 @@ from .const import (
     PLANT_FAMILIES,
     RAIN_TYPE_EVENT,
     SYSTEM_TYPES,
+    UNUSUAL_FLOW_MAX_LPM,
 )
 from .controller import IrrigationController
 from .unit_convert import LPM_TO_GPH, LPM_TO_LPH
@@ -856,7 +857,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._area = zone_config.get(CONF_ZONE_AREA, 0.0)
         self._system_type = zone_config.get(CONF_ZONE_SYSTEM_TYPE)
         self._flow_rate = zone_config.get(CONF_ZONE_FLOW_RATE, 0.0)
-        if self._flow_rate > 30:
+        if self._flow_rate > UNUSUAL_FLOW_MAX_LPM:
             _LOGGER.warning(
                 "Zone '%s': flow_rate_lpm=%.1f L/min (= %.0f L/h) looks unrealistically high "
                 "for garden irrigation. If you configured it in L/h, divide by 60 (e.g. %.0f L/h → %.2f L/min).",

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -60,6 +60,13 @@
           "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },
+      "confirm_zone": {
+        "title": "Unusual zone values",
+        "description": "Zone \"{zone_name}\" has values outside the typical range:\n\n{warnings}\n\nThis often means a unit mix-up (e.g. flow rate entered in L/min instead of L/h). Tick the box to save anyway, or submit without ticking to go back and correct the values.",
+        "data": {
+          "confirm": "These values are correct, save the zone"
+        }
+      },
       "add_another": {
         "title": "Add another zone?",
         "description": "You have configured {zone_count} zone(s): {zone_names}.",
@@ -89,6 +96,7 @@
           "model_params": "Edit model parameters (α, T_base, D_max)",
           "add_zone": "Add a new irrigation zone",
           "edit_zone": "Edit an irrigation zone",
+          "check_zones": "Check configured zones for unusual values",
           "remove_zone": "Remove an irrigation zone"
         }
       },
@@ -121,6 +129,13 @@
           "irrigation_time": "Daily irrigation time"
         }
       },
+      "confirm_zone": {
+        "title": "Unusual zone values",
+        "description": "Zone \"{zone_name}\" has values outside the typical range:\n\n{warnings}\n\nThis often means a unit mix-up (e.g. flow rate entered in L/min instead of L/h). Tick the box to save anyway, or submit without ticking to go back and correct the values.",
+        "data": {
+          "confirm": "These values are correct, save the zone"
+        }
+      },
       "edit_zone": {
         "title": "Edit irrigation zone",
         "data": {
@@ -146,6 +161,10 @@
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
         }
+      },
+      "check_zones": {
+        "title": "Check configured zones",
+        "description": "Checked {zone_count} zone(s) — {findings_count} unusual value(s) found:\n\n{report}\n\nUse \"Edit an irrigation zone\" to correct them. Unusual values can still be legitimate (planter zones, sprinkler manifolds) — this is only a plausibility check, nothing was modified."
       },
       "remove_zone": {
         "title": "Remove irrigation zone",

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -60,6 +60,13 @@
           "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },
+      "confirm_zone": {
+        "title": "Unusual zone values",
+        "description": "Zone \"{zone_name}\" has values outside the typical range:\n\n{warnings}\n\nThis often means a unit mix-up (e.g. flow rate entered in L/min instead of L/h). Tick the box to save anyway, or submit without ticking to go back and correct the values.",
+        "data": {
+          "confirm": "These values are correct, save the zone"
+        }
+      },
       "add_another": {
         "title": "Add another zone?",
         "description": "You have configured {zone_count} zone(s): {zone_names}.",
@@ -89,6 +96,7 @@
           "model_params": "Edit model parameters (α, T_base, D_max)",
           "add_zone": "Add a new irrigation zone",
           "edit_zone": "Edit an irrigation zone",
+          "check_zones": "Check configured zones for unusual values",
           "remove_zone": "Remove an irrigation zone"
         }
       },
@@ -121,6 +129,13 @@
           "irrigation_time": "Daily irrigation time"
         }
       },
+      "confirm_zone": {
+        "title": "Unusual zone values",
+        "description": "Zone \"{zone_name}\" has values outside the typical range:\n\n{warnings}\n\nThis often means a unit mix-up (e.g. flow rate entered in L/min instead of L/h). Tick the box to save anyway, or submit without ticking to go back and correct the values.",
+        "data": {
+          "confirm": "These values are correct, save the zone"
+        }
+      },
       "edit_zone": {
         "title": "Edit irrigation zone",
         "data": {
@@ -146,6 +161,10 @@
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
         }
+      },
+      "check_zones": {
+        "title": "Check configured zones",
+        "description": "Checked {zone_count} zone(s) — {findings_count} unusual value(s) found:\n\n{report}\n\nUse \"Edit an irrigation zone\" to correct them. Unusual values can still be legitimate (planter zones, sprinkler manifolds) — this is only a plausibility check, nothing was modified."
       },
       "remove_zone": {
         "title": "Remove irrigation zone",

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -60,6 +60,13 @@
           "irrigation_time": "Ora del giorno in cui NeverDry verifica il deficit e irriga se supera la soglia. Lascia vuoto per disabilitare la pianificazione automatica"
         }
       },
+      "confirm_zone": {
+        "title": "Valori zona inusuali",
+        "description": "La zona \"{zone_name}\" ha valori fuori dall'intervallo tipico:\n\n{warnings}\n\nSpesso indica un errore di unità (es. portata inserita in L/min invece che L/h). Spunta la casella per salvare comunque, oppure invia senza spuntare per tornare indietro e correggere i valori.",
+        "data": {
+          "confirm": "I valori sono corretti, salva la zona"
+        }
+      },
       "add_another": {
         "title": "Aggiungere un'altra zona?",
         "description": "Hai configurato {zone_count} zona/e: {zone_names}.",
@@ -89,6 +96,7 @@
           "model_params": "Modifica i parametri del modello (α, T_base, D_max)",
           "add_zone": "Aggiungi una nuova zona di irrigazione",
           "edit_zone": "Modifica una zona di irrigazione",
+          "check_zones": "Verifica le zone configurate (valori inusuali)",
           "remove_zone": "Rimuovi una zona di irrigazione"
         }
       },
@@ -121,6 +129,13 @@
           "irrigation_time": "Orario di irrigazione giornaliero"
         }
       },
+      "confirm_zone": {
+        "title": "Valori zona inusuali",
+        "description": "La zona \"{zone_name}\" ha valori fuori dall'intervallo tipico:\n\n{warnings}\n\nSpesso indica un errore di unità (es. portata inserita in L/min invece che L/h). Spunta la casella per salvare comunque, oppure invia senza spuntare per tornare indietro e correggere i valori.",
+        "data": {
+          "confirm": "I valori sono corretti, salva la zona"
+        }
+      },
       "edit_zone": {
         "title": "Modifica zona di irrigazione",
         "data": {
@@ -146,6 +161,10 @@
           "threshold": "Soglia di irrigazione",
           "irrigation_time": "Orario di irrigazione giornaliero"
         }
+      },
+      "check_zones": {
+        "title": "Verifica zone configurate",
+        "description": "Verificate {zone_count} zone — {findings_count} valori inusuali trovati:\n\n{report}\n\nUsa \"Modifica una zona di irrigazione\" per correggerli. Valori inusuali possono comunque essere legittimi (fioriere, impianti sprinkler): è solo un controllo di plausibilità, nulla è stato modificato."
       },
       "remove_zone": {
         "title": "Rimuovi zona di irrigazione",

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -418,13 +418,21 @@
 <!-- What's new -->
 <section class="how-it-works">
     <div class="container">
-        <h2>What's new in v0.10.8</h2>
-        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-07-04</p>
+        <h2>What's new in v0.10.9</h2>
+        <p style="margin-bottom: 1.2em; opacity: 0.8;">Released 2026-07-05</p>
         <ul style="max-width: 680px; margin: 0 auto; text-align: left; line-height: 2;">
-            <li><strong>Zone Card loads reliably</strong> — the card is now registered as a real Lovelace resource, fixing "Custom element doesn't exist: never-dry-zone-card" after install or upgrade (no more manual cache clearing).</li>
-            <li><strong>Card editor hardening</strong> — zone names are now HTML-escaped in the card editor.</li>
+            <li><strong>Zone Card fixed on HA 2026.2+</strong> — Home Assistant renamed an internal Lovelace attribute, so the card resource was never registered and "Custom element doesn't exist: never-dry-zone-card" was back. Now detected correctly on all HA versions, with clear log messages if registration falls back.</li>
+            <li><strong>Deficit settles on delivery timeout</strong> — if the flow sensor reads zero while the valve is actually watering, the delivered volume is now estimated from the configured flow rate, so the deficit no longer stays stuck (and irrigation no longer repeats endlessly).</li>
+            <li><strong>Config sanity guards</strong> — unusual zone values (area below 5 m², flow rate below 10 L/h or above 1800 L/h — usually a L/min vs L/h mix-up) now ask for confirmation before saving, and a new "Check configured zones" menu entry audits existing zones.</li>
         </ul>
-        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.8">Full release notes on GitHub →</a></p>
+        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.9">Full release notes on GitHub →</a></p>
+        <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
+            <summary style="cursor: pointer;">v0.10.8 — 2026-07-04</summary>
+            <ul style="line-height: 2; margin-top: 0.5em;">
+                <li><strong>Zone Card loads reliably</strong> — the card is now registered as a real Lovelace resource, fixing "Custom element doesn't exist: never-dry-zone-card" after install or upgrade (no more manual cache clearing).</li>
+                <li><strong>Card editor hardening</strong> — zone names are now HTML-escaped in the card editor.</li>
+            </ul>
+        </details>
         <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
             <summary style="cursor: pointer;">v0.10.7 — 2026-06-27</summary>
             <ul style="line-height: 2; margin-top: 0.5em;">

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -338,6 +338,35 @@ class TestFlowMeterDelivery:
         assert result == 0.0
 
     @pytest.mark.asyncio
+    async def test_stop_during_flow_rate(self, hass_mock, di_sensor):
+        """A stop request aborts the flow_rate loop and closes the valve."""
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_rate",
+                CONF_ZONE_DELIVERY_TIMEOUT: 100,
+            },
+        )
+        zone._zone_deficit = 5.0
+
+        meter_state = MagicMock()
+        meter_state.state = "10.0"
+        meter_state.attributes = {"unit_of_measurement": "L/min"}
+        hass_mock.states.get = MagicMock(return_value=meter_state)
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        ctrl._stop_requested = True
+
+        result = await ctrl._deliver_flow_rate(zone, "sensor.flow_rate", 100.0)
+
+        # Stopped before any integration step: nothing delivered, valve closed.
+        assert result == 0.0
+        close_calls = [c for c in hass_mock.services.async_call.call_args_list if "turn_off" in str(c)]
+        assert len(close_calls) >= 1
+
+    @pytest.mark.asyncio
     async def test_external_close_ends_flow_rate(self, hass_mock, di_sensor):
         """Flow-rate delivery ends as soon as the valve switch reads 'off'
         (hardware auto-close) rather than integrating for the full timeout."""

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -529,3 +529,149 @@ class TestSettleWaterAccounting:
         zone = _make_zone(hass_mock, di_sensor)
         attrs = zone.extra_state_attributes
         assert "delivery_timeout_s" not in attrs
+
+
+class TestZeroFlowTimeoutFallback:
+    """Regression: delivery timeout with zero measured flow must still settle.
+
+    Field report: the valve stayed open for the whole ``delivery_timeout``
+    (~1h), was closed by the timeout, yet the zone deficit was unchanged —
+    so the scheduler immediately wanted to irrigate again. Root cause: the
+    flow-based modes returned the measured 0.0, ``_irrigate_zones`` only
+    settles zones with ``delivered > 0``, and the hour of real watering was
+    never credited. The fix estimates the volume from the configured
+    nominal flow_rate whenever the sensor measured nothing while the valve
+    was open.
+    """
+
+    @staticmethod
+    def _stuck_states(zone, meter_entity, meter_value, unit):
+        """states.get side effect: flow sensor frozen, valve always 'on'."""
+
+        def get_state(entity_id):
+            if entity_id == meter_entity:
+                s = MagicMock()
+                s.state = meter_value
+                s.attributes = {"unit_of_measurement": unit}
+                return s
+            if entity_id == zone.valve:
+                s = MagicMock()
+                s.state = "on"
+                return s
+            return None
+
+        return get_state
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_dead_flow_meter_settles_deficit(self, hass_mock, di_sensor):
+        """End-to-end reproduction of the reported bug via _irrigate_zones."""
+        timeout_s = 2 * FLOW_METER_POLL_INTERVAL_S
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+                CONF_ZONE_DELIVERY_TIMEOUT: timeout_s,
+            },
+        )
+        zone._zone_deficit = 5.0
+        hass_mock.states.get = MagicMock(
+            side_effect=self._stuck_states(zone, "sensor.flow_meter", "100.0", "L"),
+        )
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        await ctrl._irrigate_zones(["TestZone"])
+
+        # The valve was open for the full timeout at the configured 8 L/min:
+        # the settle must credit that water even though the meter read 0.
+        expected_liters = 8.0 * timeout_s / 60.0
+        expected_mm = expected_liters * zone._efficiency / zone._area
+        assert zone._zone_deficit == pytest.approx(5.0 - expected_mm, abs=0.01)
+        assert zone._zone_deficit < 5.0
+        assert zone._total_water_delivered == pytest.approx(expected_liters, abs=0.2)
+        assert zone._last_irrigated is not None
+
+    @pytest.mark.asyncio
+    async def test_flow_meter_timeout_zero_flow_credits_estimate(self, hass_mock, di_sensor):
+        timeout_s = 2 * FLOW_METER_POLL_INTERVAL_S
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+                CONF_ZONE_DELIVERY_TIMEOUT: timeout_s,
+            },
+        )
+        zone._zone_deficit = 5.0
+        hass_mock.states.get = MagicMock(
+            side_effect=self._stuck_states(zone, "sensor.flow_meter", "100.0", "L"),
+        )
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        result = await ctrl._deliver_flow_meter(zone)
+
+        assert result == pytest.approx(8.0 * timeout_s / 60.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_flow_rate_timeout_zero_flow_credits_estimate(self, hass_mock, di_sensor):
+        timeout_s = 2 * FLOW_METER_POLL_INTERVAL_S
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_rate",
+                CONF_ZONE_DELIVERY_TIMEOUT: timeout_s,
+            },
+        )
+        zone._zone_deficit = 5.0
+        hass_mock.states.get = MagicMock(
+            side_effect=self._stuck_states(zone, "sensor.flow_rate", "0.0", "L/min"),
+        )
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        result = await ctrl._deliver_flow_rate(zone, "sensor.flow_rate", 1000.0)
+
+        assert result == pytest.approx(8.0 * timeout_s / 60.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_zero_flow_without_flow_rate_cannot_estimate(self, hass_mock, di_sensor):
+        """Without a configured flow_rate there is no basis for an estimate."""
+        timeout_s = 2 * FLOW_METER_POLL_INTERVAL_S
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_FLOW_RATE: 0.0,
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+                CONF_ZONE_DELIVERY_TIMEOUT: timeout_s,
+            },
+        )
+        zone._zone_deficit = 5.0
+        hass_mock.states.get = MagicMock(
+            side_effect=self._stuck_states(zone, "sensor.flow_meter", "100.0", "L"),
+        )
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        result = await ctrl._deliver_flow_meter(zone)
+
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_measured_flow_wins_over_estimate(self, hass_mock, di_sensor):
+        """When the meter DID measure water, the fallback must not replace it."""
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+                CONF_ZONE_DELIVERY_TIMEOUT: 100,
+            },
+        )
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+        assert ctrl._fallback_volume_estimate(zone, 3600, 42.0) == 42.0

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -96,8 +96,13 @@ def _make_resources(items=None, loaded=True):
     return resources
 
 
-def _with_lovelace(hass, mode="storage", resources=None):
-    hass.data["lovelace"] = SimpleNamespace(mode=mode, resources=resources or _make_resources())
+def _with_lovelace(hass, mode="storage", resources=None, mode_attr="mode"):
+    """Inject a fake LovelaceData into hass.data.
+
+    ``mode_attr`` selects the dataclass field name: "mode" mirrors HA ≤ 2026.1,
+    "resource_mode" mirrors HA ≥ 2026.2 (renamed in core PR #158265).
+    """
+    hass.data["lovelace"] = SimpleNamespace(**{mode_attr: mode, "resources": resources or _make_resources()})
     return hass.data["lovelace"].resources
 
 
@@ -171,3 +176,45 @@ async def test_yaml_mode_falls_back_to_extra_js_url(frontend_stubs):
     resources.async_create_item.assert_not_awaited()
     add_extra_js_url.assert_called_once()
     assert hass.data[DOMAIN][_FRONTEND_REGISTERED] is True
+
+
+async def test_storage_mode_detected_via_resource_mode(frontend_stubs):
+    """Regression GH #99: HA 2026.2 renamed LovelaceData.mode to resource_mode.
+
+    On HA ≥ 2026.2 the old attribute is gone; the storage-mode detection must
+    read resource_mode, otherwise every install silently falls back to the
+    unreliable add_extra_js_url and the card is never loaded.
+    """
+    add_extra_js_url = frontend_stubs
+    hass = _make_hass()
+    resources = _with_lovelace(hass, mode_attr="resource_mode")
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_awaited_once()
+    add_extra_js_url.assert_not_called()
+    assert hass.data[DOMAIN][_FRONTEND_REGISTERED] is True
+
+
+async def test_yaml_mode_via_resource_mode_falls_back(frontend_stubs):
+    """YAML mode expressed through the renamed attribute also falls back."""
+    add_extra_js_url = frontend_stubs
+    hass = _make_hass()
+    resources = _with_lovelace(hass, mode="yaml", mode_attr="resource_mode")
+
+    await _async_register_frontend(hass)
+
+    resources.async_create_item.assert_not_awaited()
+    add_extra_js_url.assert_called_once()
+
+
+async def test_missing_lovelace_data_logs_fallback(frontend_stubs, caplog):
+    """The fallback path must be diagnosable from the logs (gap behind GH #99)."""
+    add_extra_js_url = frontend_stubs
+    hass = _make_hass()  # no "lovelace" key in hass.data
+
+    with caplog.at_level("WARNING", logger="never_dry"):
+        await _async_register_frontend(hass)
+
+    add_extra_js_url.assert_called_once()
+    assert any("falling back to add_extra_js_url" in r.message for r in caplog.records)

--- a/tests/test_zone_config_guards.py
+++ b/tests/test_zone_config_guards.py
@@ -1,0 +1,270 @@
+"""Tests for the zone-config plausibility guards.
+
+Unusual values (tiny area, flow rate that smells like a L/min-vs-L/h
+mix-up) trigger a soft confirmation step instead of a hard error, and the
+options flow offers a read-only "check zones" report for installations
+configured before the guards existed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from never_dry import config_flow as cf
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+    UNUSUAL_AREA_MIN_M2,
+    UNUSUAL_FLOW_MAX_LPM,
+    UNUSUAL_FLOW_MIN_LPM,
+)
+
+
+def _entry(zones):
+    entry = MagicMock()
+    entry.entry_id = "abc"
+    entry.data = {CONF_ZONES: zones}
+    return entry
+
+
+@pytest.fixture(autouse=True)
+def _patch_flow_env(monkeypatch):
+    """Fill the gaps in the conftest HA stubs for flow-step tests.
+
+    The stubbed ``homeassistant`` is not a package (no ``util.unit_system``),
+    ``voluptuous``/``selector`` are empty modules, and the stub flow base
+    classes have no ``async_show_form``/``async_create_entry``/``async_show_menu``.
+    Patch just enough to drive the steps and inspect their results.
+    """
+    monkeypatch.setattr(cf, "_is_imperial", lambda hass: False)
+
+    monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial: None)
+
+    def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "errors": errors,
+            "description_placeholders": description_placeholders,
+        }
+
+    def _create_entry(self, *, data=None, title=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    for klass in (cf.NeverDryConfigFlow, cf.NeverDryOptionsFlow):
+        monkeypatch.setattr(klass, "async_show_form", _show_form, raising=False)
+        monkeypatch.setattr(klass, "async_create_entry", _create_entry, raising=False)
+
+
+class TestUnusualZoneValues:
+    """The pure helper operating on metric zone dicts."""
+
+    def test_plausible_zone_is_clean(self):
+        zone = {CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 3.33}
+        assert cf._unusual_zone_values(zone, imperial=False) == []
+
+    def test_small_area_flagged(self):
+        warnings = cf._unusual_zone_values({CONF_ZONE_AREA: 2.0}, imperial=False)
+        assert len(warnings) == 1
+        assert "m²" in warnings[0]
+
+    def test_low_flow_flagged(self):
+        zone = {CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 5.0 / 60.0}  # 5 L/h
+        warnings = cf._unusual_zone_values(zone, imperial=False)
+        assert len(warnings) == 1
+        assert "L/h" in warnings[0]
+
+    def test_high_flow_flagged(self):
+        # The classic unit mix-up: 200 L/h typed where L/min is stored.
+        zone = {CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 200.0}
+        warnings = cf._unusual_zone_values(zone, imperial=False)
+        assert len(warnings) == 1
+        assert "12000" in warnings[0]  # 200 L/min shown as 12000 L/h
+
+    def test_boundary_values_not_flagged(self):
+        zone = {
+            CONF_ZONE_AREA: UNUSUAL_AREA_MIN_M2,
+            CONF_ZONE_FLOW_RATE: UNUSUAL_FLOW_MAX_LPM,
+        }
+        assert cf._unusual_zone_values(zone, imperial=False) == []
+        zone[CONF_ZONE_FLOW_RATE] = UNUSUAL_FLOW_MIN_LPM
+        assert cf._unusual_zone_values(zone, imperial=False) == []
+
+    def test_missing_values_ignored(self):
+        assert cf._unusual_zone_values({}, imperial=False) == []
+
+    def test_imperial_messages_use_imperial_units(self):
+        zone = {CONF_ZONE_AREA: 2.0, CONF_ZONE_FLOW_RATE: 200.0}
+        warnings = cf._unusual_zone_values(zone, imperial=True)
+        assert len(warnings) == 2
+        assert "ft²" in warnings[0]
+        assert "gal/h" in warnings[1]
+
+
+class TestInitialFlowSoftConfirm:
+    """Initial setup: zone step routes through confirm_zone on unusual input."""
+
+    @pytest.mark.asyncio
+    async def test_unusual_zone_asks_confirmation(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        # Form units: area m², flow L/h. Both implausible.
+        result = await flow.async_step_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        assert result["step_id"] == "confirm_zone"
+        assert flow._zones == []
+
+    @pytest.mark.asyncio
+    async def test_confirm_saves_zone_metric(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        await flow.async_step_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        result = await flow.async_step_confirm_zone({"confirm": True})
+
+        assert result["step_id"] == "add_another"
+        assert len(flow._zones) == 1
+        assert flow._zones[0][CONF_ZONE_NAME] == "Vaso"
+        # Stored metric: 5 L/h → L/min
+        assert flow._zones[0][CONF_ZONE_FLOW_RATE] == pytest.approx(5.0 / 60.0)
+
+    @pytest.mark.asyncio
+    async def test_decline_returns_to_zone_form(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        await flow.async_step_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        result = await flow.async_step_confirm_zone({"confirm": False})
+
+        assert result["step_id"] == "zone"
+        assert flow._zones == []
+
+    @pytest.mark.asyncio
+    async def test_plausible_zone_skips_confirmation(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(
+            {CONF_ZONE_NAME: "Orto", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 200.0},
+        )
+
+        assert result["step_id"] == "add_another"
+        assert len(flow._zones) == 1
+
+
+class TestOptionsFlowSoftConfirm:
+    """Options flow: add/edit zone route through confirm_zone on unusual input."""
+
+    @pytest.mark.asyncio
+    async def test_add_zone_unusual_asks_confirmation(self, hass_mock):
+        flow = cf.NeverDryOptionsFlow(_entry([]))
+        flow.hass = hass_mock
+
+        result = await flow.async_step_add_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        assert result["step_id"] == "confirm_zone"
+        hass_mock.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confirm_saves_added_zone(self, hass_mock):
+        flow = cf.NeverDryOptionsFlow(_entry([]))
+        flow.hass = hass_mock
+        await flow.async_step_add_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        result = await flow.async_step_confirm_zone({"confirm": True})
+
+        assert result["type"] == "create_entry"
+        saved = hass_mock.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert saved[CONF_ZONES][0][CONF_ZONE_NAME] == "Vaso"
+
+    @pytest.mark.asyncio
+    async def test_decline_returns_to_add_zone_form(self, hass_mock):
+        flow = cf.NeverDryOptionsFlow(_entry([]))
+        flow.hass = hass_mock
+        await flow.async_step_add_zone(
+            {CONF_ZONE_NAME: "Vaso", CONF_ZONE_AREA: 1.0, CONF_ZONE_FLOW_RATE: 5.0},
+        )
+
+        result = await flow.async_step_confirm_zone({"confirm": False})
+
+        assert result["step_id"] == "add_zone"
+        hass_mock.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_edit_zone_unusual_asks_confirmation(self, hass_mock):
+        existing = {CONF_ZONE_NAME: "Orto", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 3.33}
+        flow = cf.NeverDryOptionsFlow(_entry([existing]))
+        flow.hass = hass_mock
+        flow._edit_zone_name = "Orto"
+
+        # Edit introduces the L/min-vs-L/h mistake: 12000 L/h form value.
+        result = await flow.async_step_edit_zone_detail(
+            {CONF_ZONE_NAME: "Orto", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 12000.0},
+        )
+
+        assert result["step_id"] == "confirm_zone"
+        hass_mock.config_entries.async_update_entry.assert_not_called()
+
+        result = await flow.async_step_confirm_zone({"confirm": True})
+
+        assert result["type"] == "create_entry"
+        saved = hass_mock.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert saved[CONF_ZONES][0][CONF_ZONE_FLOW_RATE] == pytest.approx(200.0)
+
+
+class TestCheckZonesReport:
+    """Read-only audit of all configured zones from the options menu."""
+
+    @pytest.mark.asyncio
+    async def test_report_lists_only_unusual_zones(self, hass_mock):
+        zones = [
+            {CONF_ZONE_NAME: "Orto", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 3.33},
+            {CONF_ZONE_NAME: "Melograno", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 200.0},
+        ]
+        flow = cf.NeverDryOptionsFlow(_entry(zones))
+        flow.hass = hass_mock
+
+        result = await flow.async_step_check_zones()
+
+        assert result["step_id"] == "check_zones"
+        placeholders = result["description_placeholders"]
+        assert placeholders["zone_count"] == "2"
+        assert placeholders["findings_count"] == "1"
+        assert "Melograno" in placeholders["report"]
+        assert "Orto" not in placeholders["report"]
+
+    @pytest.mark.asyncio
+    async def test_report_clean_when_all_plausible(self, hass_mock):
+        zones = [{CONF_ZONE_NAME: "Orto", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 3.33}]
+        flow = cf.NeverDryOptionsFlow(_entry(zones))
+        flow.hass = hass_mock
+
+        result = await flow.async_step_check_zones()
+
+        assert result["description_placeholders"]["findings_count"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_submit_closes_flow_without_changes(self, hass_mock):
+        flow = cf.NeverDryOptionsFlow(_entry([]))
+        flow.hass = hass_mock
+
+        result = await flow.async_step_check_zones({})
+
+        assert result["type"] == "create_entry"
+        hass_mock.config_entries.async_update_entry.assert_not_called()


### PR DESCRIPTION
## Summary

Two changes, one field-reported bug and one preventive guard:

### 1. Fix: deficit not settled when delivery timeout expires with zero measured flow
Field report: a valve stayed open for the whole `delivery_timeout` (~1h), was closed by the timeout, yet the zone deficit was unchanged — so the scheduler immediately wanted to irrigate again, looping an hour of watering per cycle.

Root cause: flow-based delivery modes (`_deliver_flow_meter`, `_deliver_flow_rate`) return the *measured* volume. With a dead/stale flow sensor that reads 0 for the whole session they returned `0.0`, and `_irrigate_zones` only settles zones with `delivered > 0` — the real watering was never credited.

Fix: new `_fallback_volume_estimate()` — when the session ends with zero measured flow but the valve was open for `elapsed_s`, credit `configured flow_rate × elapsed` so the settle runs (deficit reduced, `last_irrigated` updated, SESSION_RESULT logged). Also applied to the abort path of `_deliver_volume_preset` (capped at the armed dose). Without a configured `flow_rate`, an explicit warning is logged instead.

### 2. Zone config plausibility guards (soft-confirm)
Catch the classic L/min-vs-L/h mix-up when the value is typed, not later in the logs:
- Thresholds in `const.py`: area < 5 m², flow < 10 L/h or > 1800 L/h (the runtime warning in `sensor.py` now reuses the same upper bound).
- Unusual values in initial setup / add zone / edit zone route to a `confirm_zone` step: tick to save anyway, decline to go back. Nothing is hard-rejected (planter zones and sprinkler manifolds legitimately exceed the ranges).
- New options-menu entry **Check configured zones**: read-only report of unusual values across existing zones.
- Translations (en, it, strings.json).

## Testing
- End-to-end regression test reproducing the field report — verified failing on the pre-fix code, passing with the fix.
- 4 more tests on the fallback paths; 18 tests for the guards (thresholds, boundaries, confirm/decline in both flows, check-zones report).
- Full suite: 645 passed, ruff clean.

### 3. Fix: zone card Lovelace resource never registered on HA ≥ 2026.2 (fixes #99)
HA core 2026.2 renamed `LovelaceData.mode` → `resource_mode` (home-assistant/core#158265). The storage-mode detection read the old attribute, so on HA ≥ 2026.2 the resource registration from #98 never executed and every install silently fell back to `add_extra_js_url` — the service-worker-fragile mechanism #98 was meant to replace. Fixed by reading `resource_mode` with fallback to `mode` (HA ≤ 2026.1), and logging both fallback paths so this is diagnosable from logs. Regression test verified failing on pre-fix code. **Verified live on HA test instance**: `.storage/lovelace_resources` now contains the card entry after restart.

### Release
Bumps version to **0.10.9** and updates the What's new section (patch release for the user-facing #99 regression).