### PR TITLE
fix: settle tracked manual sessions on entry unload (AI-160)

### DIFF
--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -413,6 +413,32 @@ class IrrigationController:
         for unsub in self._unsubs:
             unsub()
         self._unsubs.clear()
+        # Settle any manual session still open: the safety monitor dies
+        # with this controller, and the successor has no baseline for a
+        # valve it never saw open — its close event would be ignored and
+        # the delivered water never credited. Close the valve and credit
+        # what accrued so far, exactly once. Listeners are already
+        # unsubscribed above, so the close cannot re-enter the manual
+        # accounting through the state listener.
+        for entity_id in list(self._manual_valve_open):
+            zone_name = self._valve_to_zone.get(entity_id)
+            zone = self._zones.get(zone_name) if zone_name else None
+            if zone is None:
+                self._manual_valve_open.pop(entity_id, None)
+                self._manual_session_meta.pop(entity_id, None)
+                mtask = self._manual_safety_tasks.pop(entity_id, None)
+                if mtask and not mtask.done():
+                    mtask.cancel()
+                continue
+            state = self._hass.states.get(entity_id)
+            if state is not None and state.state == "on":
+                _LOGGER.info(
+                    "Unload with manual session open: zone='%s' — closing valve and settling",
+                    zone_name,
+                )
+                with contextlib.suppress(Exception):
+                    await self._close_valve(entity_id)
+            self._finalize_manual_session(entity_id, zone_name, zone)
 
     async def _handle_stop(self, call: ServiceCall) -> None:
         """Emergency stop: close every configured valve concurrently."""
@@ -1316,95 +1342,105 @@ class IrrigationController:
                 # stray event. Treating it as manual used to fully reset
                 # the deficit (field bug, 2026-07-15).
                 return
-            # Cancel the safety watchdog: the user (or the watchdog itself)
-            # already closed the valve.
-            task = self._manual_safety_tasks.pop(entity_id, None)
-            if task and not task.done():
-                task.cancel()
-            # Valve closed — account the delivered water. Measured by the
-            # flow meter when possible, estimated from flow_rate x elapsed
-            # otherwise. A close NEVER fully resets the deficit: that is
-            # mark_irrigated's exclusive semantics.
-            baseline = self._manual_valve_open.pop(entity_id)
-            zone.set_irrigating(False)
+            self._finalize_manual_session(entity_id, zone_name, zone)
 
-            session_meta = self._manual_session_meta.pop(entity_id, None)
-            ts_end = datetime.now()
-            elapsed_s = (ts_end - session_meta[0]).total_seconds() if session_meta else 0.0
+    def _finalize_manual_session(self, entity_id: str, zone_name: str, zone) -> None:
+        """Account a tracked manual session and settle the zone exactly once.
 
-            delivered_liters = 0.0
-            if zone.flow_meter_sensor and baseline is not None:
-                is_rate = self._is_flow_rate_sensor(zone.flow_meter_sensor)
-                if is_rate:
-                    # Estimate volume from average flow rate x duration
-                    duration_s = time.monotonic() - baseline
-                    current_rate = self._read_flow_meter(zone.flow_meter_sensor)
-                    if current_rate is not None and current_rate > 0:
-                        unit = self._get_flow_meter_unit(zone.flow_meter_sensor)
-                        lpm = self._rate_to_lpm(current_rate, unit)
-                        delivered_liters = lpm / 60 * duration_s
-                else:
-                    # Cumulative: simple difference (baseline already in liters)
-                    flow_end = self._read_volume_liters(zone.flow_meter_sensor)
-                    delivered_liters = max(0.0, flow_end - baseline) if flow_end is not None else 0.0
-                # Meter measured nothing → credit the guard-flow estimate.
-                delivered_liters = self._fallback_volume_estimate(zone, elapsed_s, delivered_liters)
-            elif zone._flow_rate > 0 and elapsed_s > 0:
-                delivered_liters = zone._flow_rate * elapsed_s / 60.0
-                _LOGGER.info(
-                    "Manual irrigation estimated: zone='%s', %.1fL from flow_rate %.2f L/min x %.0fs",
-                    zone_name,
-                    delivered_liters,
-                    zone._flow_rate,
-                    elapsed_s,
-                )
+        Cancels the safety monitor, credits the delivered water — measured
+        by the flow meter when possible, estimated from flow_rate x elapsed
+        otherwise — and writes the session history. A close NEVER fully
+        resets the deficit: that is mark_irrigated's exclusive semantics.
+
+        Called from the valve state listener on the manual on→off
+        transition, and from :meth:`async_stop` for sessions still open at
+        entry unload — the monitor dies with this controller and the
+        successor has no baseline for a valve it never saw open, so the
+        water must be credited here or never.
+        """
+        task = self._manual_safety_tasks.pop(entity_id, None)
+        if task and not task.done():
+            task.cancel()
+        baseline = self._manual_valve_open.pop(entity_id)
+        zone.set_irrigating(False)
+
+        session_meta = self._manual_session_meta.pop(entity_id, None)
+        ts_end = datetime.now()
+        elapsed_s = (ts_end - session_meta[0]).total_seconds() if session_meta else 0.0
+
+        delivered_liters = 0.0
+        if zone.flow_meter_sensor and baseline is not None:
+            is_rate = self._is_flow_rate_sensor(zone.flow_meter_sensor)
+            if is_rate:
+                # Estimate volume from average flow rate x duration
+                duration_s = time.monotonic() - baseline
+                current_rate = self._read_flow_meter(zone.flow_meter_sensor)
+                if current_rate is not None and current_rate > 0:
+                    unit = self._get_flow_meter_unit(zone.flow_meter_sensor)
+                    lpm = self._rate_to_lpm(current_rate, unit)
+                    delivered_liters = lpm / 60 * duration_s
             else:
-                _LOGGER.warning(
-                    "Manual irrigation on zone '%s' cannot be quantified (no flow meter,"
-                    " no flow_rate) — deficit left unchanged; use mark_irrigated if the"
-                    " zone was fully watered",
-                    zone_name,
-                )
-
-            if delivered_liters > 0 and zone._area > 0:
-                delivered_mm = delivered_liters * zone._efficiency / zone._area
-                zone._zone_deficit = max(0.0, zone._zone_deficit - delivered_mm)
-                zone._last_irrigation_source = "manual"
-                zone._last_irrigated = ts_end
-                zone._last_volume_delivered = round(delivered_liters, 1)
-                zone._session_water_delivered = round(delivered_liters, 1)
-                zone._total_water_delivered += delivered_liters
-                zone._yearly_water_delivered += delivered_liters
-                _LOGGER.info(
-                    "Manual irrigation accounted: zone='%s', delivered=%.1fL, new deficit=%.2fmm",
-                    zone_name,
-                    delivered_liters,
-                    zone._zone_deficit,
-                )
-
-            zone.async_write_ha_state()
-            self._hass.bus.async_fire(
-                EVENT_IRRIGATION_COMPLETE,
-                {
-                    "zone": zone_name,
-                    "source": "manual",
-                    "deficit_mm": round(zone._zone_deficit, 2),
-                },
+                # Cumulative: simple difference (baseline already in liters)
+                flow_end = self._read_volume_liters(zone.flow_meter_sensor)
+                delivered_liters = max(0.0, flow_end - baseline) if flow_end is not None else 0.0
+            # Meter measured nothing → credit the guard-flow estimate.
+            delivered_liters = self._fallback_volume_estimate(zone, elapsed_s, delivered_liters)
+        elif zone._flow_rate > 0 and elapsed_s > 0:
+            delivered_liters = zone._flow_rate * elapsed_s / 60.0
+            _LOGGER.info(
+                "Manual irrigation estimated: zone='%s', %.1fL from flow_rate %.2f L/min x %.0fs",
+                zone_name,
+                delivered_liters,
+                zone._flow_rate,
+                elapsed_s,
             )
-            if session_meta is not None:
-                ts_start, deficit_pre = session_meta
-                zone._last_session_duration_s = round(elapsed_s)
-                self._log_session_result(
-                    zone_name=zone_name,
-                    zone=zone,
-                    source="manual",
-                    ts_start=ts_start,
-                    ts_end=ts_end,
-                    volume_target_L=None,
-                    volume_delivered_L=delivered_liters,
-                    deficit_mm_pre=deficit_pre,
-                    deficit_mm_post=zone._zone_deficit,
-                )
+        else:
+            _LOGGER.warning(
+                "Manual irrigation on zone '%s' cannot be quantified (no flow meter,"
+                " no flow_rate) — deficit left unchanged; use mark_irrigated if the"
+                " zone was fully watered",
+                zone_name,
+            )
+
+        if delivered_liters > 0 and zone._area > 0:
+            delivered_mm = delivered_liters * zone._efficiency / zone._area
+            zone._zone_deficit = max(0.0, zone._zone_deficit - delivered_mm)
+            zone._last_irrigation_source = "manual"
+            zone._last_irrigated = ts_end
+            zone._last_volume_delivered = round(delivered_liters, 1)
+            zone._session_water_delivered = round(delivered_liters, 1)
+            zone._total_water_delivered += delivered_liters
+            zone._yearly_water_delivered += delivered_liters
+            _LOGGER.info(
+                "Manual irrigation accounted: zone='%s', delivered=%.1fL, new deficit=%.2fmm",
+                zone_name,
+                delivered_liters,
+                zone._zone_deficit,
+            )
+
+        zone.async_write_ha_state()
+        self._hass.bus.async_fire(
+            EVENT_IRRIGATION_COMPLETE,
+            {
+                "zone": zone_name,
+                "source": "manual",
+                "deficit_mm": round(zone._zone_deficit, 2),
+            },
+        )
+        if session_meta is not None:
+            ts_start, deficit_pre = session_meta
+            zone._last_session_duration_s = round(elapsed_s)
+            self._log_session_result(
+                zone_name=zone_name,
+                zone=zone,
+                source="manual",
+                ts_start=ts_start,
+                ts_end=ts_end,
+                volume_target_L=None,
+                volume_delivered_L=delivered_liters,
+                deficit_mm_pre=deficit_pre,
+                deficit_mm_post=zone._zone_deficit,
+            )
 
     async def _external_session_monitor(self, entity_id: str, zone_name: str) -> None:
         """Auto-close a manually-opened valve at min(volume_needed, timeout).

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,5 +1,7 @@
 """Tests for IrrigationController — valve control and irrigation cycles."""
 
+import asyncio
+import contextlib
 import time
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, call
@@ -1225,3 +1227,113 @@ class TestMarkIrrigatedFeedback:
 
         assert zone_orto._last_irrigated is not None
         assert zone_orto._last_volume_delivered > 0
+
+
+class TestManualSessionUnloadSettle:
+    """async_stop must settle manual sessions still open at entry unload.
+
+    The safety monitor dies with the controller and the successor has no
+    baseline for a valve it never saw open: without the unload settle the
+    delivered water would never be credited (AI-160).
+    """
+
+    def _make_valve_event(self, entity_id, old_state, new_state):
+        event = MagicMock()
+        old = MagicMock()
+        old.state = old_state
+        new = MagicMock()
+        new.state = new_state
+        event.data = {"entity_id": entity_id, "old_state": old, "new_state": new}
+        return event
+
+    def _open_manual_session(self, controller, backdate_s=300):
+        """Track a manual open on Orto and backdate it by ``backdate_s``."""
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "off", "on"))
+        ts_start, deficit_pre = controller._manual_session_meta["switch.valve_orto"]
+        controller._manual_session_meta["switch.valve_orto"] = (
+            ts_start - timedelta(seconds=backdate_s),
+            deficit_pre,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unload_settles_open_manual_session(self, controller, zone_orto, hass_mock):
+        """Valve still on at unload: close it and credit the accrued estimate.
+        Orto: 8 L/min x 300 s = 40 L on 20 m² at η=0.9 → 1.8 mm."""
+        zone_orto._zone_deficit = 15.0
+        self._open_manual_session(controller)
+
+        valve_state = MagicMock(state="on")
+        hass_mock.states.get = lambda eid: valve_state if eid == "switch.valve_orto" else None
+
+        await controller.async_stop()
+
+        assert zone_orto._zone_deficit == pytest.approx(15.0 - 1.8, abs=0.05)
+        assert zone_orto._last_irrigation_source == "manual"
+        assert zone_orto._last_volume_delivered == pytest.approx(40.0, abs=0.5)
+        assert zone_orto.is_irrigating is False
+        hass_mock.services.async_call.assert_any_call(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.valve_orto"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_unload_clears_manual_tracking_state(self, controller, zone_orto, hass_mock):
+        """Baseline, meta and safety monitor must all be released on unload."""
+        zone_orto._zone_deficit = 15.0
+        self._open_manual_session(controller)
+        monitor = controller._manual_safety_tasks["switch.valve_orto"]
+
+        valve_state = MagicMock(state="on")
+        hass_mock.states.get = lambda eid: valve_state if eid == "switch.valve_orto" else None
+
+        await controller.async_stop()
+
+        assert "switch.valve_orto" not in controller._manual_valve_open
+        assert "switch.valve_orto" not in controller._manual_session_meta
+        assert "switch.valve_orto" not in controller._manual_safety_tasks
+        # Let the loop process the cancellation before asserting.
+        with contextlib.suppress(asyncio.CancelledError):
+            await monitor
+        assert monitor.cancelled() or monitor.done()
+
+    @pytest.mark.asyncio
+    async def test_unload_valve_already_off_settles_without_close(self, controller, zone_orto, hass_mock):
+        """Tracked session whose valve already reads off (close event lost,
+        e.g. Zigbee report missed): settle the accounting, send no command."""
+        zone_orto._zone_deficit = 15.0
+        self._open_manual_session(controller)
+
+        valve_state = MagicMock(state="off")
+        hass_mock.states.get = lambda eid: valve_state if eid == "switch.valve_orto" else None
+
+        await controller.async_stop()
+
+        assert zone_orto._zone_deficit == pytest.approx(15.0 - 1.8, abs=0.05)
+        hass_mock.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unload_settles_exactly_once(self, controller, zone_orto, hass_mock):
+        """A late off event after unload must not settle a second time."""
+        zone_orto._zone_deficit = 15.0
+        self._open_manual_session(controller)
+
+        valve_state = MagicMock(state="on")
+        hass_mock.states.get = lambda eid: valve_state if eid == "switch.valve_orto" else None
+
+        await controller.async_stop()
+        deficit_after_stop = zone_orto._zone_deficit
+
+        controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "on", "off"))
+
+        assert zone_orto._zone_deficit == pytest.approx(deficit_after_stop, abs=0.001)
+
+    @pytest.mark.asyncio
+    async def test_unload_without_manual_session_is_noop(self, controller, zone_orto, hass_mock):
+        """No tracked session: unload must not touch the zone accounting."""
+        zone_orto._zone_deficit = 15.0
+
+        await controller.async_stop()
+
+        assert zone_orto._zone_deficit == 15.0
+        hass_mock.services.async_call.assert_not_called()


### PR DESCRIPTION
## Problem

`async_stop` (entry unload / reload) awaited the commanded irrigation task but silently dropped **tracked manual sessions**:

1. the external safety monitor died with the old controller (orphan task that could still fire `turn_off`);
2. the successor controller had no baseline for a valve it never saw open, so the eventual `on → off` event was ignored by design (the e7b65b6 guard) — **the delivered water was never credited and the deficit never scaled**.

This is the manual-entry-point counterpart of the UNLOAD column of the end-trigger coverage matrix (developer_manual §7.2): the commanded loops settle in their `finally` block, the manual path had no equivalent.

## Fix

- Extract the manual-close accounting into `_finalize_manual_session` — shared verbatim by the valve state listener and `async_stop`.
- On unload, for every tracked manual session: cancel the safety monitor, close the valve if it still reads `on`, and settle the accounting with the volume accrued so far (measured by the flow meter when possible, guard-flow estimate otherwise) — exactly once. A close never fully resets the deficit.
- Listeners are unsubscribed **before** settling, so the unload close cannot re-enter the manual accounting through the state listener, and the late `off` event seen by the successor is ignored (no baseline) — no double settle.

## Tests

New `TestManualSessionUnloadSettle` (5 cases): open-session settle with credit, tracking-state cleanup + monitor cancellation, valve-already-off settle without command, exactly-once settle vs late off event, no-op without tracked session. Full suite: 727 passed.