### PR TITLE
feat: star CTA beside Ko-fi in Support section (site + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ Found a bug or have an idea? Open an issue — reports from real gardens are wha
 
 ## Support
 
-If NeverDry saves your garden (and your water bill), consider a one-time donation:
+If NeverDry saves your garden (and your water bill), consider a one-time donation — or just leave a star, it costs nothing and helps others find the project:
 
-<a href="https://ko-fi.com/drake69"><img src="https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" height="35"></a>
+<a href="https://ko-fi.com/drake69"><img src="https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" height="35"></a>&nbsp;&nbsp;<a href="https://github.com/drake69/NeverDry/stargazers"><img src="https://img.shields.io/badge/Star_on_GitHub-24292e?style=for-the-badge&logo=github&logoColor=white" alt="Star on GitHub" height="35"></a>
 
 ---
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -220,7 +220,10 @@
 <section class="support">
     <h2>Projekt unterst&uuml;tzen</h2>
     <p>Wenn NeverDry Ihren Garten und Ihre Wasserrechnung rettet, erw&auml;gen Sie eine Spende:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -233,7 +233,10 @@
 <section class="support">
     <h2>Projekt unterst&uuml;tzen</h2>
     <p>Wenn NeverDry Ihren Garten und Ihre Wasserrechnung rettet, erw&auml;gen Sie eine Spende:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -228,7 +228,10 @@
 <section class="support">
     <h2>Apoya el Proyecto</h2>
     <p>Si NeverDry salva tu jard&iacute;n y tu factura del agua, considera una donaci&oacute;n:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoyar en Ko-fi</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoyar en Ko-fi</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deja una estrella en GitHub</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -233,7 +233,10 @@
 <section class="support">
     <h2>Soutenir le Projet</h2>
     <p>Si NeverDry sauve votre jardin et votre facture d'eau, pensez &agrave; faire un don :</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Soutenir sur Ko-fi</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Soutenir sur Ko-fi</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Laissez une &eacute;toile sur GitHub</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -220,7 +220,10 @@
 <section class="support">
     <h2>Podr&zcaron;i Projekt</h2>
     <p>Ako NeverDry spa&scaron;ava va&scaron; vrt i ra&ccaron;un za vodu, razmislite o donaciji:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Podr&scaron;ka na Ko-fi-ju</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Podr&scaron;ka na Ko-fi-ju</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Ostavite zvjezdicu na GitHubu</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -220,7 +220,10 @@
 <section class="support">
     <h2>T&aacute;mogasd a Projektet</h2>
     <p>Ha a NeverDry megmenti a kertedet &eacute;s a v&iacute;zsz&aacute;ml&aacute;t, fontold meg az adom&aacute;nyt:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ T&aacute;mogat&aacute;s Ko-fi-n</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ T&aacute;mogat&aacute;s Ko-fi-n</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Adj csillagot a GitHubon</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -484,7 +484,10 @@
 <section class="support">
     <h2>Support the Project</h2>
     <p>If NeverDry saves your garden and your water bill, consider a one-time donation:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Support on Ko-fi</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Support on Ko-fi</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Star on GitHub</a>
+    </div>
 </section>
 
 <!-- Disclaimer & Credits -->

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -233,7 +233,10 @@
 <section class="support">
     <h2>Sostieni il progetto</h2>
     <p>Se NeverDry ti aiuta a curare il giardino e a ridurre la bolletta dell'acqua, valuta una piccola donazione.</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Sostieni su Ko-fi</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Sostieni su Ko-fi</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Lascia una stella su GitHub</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -228,7 +228,10 @@
 <section class="support">
     <h2>Apoie o Projeto</h2>
     <p>Se o NeverDry salva o seu jardim e a conta de &aacute;gua, considere uma doa&ccedil;&atilde;o:</p>
-    <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoiar no Ko-fi</a>
+    <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoiar no Ko-fi</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deixe uma estrela no GitHub</a>
+    </div>
 </section>
 
 <section class="support" style="background: #f0f0f0; padding: 40px 0;">


### PR DESCRIPTION
## Summary

Readers who reach the end of the landing page or README have already decided the project is worth something — that is the right moment to ask for a star, not the top of the page.

- **gh-pages (all 9 language pages)**: the Support section now shows two buttons side by side — Ko-fi and a ⭐ *Star on GitHub* button (label localized per language), laid out with the same flex row used in the Get Help section.
- **README**: the Support section gains a *Star on GitHub* badge next to the Ko-fi badge, and the intro sentence mentions the star as a zero-cost alternative.

## Notes
The live site updates only when this reaches `main` (gh-pages workflow triggers on main pushes).