### PR TITLE
fix: dispatch domain services across all controllers (GH #105)

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_ZONE_NAME, CONF_ZONES, CONFIG_VERSION, DOMAIN
+from .services import async_unload_services
 
 
 def zone_slug(zone_name: str) -> str:
@@ -244,6 +245,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await hass.async_add_executor_job(_teardown_file_logger, handler)
         hass.data[DOMAIN].pop(entry.entry_id, None)
         hass.data[DOMAIN].pop(f"_operators_{entry.entry_id}", None)
+        # Drop the domain services when the last controller is gone.
+        async_unload_services(hass)
     return unload_ok
 
 

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -39,14 +39,6 @@ from .const import (
     EVENT_IRRIGATION_COMPLETE,
     FLOW_METER_POLL_INTERVAL_S,
     MIN_SERVICE_INTERVAL_S,
-    SERVICE_IRRIGATE_ALL,
-    SERVICE_IRRIGATE_ZONE,
-    SERVICE_MARK_IRRIGATED,
-    SERVICE_RESET,
-    SERVICE_RESET_VALVE,
-    SERVICE_SET_DEFICIT,
-    SERVICE_STOP,
-    SERVICE_STOP_ZONE,
 )
 from .valve_fsm import ValveState
 from .valve_notifier import NotificationKind, Severity, ValveNotifier
@@ -145,17 +137,23 @@ class IrrigationController:
         """Return the mapping of switch entity_id → ValveOperator."""
         return self._valve_operators
 
-    def register_services(self) -> None:
-        """Register all irrigation services with Home Assistant."""
-        self._hass.services.async_register(DOMAIN, SERVICE_RESET, self._handle_reset)
-        self._hass.services.async_register(DOMAIN, SERVICE_IRRIGATE_ZONE, self._handle_irrigate_zone)
-        self._hass.services.async_register(DOMAIN, SERVICE_IRRIGATE_ALL, self._handle_irrigate_all)
-        self._hass.services.async_register(DOMAIN, SERVICE_STOP, self._handle_stop)
-        self._hass.services.async_register(DOMAIN, SERVICE_STOP_ZONE, self._handle_stop_zone)
-        self._hass.services.async_register(DOMAIN, SERVICE_MARK_IRRIGATED, self._handle_mark_irrigated)
-        self._hass.services.async_register(DOMAIN, SERVICE_RESET_VALVE, self._handle_reset_valve)
-        self._hass.services.async_register(DOMAIN, SERVICE_SET_DEFICIT, self._handle_set_deficit)
+    @property
+    def zone_names(self) -> list[str]:
+        """Names of the zones this controller manages."""
+        return list(self._zones.keys())
 
+    def has_zone(self, zone_name: str) -> bool:
+        """True when this controller manages the given zone."""
+        return zone_name in self._zones
+
+    def register_services(self) -> None:
+        """Register this controller's state listeners and schedulers.
+
+        HA services are NOT registered here: they are per-domain, so a
+        second config entry would silently capture every ``never_dry.*``
+        call (GH #105). ``services.async_setup_services`` registers them
+        once and dispatches to the controller that owns the target zone.
+        """
         # Monitor valve state changes to detect manual irrigation
         valve_entities = [v for v in self._valve_to_zone if v]
         if valve_entities:

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -94,6 +94,7 @@ from .const import (
     UNUSUAL_FLOW_MAX_LPM,
 )
 from .controller import IrrigationController
+from .services import async_setup_services
 from .unit_convert import LPM_TO_GPH, LPM_TO_LPH
 
 _LOGGER = logging.getLogger(__name__)
@@ -435,7 +436,10 @@ async def async_setup_platform(
     """Set up the NeverDry sensors from YAML configuration."""
     entities, di_sensor, zone_sensors = _create_entities(hass, config)
     async_add_entities(entities, True)
-    _setup_controller(hass, config, di_sensor, zone_sensors)
+    controller = _setup_controller(hass, config, di_sensor, zone_sensors)
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["_controller_yaml"] = controller
+    async_setup_services(hass)
 
 
 async def async_setup_entry(
@@ -453,6 +457,10 @@ async def async_setup_entry(
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][f"_controller_{entry.entry_id}"] = controller
     hass.data[DOMAIN][f"_operators_{entry.entry_id}"] = controller.valve_operators
+    # Domain services are registered once and dispatch across ALL entries'
+    # controllers (GH #105) — never per controller, or the last entry to
+    # load would capture every never_dry.* call.
+    async_setup_services(hass)
 
 
 # ══════════════════════════════════════════════════════════
@@ -1300,7 +1308,11 @@ class ZoneYearlyWaterSensor(SensorEntity):
     """
 
     _attr_has_entity_name = True
-    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
+    # WATER (not VOLUME_STORAGE): HA rejects total_increasing on
+    # volume_storage — that class means "amount currently stored", while
+    # this is a cumulative consumption total (GH #105). WATER also makes
+    # the sensor usable in the HA Energy dashboard water tracking.
+    _attr_device_class = SensorDeviceClass.WATER
     _attr_name = "Yearly water"
     _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING

--- a/custom_components/never_dry/services.py
+++ b/custom_components/never_dry/services.py
@@ -1,0 +1,152 @@
+"""Domain-level service registration with multi-entry dispatch (GH #105).
+
+Every config entry builds its own :class:`IrrigationController`, but Home
+Assistant services are registered per *domain*: with two entries, whichever
+controller registered last silently captured every ``never_dry.*`` call, so
+zones belonging to the other controller were "not found" and their valves
+never switched.
+
+This module registers each service exactly once and dispatches calls to the
+right controller:
+
+- **Zone-scoped services** (``irrigate_zone``, ``stop_zone``,
+  ``mark_irrigated``, ``reset_valve``, ``set_deficit``) look the zone up
+  across *all* controllers and route the call to the one that owns it.
+  Called without a zone name, the services that support "all zones"
+  semantics fan out to every controller.
+- **Global services** (``stop``, ``irrigate_all``, ``reset``) fan out to
+  every controller — an emergency stop must close every valve of every
+  configured system.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant, ServiceCall
+
+from .const import (
+    ATTR_ZONE_NAME,
+    DOMAIN,
+    SERVICE_IRRIGATE_ALL,
+    SERVICE_IRRIGATE_ZONE,
+    SERVICE_MARK_IRRIGATED,
+    SERVICE_RESET,
+    SERVICE_RESET_VALVE,
+    SERVICE_SET_DEFICIT,
+    SERVICE_STOP,
+    SERVICE_STOP_ZONE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_SERVICES_REGISTERED = "_services_registered"
+_CONTROLLER_KEY_PREFIX = "_controller_"
+
+# service name → controller handler method name
+_ZONE_SCOPED: dict[str, str] = {
+    SERVICE_IRRIGATE_ZONE: "_handle_irrigate_zone",
+    SERVICE_STOP_ZONE: "_handle_stop_zone",
+    SERVICE_MARK_IRRIGATED: "_handle_mark_irrigated",
+    SERVICE_RESET_VALVE: "_handle_reset_valve",
+    SERVICE_SET_DEFICIT: "_handle_set_deficit",
+}
+_GLOBAL: dict[str, str] = {
+    SERVICE_STOP: "_handle_stop",
+    SERVICE_IRRIGATE_ALL: "_handle_irrigate_all",
+    SERVICE_RESET: "_handle_reset",
+}
+
+
+def _controllers(hass: HomeAssistant) -> list:
+    """Return every live IrrigationController across all config entries."""
+    domain_data = hass.data.get(DOMAIN, {})
+    return [v for k, v in domain_data.items() if isinstance(k, str) and k.startswith(_CONTROLLER_KEY_PREFIX)]
+
+
+def _all_zone_names(controllers: list) -> list[str]:
+    return [name for c in controllers for name in c.zone_names]
+
+
+async def _dispatch_zone_scoped(hass: HomeAssistant, handler_name: str, call: ServiceCall) -> None:
+    """Route a zone-scoped call to the controller that owns the zone.
+
+    Without a zone name the call fans out to every controller — the
+    handlers that support "all zones" semantics (mark_irrigated,
+    set_deficit) apply it per controller, the others log their own error.
+    """
+    controllers = _controllers(hass)
+    if not controllers:
+        _LOGGER.error("%s: no NeverDry controller is loaded", call.service)
+        return
+
+    zone_name = call.data.get(ATTR_ZONE_NAME)
+    if not zone_name:
+        for controller in controllers:
+            await getattr(controller, handler_name)(call)
+        return
+
+    matches = [c for c in controllers if c.has_zone(zone_name)]
+    if not matches:
+        _LOGGER.error(
+            "%s: zone '%s' not found in any controller. Available: %s",
+            call.service,
+            zone_name,
+            _all_zone_names(controllers),
+        )
+        return
+    if len(matches) > 1:
+        _LOGGER.warning(
+            "%s: zone '%s' exists in %d controllers — using the first; rename the zones to disambiguate",
+            call.service,
+            zone_name,
+            len(matches),
+        )
+    await getattr(matches[0], handler_name)(call)
+
+
+async def _dispatch_global(hass: HomeAssistant, handler_name: str, call: ServiceCall) -> None:
+    """Fan a global call out to every controller."""
+    controllers = _controllers(hass)
+    if not controllers:
+        _LOGGER.error("%s: no NeverDry controller is loaded", call.service)
+        return
+    for controller in controllers:
+        await getattr(controller, handler_name)(call)
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the domain services once, idempotently."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get(_SERVICES_REGISTERED):
+        return
+    domain_data[_SERVICES_REGISTERED] = True
+
+    def _zone_handler(handler_name: str):
+        async def handler(call: ServiceCall) -> None:
+            await _dispatch_zone_scoped(hass, handler_name, call)
+
+        return handler
+
+    def _global_handler(handler_name: str):
+        async def handler(call: ServiceCall) -> None:
+            await _dispatch_global(hass, handler_name, call)
+
+        return handler
+
+    for service, handler_name in _ZONE_SCOPED.items():
+        hass.services.async_register(DOMAIN, service, _zone_handler(handler_name))
+    for service, handler_name in _GLOBAL.items():
+        hass.services.async_register(DOMAIN, service, _global_handler(handler_name))
+
+
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Remove the domain services when the last controller is gone."""
+    domain_data = hass.data.get(DOMAIN, {})
+    if not domain_data.get(_SERVICES_REGISTERED):
+        return
+    if _controllers(hass):
+        return  # another entry still needs them
+    for service in (*_ZONE_SCOPED, *_GLOBAL):
+        hass.services.async_remove(DOMAIN, service)
+    domain_data.pop(_SERVICES_REGISTERED, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def _create_ha_stubs():
         PRECIPITATION_INTENSITY = "precipitation_intensity"
         VOLUME_FLOW_RATE = "volume_flow_rate"
         VOLUME_STORAGE = "volume_storage"
+        WATER = "water"
 
     sensor_mod.SensorStateClass = SensorStateClass
     sensor_mod.SensorDeviceClass = SensorDeviceClass

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -22,9 +22,11 @@ class TestControllerState:
         assert controller.is_running is False
         assert controller.active_valve is None
 
-    def test_register_services(self, controller, hass_mock):
+    def test_register_services_does_not_register_ha_services(self, controller, hass_mock):
+        """GH #105: HA services are domain-level (services.py), never per
+        controller — a second entry would capture every never_dry.* call."""
         controller.register_services()
-        assert hass_mock.services.async_register.call_count == 8
+        hass_mock.services.async_register.assert_not_called()
 
 
 class TestIrrigateSingleZone:

--- a/tests/test_multi_controller_services.py
+++ b/tests/test_multi_controller_services.py
@@ -1,0 +1,233 @@
+"""Multi-entry service dispatch (GH #105).
+
+With two NeverDry config entries, domain services used to be captured by
+whichever controller registered last: zones of the other controller were
+"not found" and their valves never switched. The services module now
+registers each service once and routes calls to the controller that owns
+the target zone; global services fan out to every controller.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from never_dry import services as svc
+from never_dry.const import (
+    ATTR_ZONE_NAME,
+    CONF_ZONE_AREA,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_NAME,
+    CONF_ZONE_VALVE,
+    DOMAIN,
+    SERVICE_IRRIGATE_ZONE,
+)
+from never_dry.controller import IrrigationController
+from never_dry.sensor import IrrigationZoneSensor
+
+
+def _make_zone(hass_mock, di_sensor, name, valve):
+    return IrrigationZoneSensor(
+        hass_mock,
+        {
+            CONF_ZONE_NAME: name,
+            CONF_ZONE_VALVE: valve,
+            CONF_ZONE_AREA: 20.0,
+            CONF_ZONE_FLOW_RATE: 8.0,
+        },
+        di_sensor,
+    )
+
+
+def _call(service="irrigate_zone", **data):
+    call = MagicMock()
+    call.service = service
+    call.data = data
+    return call
+
+
+@pytest.fixture
+def two_controllers(hass_mock, di_sensor):
+    """Two controllers with one zone each, wired into hass.data like two entries."""
+    zone_a = _make_zone(hass_mock, di_sensor, "Hochbeet", "switch.hochbeet")
+    zone_b = _make_zone(hass_mock, di_sensor, "Beet Terrasse", "switch.terrasse")
+    ctrl_1 = IrrigationController(hass_mock, di_sensor, [zone_a], inter_zone_delay=0)
+    ctrl_2 = IrrigationController(hass_mock, di_sensor, [zone_b], inter_zone_delay=0)
+    hass_mock.data = {DOMAIN: {"_controller_entry1": ctrl_1, "_controller_entry2": ctrl_2}}
+    return ctrl_1, ctrl_2
+
+
+class TestZoneLookup:
+    def test_has_zone_and_zone_names(self, two_controllers):
+        ctrl_1, ctrl_2 = two_controllers
+        assert ctrl_1.has_zone("Hochbeet") and not ctrl_1.has_zone("Beet Terrasse")
+        assert ctrl_2.has_zone("Beet Terrasse") and not ctrl_2.has_zone("Hochbeet")
+        assert ctrl_1.zone_names == ["Hochbeet"]
+
+    def test_controllers_discovered_from_hass_data(self, hass_mock, two_controllers):
+        assert set(svc._controllers(hass_mock)) == set(two_controllers)
+
+
+class TestZoneScopedDispatch:
+    """Zone-scoped calls reach the controller that owns the zone — GH #105 repro."""
+
+    @pytest.mark.asyncio
+    async def test_routes_to_second_controller(self, hass_mock, two_controllers):
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_irrigate_zone = AsyncMock()
+        ctrl_2._handle_irrigate_zone = AsyncMock()
+
+        call = _call(**{ATTR_ZONE_NAME: "Beet Terrasse"})
+        await svc._dispatch_zone_scoped(hass_mock, "_handle_irrigate_zone", call)
+
+        ctrl_2._handle_irrigate_zone.assert_awaited_once_with(call)
+        ctrl_1._handle_irrigate_zone.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_routes_to_first_controller(self, hass_mock, two_controllers):
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_stop_zone = AsyncMock()
+        ctrl_2._handle_stop_zone = AsyncMock()
+
+        await svc._dispatch_zone_scoped(
+            hass_mock, "_handle_stop_zone", _call("stop_zone", **{ATTR_ZONE_NAME: "Hochbeet"})
+        )
+
+        ctrl_1._handle_stop_zone.assert_awaited_once()
+        ctrl_2._handle_stop_zone.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_zone_logs_all_available(self, hass_mock, two_controllers, caplog):
+        import logging
+
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_irrigate_zone = AsyncMock()
+        ctrl_2._handle_irrigate_zone = AsyncMock()
+
+        with caplog.at_level(logging.ERROR, logger="custom_components.never_dry"):
+            await svc._dispatch_zone_scoped(hass_mock, "_handle_irrigate_zone", _call(**{ATTR_ZONE_NAME: "Nope"}))
+
+        ctrl_1._handle_irrigate_zone.assert_not_awaited()
+        ctrl_2._handle_irrigate_zone.assert_not_awaited()
+        assert any("Hochbeet" in r.getMessage() and "Beet Terrasse" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_zone_name_fans_out(self, hass_mock, two_controllers):
+        """mark_irrigated / set_deficit without a zone apply to every controller."""
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_mark_irrigated = AsyncMock()
+        ctrl_2._handle_mark_irrigated = AsyncMock()
+
+        await svc._dispatch_zone_scoped(hass_mock, "_handle_mark_irrigated", _call("mark_irrigated"))
+
+        ctrl_1._handle_mark_irrigated.assert_awaited_once()
+        ctrl_2._handle_mark_irrigated.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_zone_name_uses_first_and_warns(self, hass_mock, di_sensor, caplog):
+        import logging
+
+        zone_1 = _make_zone(hass_mock, di_sensor, "Orto", "switch.a")
+        zone_2 = _make_zone(hass_mock, di_sensor, "Orto", "switch.b")
+        ctrl_1 = IrrigationController(hass_mock, di_sensor, [zone_1], inter_zone_delay=0)
+        ctrl_2 = IrrigationController(hass_mock, di_sensor, [zone_2], inter_zone_delay=0)
+        ctrl_1._handle_irrigate_zone = AsyncMock()
+        ctrl_2._handle_irrigate_zone = AsyncMock()
+        hass_mock.data = {DOMAIN: {"_controller_e1": ctrl_1, "_controller_e2": ctrl_2}}
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.never_dry"):
+            await svc._dispatch_zone_scoped(hass_mock, "_handle_irrigate_zone", _call(**{ATTR_ZONE_NAME: "Orto"}))
+
+        ctrl_1._handle_irrigate_zone.assert_awaited_once()
+        ctrl_2._handle_irrigate_zone.assert_not_awaited()
+        assert any("2 controllers" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_controllers_logs_error(self, hass_mock, caplog):
+        import logging
+
+        hass_mock.data = {DOMAIN: {}}
+        with caplog.at_level(logging.ERROR, logger="custom_components.never_dry"):
+            await svc._dispatch_zone_scoped(hass_mock, "_handle_irrigate_zone", _call(**{ATTR_ZONE_NAME: "X"}))
+        assert any("no NeverDry controller" in r.getMessage() for r in caplog.records)
+
+
+class TestGlobalDispatch:
+    @pytest.mark.asyncio
+    async def test_stop_fans_out_to_all(self, hass_mock, two_controllers):
+        """Emergency stop must close every valve of every entry."""
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_stop = AsyncMock()
+        ctrl_2._handle_stop = AsyncMock()
+
+        await svc._dispatch_global(hass_mock, "_handle_stop", _call("stop"))
+
+        ctrl_1._handle_stop.assert_awaited_once()
+        ctrl_2._handle_stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_irrigate_all_fans_out(self, hass_mock, two_controllers):
+        ctrl_1, ctrl_2 = two_controllers
+        ctrl_1._handle_irrigate_all = AsyncMock()
+        ctrl_2._handle_irrigate_all = AsyncMock()
+
+        await svc._dispatch_global(hass_mock, "_handle_irrigate_all", _call("irrigate_all"))
+
+        ctrl_1._handle_irrigate_all.assert_awaited_once()
+        ctrl_2._handle_irrigate_all.assert_awaited_once()
+
+
+class TestRegistrationLifecycle:
+    def test_setup_is_idempotent(self, hass_mock):
+        """A second entry must NOT re-register (and thus re-bind) the services."""
+        hass_mock.data = {DOMAIN: {}}
+        hass_mock.services.async_register = MagicMock()
+
+        svc.async_setup_services(hass_mock)
+        first_count = hass_mock.services.async_register.call_count
+        svc.async_setup_services(hass_mock)
+
+        assert first_count == 8
+        assert hass_mock.services.async_register.call_count == first_count
+
+    def test_registers_all_services(self, hass_mock):
+        hass_mock.data = {DOMAIN: {}}
+        hass_mock.services.async_register = MagicMock()
+
+        svc.async_setup_services(hass_mock)
+
+        registered = {c.args[1] for c in hass_mock.services.async_register.call_args_list}
+        assert SERVICE_IRRIGATE_ZONE in registered
+        assert len(registered) == 8
+
+    def test_unload_keeps_services_while_controllers_remain(self, hass_mock, two_controllers):
+        hass_mock.data[DOMAIN][svc._SERVICES_REGISTERED] = True
+        hass_mock.services.async_remove = MagicMock()
+
+        svc.async_unload_services(hass_mock)
+
+        hass_mock.services.async_remove.assert_not_called()
+
+    def test_unload_removes_services_when_last_controller_gone(self, hass_mock):
+        hass_mock.data = {DOMAIN: {svc._SERVICES_REGISTERED: True}}
+        hass_mock.services.async_remove = MagicMock()
+
+        svc.async_unload_services(hass_mock)
+
+        assert hass_mock.services.async_remove.call_count == 8
+        assert svc._SERVICES_REGISTERED not in hass_mock.data[DOMAIN]
+
+    @pytest.mark.asyncio
+    async def test_registered_handler_dispatches(self, hass_mock, two_controllers):
+        """End-to-end: the handler registered for irrigate_zone routes by zone."""
+        _ctrl_1, ctrl_2 = two_controllers
+        ctrl_2._handle_irrigate_zone = AsyncMock()
+        registered = {}
+        hass_mock.services.async_register = MagicMock(
+            side_effect=lambda domain, name, handler: registered.__setitem__(name, handler)
+        )
+        hass_mock.data[DOMAIN].pop(svc._SERVICES_REGISTERED, None)
+
+        svc.async_setup_services(hass_mock)
+        call = _call(**{ATTR_ZONE_NAME: "Beet Terrasse"})
+        await registered[SERVICE_IRRIGATE_ZONE](call)
+
+        ctrl_2._handle_irrigate_zone.assert_awaited_once_with(call)

--- a/tests/test_sensor_device_classes.py
+++ b/tests/test_sensor_device_classes.py
@@ -51,10 +51,15 @@ class TestDeviceClassDeclarations:
         sensor = ZoneSessionWaterSensor(zone_orto)
         assert sensor._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
 
-    def test_zone_yearly_water_volume_storage(self, di_sensor, zone_orto):
-        """Yearly water delivered [L] → HA converts to [gal] in imperial."""
+    def test_zone_yearly_water_is_water_total(self, di_sensor, zone_orto):
+        """Yearly water is a cumulative consumption total (GH #105):
+        device_class WATER + state_class total_increasing — volume_storage
+        rejects total_increasing in current HA."""
+        from homeassistant.components.sensor import SensorStateClass
+
         sensor = ZoneYearlyWaterSensor(zone_orto)
-        assert sensor._attr_device_class == SensorDeviceClass.VOLUME_STORAGE
+        assert sensor._attr_device_class == SensorDeviceClass.WATER
+        assert sensor._attr_state_class == SensorStateClass.TOTAL_INCREASING
 
     def test_zone_duration_sensor_duration(self, di_sensor, zone_orto):
         """Planned irrigation duration [s] — device_class=DURATION for correct display."""


### PR DESCRIPTION
Fixes #105.

## Problem

With two (or more) NeverDry config entries, every controller registered the same `never_dry.*` domain services and the last one silently captured them all: zones belonging to the other controllers were "not found" and their valves never switched, while the service call still reported success.

```
Zone 'Beet Terrasse' not found. Available: ['Hochbeet']
```

## Fix

- **New `services.py`** — each service is registered exactly once at domain level and dispatched across **all** controllers (any number of entries, N ≥ 1):
  - Zone-scoped services (`irrigate_zone`, `stop_zone`, `mark_irrigated`, `reset_valve`, `set_deficit`) look the zone up across every controller and route the call to the one that owns it. Unknown zone → error listing zones of all controllers. Duplicate zone names across entries → warning, first match wins.
  - Global services (`stop`, `irrigate_all`, `reset`) fan out to every controller — an emergency stop must close every valve of every configured system.
  - Services are removed when the last config entry unloads.
- **Controller** no longer registers HA services; `register_services()` keeps only its state listeners and schedulers.
- **Bonus fix from the same report**: `yearly_water` sensors now use `device_class: water` — `total_increasing` is invalid on `volume_storage` in current HA. This also makes them usable in the Energy dashboard water tracking.

## Tests

New `test_multi_controller_services.py` reproduces the exact two-controller scenario from the issue and covers routing in both directions, global fan-out, unknown zone, duplicate names, idempotent registration, and unload. Full suite: 664 passed.