### PR TITLE
ci: run tests on pushes to develop for Codecov branch baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
## Summary

Add `develop` to the `push` trigger of the Tests workflow so that every merge into `develop` runs the test suite and uploads coverage to Codecov.

This gives Codecov a proper coverage baseline for the `develop` branch: integration PRs get compared against develop's own coverage instead of main's, and the develop coverage graph is tracked over time.