### PR TITLE
ci: run CI workflows on pull requests targeting develop

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   validate:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   validate:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Add `develop` to the `pull_request` trigger of the five CI workflows (Tests, Lint, Hassfest, HACS Validation, Security), so every PR opened against the `develop` integration branch gets full CI validation before merge — previously CI only ran on `main` pushes and PRs.

Push triggers stay main-only: direct pushes to `develop` are no longer part of the workflow (branch is now protected).