### PR TITLE
Add domain object model design doc; realign docs with codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,41 @@ If a valve doesn't respond after three attempts, NeverDry blocks that zone and s
 
 ## Sensors and entities
 
+**Integration-level:**
+
 | Entity | Native unit | Description |
 |--------|-------------|-------------|
 | `sensor.et_hourly_estimate` | mm/h | Instantaneous evapotranspiration rate |
 | `sensor.never_dry` | mm | Reference soil water deficit (Kc=1.0) |
-| `sensor.<zone>_volume` | L | Per-zone volume delivered; attributes: `duration_s`, `deficit_mm`, `kc`, `plant_family`, `irrigating`, ... |
-| `sensor.<zone>_deficit` | mm | Per-zone water deficit; attributes: `valve_fsm_state`, `valve_in_maintenance`, `irrigating`, `flow_rate_lpm` |
-| `sensor.<zone>_valve` | — | Mirror of the physical valve state (`open`/`closed`) inside the zone device card |
-| `sensor.<zone>_battery` | % | Mirror of the valve battery sensor inside the zone device card |
-| `sensor.<zone>_flow_meter` | L/min | Mirror of the flow meter inside the zone device card |
-| `button.<zone>_reset_maintenance` | — | Unlock a valve that NeverDry blocked after repeated failures |
+
+**Per zone** (grouped under each zone's device card):
+
+| Entity | Native unit | Description |
+|--------|-------------|-------------|
+| `sensor.<zone>_volume` | L | Volume needed by the next session; attributes: `duration_s`, `deficit_mm`, `kc`, `plant_family`, `irrigating`, ... |
+| `sensor.<zone>_deficit` | mm | Zone water deficit; attributes: `valve_fsm_state`, `valve_in_maintenance`, `irrigating`, `flow_rate_lpm` |
+| `sensor.<zone>_duration` | s | Estimated duration of the next session |
+| `sensor.<zone>_last_irrigated` | timestamp | When the zone was last irrigated |
+| `sensor.<zone>_last_source` | — | What triggered the last irrigation (service, button, schedule, ...) |
+| `sensor.<zone>_last_volume` | L | Water delivered by the last session |
+| `sensor.<zone>_last_duration` | s | Duration of the last session |
+| `sensor.<zone>_session_water` | L | Water delivered in the current session |
+| `sensor.<zone>_yearly_water` | L | Cumulative water delivered this year |
+| `sensor.<zone>_rain` | mm | Cumulative rain accounted for the zone |
+| `sensor.<zone>_kc` | — | Current crop coefficient (seasonal) |
+| `sensor.<zone>_flow_rate` | L/min | Configured flow rate |
+| `sensor.<zone>_threshold` | mm | Configured trigger threshold |
+| `sensor.<zone>_area` | m² | Configured irrigated area |
+| `sensor.<zone>_efficiency` | — | Configured system efficiency |
+| `sensor.<zone>_irrigation_mode` | — | Scheduling mode (manual / reactive / scheduled) |
+| `sensor.<zone>_irrigation_time` | — | Daily irrigation time (scheduled mode) |
+| `sensor.<zone>_valve` | — | Mirror of the physical valve state (`open`/`closed`) |
+| `sensor.<zone>_battery` | % | Mirror of the valve battery sensor |
+| `sensor.<zone>_flow_meter` | L/min | Mirror of the flow meter |
+| `button.<zone>_irrigate` | — | Start an irrigation session now |
+| `button.<zone>_mark_irrigated` | — | Reset the deficit without opening the valve |
+| `button.<zone>_stop` | — | Stop the zone's irrigation immediately |
+| `button.<zone>_reset_valve` | — | Unlock a valve that NeverDry blocked after repeated failures |
 
 All sensors that carry a physical unit declare the proper HA `device_class` (e.g. `precipitation`, `volume_storage`, `volume_flow_rate`). Home Assistant automatically converts the displayed unit to your system preference — go to **Settings → System → General → Unit system** to switch between metric and imperial. Deficit values appear in mm or inches; volumes in litres or gallons; flow rate in L/min or gal/min; ET rate in mm/h or in/h.
 
@@ -87,6 +112,8 @@ Labels and units follow your Home Assistant language and unit system automatical
 | `never_dry.irrigate_zone` | Open valve, water for the calculated duration, close, update zone deficit |
 | `never_dry.irrigate_all` | Water all zones one by one, then mark all as done |
 | `never_dry.stop` | Emergency stop — close all valves immediately |
+| `never_dry.stop_zone` | Stop irrigation for a single zone and close its valve |
+| `never_dry.mark_irrigated` | Reset a zone's deficit without opening the valve — for when you watered manually |
 | `never_dry.reset` | Reset all zone deficits to zero |
 | `never_dry.reset_valve` | Unlock a valve blocked by NeverDry after repeated close failures |
 | `never_dry.set_deficit` | Set the deficit of one zone (or all zones) to an arbitrary mm value — useful for testing and manual calibration |

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -1,0 +1,77 @@
+# Design — Domain Object Model
+
+**Status:** Draft
+**Date:** 2026-07-05
+**Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump)
+
+## Purpose
+
+Define the conceptual objects of NeverDry's irrigation domain, independent of the current
+module layout. This model guides where new features belong (e.g. "does the master valve go
+in the scheduler or in the system?") and what should become an explicit first-class object
+as the codebase evolves. For the current module/data-flow architecture see
+`developer_manual.md` §1.
+
+## The five objects
+
+| Object | Responsibility | Key attributes |
+|---|---|---|
+| **System** | Global model and shared infrastructure | α (ET sensitivity), D_max, global sensors (temperature, rain), *declares* the master valve/pump |
+| **Zone** | Irrigation unit; translates the model into water demand | Kc / plant family, area, sun exposure; cycle & soak rule; translates mm → liters |
+| **Scheduler** | The *when* | Time windows, sequences, calendars |
+| **ZoneDriver** | The *how* — actuation of one zone's water demand | Entity adapter (`valve.*`/`switch.*`), delivery mode (native volume in liters vs time in seconds via flow rate), flow rate, zero-flow guard |
+| **MasterDriver** | Coordination of shared hydraulics (pump / master valve) | ON when any ZoneDriver is active, OFF when none; configurable off-delay; no notion of liters |
+
+ZoneDriver and MasterDriver are two specializations of a common **Driver** base, which owns
+what they share: the entity adapter, ON/OFF command with state confirmation, adaptive
+latency/timeout, and the safety layers (watchdog, close on error/stop/restart).
+
+## Translation chain
+
+```
+System     computes the deficit (mm)            α, D_max, FAO-56 water balance
+   │
+Zone       translates mm → liters (via area)    applies cycle & soak
+   │
+ZoneDriver translates liters → actuation        native volume if supported,
+   │                                            else seconds via flow rate
+Scheduler  decides in which window it happens
+```
+
+Liters are the **contract** between Zone and ZoneDriver: the zone always requests liters;
+only the driver knows whether to deliver them by volume or by time. This makes the fallback
+natural — same request, two actuation strategies.
+
+## Design decisions
+
+### Master valve/pump: declared in System, executed by a Driver
+
+The master valve is not scheduling logic — it takes no decisions. It reacts to the aggregate
+execution state (an OR over zone drivers), with an off-delay to avoid pump cycling during
+sequential zone runs. It is shared hydraulic infrastructure, like the global sensors, so its
+*configuration* lives at system level (as requested in GH #95: "master entity configurable at
+integration level").
+
+Its *execution* however is a Driver: modeling it as a Driver specialization means the safety
+layers (never leave the pump running on error/stop/restart) are written once in the base and
+inherited — instead of duplicating watchdog and error handling inside "system" as a special
+case.
+
+### Cycle & soak: a Zone rule
+
+Cycle/soak parameters depend on soil infiltration rate and zone properties (slope, soil
+type), so they are per-zone configuration. The *execution* of the cycles is driver/controller
+mechanics, but the rule lives in the Zone.
+
+## Mapping to current code (2026-07-05)
+
+| Object | Current state |
+|---|---|
+| System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` |
+| Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). Cycle & soak: not implemented |
+| Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory) |
+| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress |
+| MasterDriver | ❌ not implemented (GH #95) |
+
+The refactoring direction is to make the Driver base explicit when implementing GH #95, so
+MasterDriver inherits the existing safety layers rather than reimplementing them.

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -21,15 +21,25 @@
 
 ```
 custom_components/never_dry/
-├── __init__.py        → Integration setup (YAML + config entry)
+├── __init__.py        → Integration setup (YAML + config entry), activity log setup
 ├── const.py           → All constants, defaults, system types, plant families
 ├── sensor.py          → compute_kc(), ETSensor, DrynessIndexSensor, IrrigationZoneSensor
-├── controller.py      → IrrigationController (valve control, monitoring mode)
+│                        + per-zone stat/linked sensors (deficit, rain, water totals, Kc, …)
+├── controller.py      → IrrigationController (irrigation cycle, services, monitoring mode)
+├── button.py          → Per-zone buttons: Irrigate, Mark irrigated, Stop, Reset valve
+├── valve_operator.py  → ValveOperator: open/close with confirmation, delivery modes, watchdog
+├── valve_fsm.py       → Valve finite-state machine (idle → … → maintenance)
+├── valve_latency.py   → ValveLatencyTracker: adaptive timeout (rolling mean + 3σ)
+├── valve_notifier.py  → User notifications on valve failures
+├── unit_convert.py    → Metric/imperial conversions at the I/O boundaries
+├── diagnostics.py     → HA "Download diagnostics" support
 ├── config_flow.py     → UI setup wizard + options flow
+├── manifest.json      → Integration manifest
 ├── services.yaml      → HA service definitions
 ├── strings.json       → UI strings
-└── translations/
-    └── en.json        → English translations
+├── translations/      → en.json, it.json
+├── brand/             → Local brand assets (icon/logo)
+└── www/               → never-dry-zone-card.js (bundled Lovelace card, auto-registered)
 ```
 
 **Data flow:**
@@ -51,6 +61,8 @@ VWC sensor (optional) ─┘    │
 ```
 
 `DrynessIndexSensor` is the "reference" sensor at Kc=1.0. Each zone sensor registers as a listener and maintains its own deficit scaled by a crop coefficient Kc. The Kc varies seasonally based on the plant family assigned to the zone, with automatic hemisphere detection from `hass.config.latitude`.
+
+For the conceptual domain model behind this layout (System / Zone / Scheduler / ZoneDriver / MasterDriver) and where upcoming features belong, see [`design_domain_object_model.md`](design_domain_object_model.md).
 
 ## 2. Core formulas and their location
 
@@ -289,7 +301,10 @@ Services are registered in `IrrigationController.register_services()`.
 | `never_dry.irrigate_zone` | `_handle_irrigate_zone` | Single zone: open → wait → close → reset zone deficit |
 | `never_dry.irrigate_all` | `_handle_irrigate_all` | All zones sequentially, then reset all deficits |
 | `never_dry.stop` | `_handle_stop` | Close all valves, abort cycle (no deficit reset) |
+| `never_dry.stop_zone` | `_handle_stop_zone` | Stop irrigation for a single zone and close its valve (no deficit reset) |
 | `never_dry.mark_irrigated` | `_handle_mark_irrigated` | Resets deficit without opening any valve (used when the user watered with a different tool — hose, separate sprinkler, unmetered rain) |
+| `never_dry.reset_valve` | `_handle_reset_valve` | Reset the valve FSM from `maintenance` back to `idle` |
+| `never_dry.set_deficit` | `_handle_set_deficit` | Set the deficit of one zone (or all zones) to an arbitrary mm value |
 
 ## 6. Config flow
 
@@ -298,7 +313,7 @@ Services are registered in `IrrigationController.register_services()`.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Zone display name |
-| `valve` | No | Switch entity controlling the valve (omit for monitoring mode) |
+| `valve` | No | Valve or switch entity controlling the valve (omit for monitoring mode) |
 | `area_m2` | Yes | Irrigated area [m²] |
 | `system_type` | Yes | Irrigation system → sets default efficiency |
 | `efficiency` | No | Override efficiency [0.1–1.0] |
@@ -306,6 +321,12 @@ Services are registered in `IrrigationController.register_services()`.
 | `kc` | No | Override Kc [0.1–2.0] |
 | `flow_rate_lpm` | Yes | Valve flow rate [L/min] |
 | `threshold` | No | Mode A trigger threshold [mm] (default 20) |
+| `delivery_mode` | No | Delivery method: `estimated_flow` (timer), `flow_meter` (sensor-monitored), `volume_preset` (smart valve with volume dosing) |
+| `flow_meter_sensor` | No | Flow measurement sensor entity (required if `delivery_mode=flow_meter`) |
+| `volume_entity` | No | Number entity for volume commands (required if `delivery_mode=volume_preset`) |
+| `delivery_timeout` | No | Safety timeout [s] for `flow_meter` and `volume_preset` modes (default 3600) |
+| `irrigation_mode` | No | Scheduling mode: `manual`, `reactive` (threshold-based), `scheduled` (time-based) |
+| `irrigation_time` | No | Daily irrigation time (HH:MM) for `scheduled` mode |
 
 ## 7. Testing
 


### PR DESCRIPTION
## Summary

- New `docs/design_domain_object_model.md`: conceptual domain model (System / Zone / Scheduler / ZoneDriver / MasterDriver), the liters-as-contract translation chain, and the design decisions for the master valve (#95) and cycle & soak (#74). Includes a mapping table of the model to the current code.
- `developer_manual.md` realigned with the codebase: architecture tree updated (valve_* modules, button, diagnostics, unit_convert, www, brand, it.json), services table completed (stop_zone, reset_valve, set_deficit), zone config fields completed (delivery_mode, flow_meter_sensor, volume_entity, delivery_timeout, irrigation_mode, irrigation_time).
- `README.md`: services table completed (stop_zone, mark_irrigated) and the per-zone entity list expanded to the full set (stat sensors, mirrors, buttons).

## Context

The design doc formalizes the actuator abstraction discussed in #74 and gives #95 (master pump) its architectural home: a common Driver base whose safety layers are inherited by both ZoneDriver and MasterDriver.

Docs only — no code changes.

Refs #74, #94, #95