### PR TITLE
fix: retry cap 5 with silent transient retries — CRITICAL only on definitive failure (AI-157)

### DIFF
--- a/custom_components/never_dry/valve_operator.py
+++ b/custom_components/never_dry/valve_operator.py
@@ -107,7 +107,7 @@ _OPERATION_FOR_FAILURE: dict[FailureKind, str] = {
 class ValveOperator:
     """HA-aware driver for a single valve, sitting on top of a :class:`ValveFsm`."""
 
-    DEFAULT_BACKOFF_S: ClassVar[tuple[float, ...]] = (1.0, 2.0, 4.0)
+    DEFAULT_BACKOFF_S: ClassVar[tuple[float, ...]] = (1.0, 2.0, 4.0, 8.0, 16.0)
 
     def __init__(
         self,
@@ -116,7 +116,7 @@ class ValveOperator:
         flow_sensor_entity_id: str | None = None,
         zone_name: str = "",
         fsm_config: FsmConfig | None = None,
-        max_retries: int = 2,
+        max_retries: int = 5,
         backoff_s: tuple[float, ...] | None = None,
         flow_zero_threshold: float = 0.05,
         notifier: ValveNotifier | None = None,
@@ -131,7 +131,14 @@ class ValveOperator:
         self._switch_entity_id = switch_entity_id
         self._flow_sensor_entity_id = flow_sensor_entity_id
         self._zone_name = zone_name or switch_entity_id
-        self._fsm_config = fsm_config or FsmConfig(has_flow_meter=flow_sensor_entity_id is not None)
+        # Derived maintenance threshold: one command owns 1 + max_retries
+        # attempts, so the retry budget can never trip MAINTENANCE
+        # mid-command — a fully-failed command reaches it exactly at its
+        # definitive failure.
+        self._fsm_config = fsm_config or FsmConfig(
+            has_flow_meter=flow_sensor_entity_id is not None,
+            max_consecutive_failures=max_retries + 1,
+        )
         self._fsm = ValveFsm(self._fsm_config)
         self._max_retries = max_retries
         self._backoff_s = backoff_s if backoff_s is not None else self.DEFAULT_BACKOFF_S
@@ -151,6 +158,7 @@ class ValveOperator:
         self._completion: asyncio.Future[OperationResult] | None = None
         self._expected_terminal: tuple[ValveState, ...] = ()
         self._leak_recovery_attempted: bool = False
+        self._retries_left: int = 0
         self._watchdog_task: asyncio.Task | None = None
         self._hw_duration_set: bool = False
 
@@ -281,6 +289,7 @@ class ValveOperator:
         async with self._lock:
             retries = 0
             while True:
+                self._retries_left = self._max_retries - retries
                 outcome = await self._run_cycle(cmd, terminals)
                 if outcome.status == OperationStatus.OK:
                     return self._finalise(outcome, retries, start)
@@ -403,7 +412,22 @@ class ValveOperator:
         recovery first, and _escalate_stuck_open() sends CRITICAL only if
         recovery fails.  Sending CRITICAL before recovery is known causes
         spurious "Valve stuck open" alerts.
+
+        Transient failures (OPEN_FAILED, CLOSE_VERIFICATION_FAILED) are
+        also suppressed while retry attempts remain: on a flaky Zigbee
+        mesh a late confirmation is routine, and alerting on every
+        attempt produced spurious CRITICALs (GH #105). The notification
+        fires only when the retry budget is exhausted and the command is
+        definitively failed.
         """
+        if kind in _TRANSIENT_FAILURES and self._retries_left > 0:
+            _LOGGER.warning(
+                "Valve '%s' transient failure %s — retrying (%d attempt(s) left)",
+                self._zone_name,
+                kind.name,
+                self._retries_left,
+            )
+            return
         _LOGGER.error("Valve '%s' failure: %s", self._zone_name, kind.name)
         if self._notifier is None:
             return

--- a/tests/test_valve_operator.py
+++ b/tests/test_valve_operator.py
@@ -1192,3 +1192,81 @@ async def test_hw_max_duration_mqtt_exception_is_logged(hass, caplog):
     assert result.status == OperationStatus.OK
     assert mqtt_calls, "MQTT publish was never attempted"
     assert "failed to set hardware max_duration via MQTT" in caplog.text
+
+
+# ── Retry cap and transient-notification suppression (AI-157) ─────────
+
+
+async def test_default_retry_budget_and_derived_maintenance_threshold(hass):
+    """Defaults: 5 retries, doubling backoff, MAINTENANCE at 1 + max_retries.
+
+    The derived threshold guarantees one command's retry budget can never
+    trip MAINTENANCE mid-command: a fully-failed command reaches it exactly
+    at its definitive failure.
+    """
+    op = ValveOperator(hass=hass, switch_entity_id="switch.valve")
+    assert op._max_retries == 5
+    assert op.DEFAULT_BACKOFF_S == (1.0, 2.0, 4.0, 8.0, 16.0)
+    assert op._fsm_config.max_consecutive_failures == 6
+
+
+async def test_transient_notification_only_after_retry_budget_exhausted(hass):
+    """OPEN_FAILED on every attempt: intermediate failures stay silent,
+    the notifier fires exactly once when the command is definitively failed."""
+    from never_dry.valve_fsm import FsmConfig
+    from never_dry.valve_notifier import NotificationKind
+
+    notifier = MagicMock()
+    notifier.notify = AsyncMock()
+    op = ValveOperator(
+        hass=hass,
+        switch_entity_id="switch.valve",
+        zone_name="capzone",
+        # High maintenance threshold: keep the test on the FAILED path.
+        fsm_config=FsmConfig(
+            has_flow_meter=False,
+            open_timeout_s=0.05,
+            close_timeout_s=0.05,
+            flow_verify_timeout_s=0.05,
+            leak_timeout_s=0.05,
+            max_consecutive_failures=10,
+        ),
+        max_retries=2,
+        backoff_s=(0.0,),
+        notifier=notifier,
+    )
+
+    result = await op.open()
+
+    assert result.status == OperationStatus.FAILED
+    assert result.retries_used == 2
+    assert notifier.notify.await_count == 1
+    kind = notifier.notify.await_args.args[1]
+    assert kind == NotificationKind.COMMAND_FAILED
+
+
+async def test_fully_failed_command_enters_maintenance_at_budget_end(hass):
+    """With the derived threshold (1 + max_retries) a command that fails
+    every attempt lands in MAINTENANCE exactly at its definitive failure."""
+    from never_dry.valve_fsm import FsmConfig
+
+    op = ValveOperator(
+        hass=hass,
+        switch_entity_id="switch.valve",
+        zone_name="maintzone",
+        fsm_config=FsmConfig(
+            has_flow_meter=False,
+            open_timeout_s=0.05,
+            close_timeout_s=0.05,
+            flow_verify_timeout_s=0.05,
+            leak_timeout_s=0.05,
+            max_consecutive_failures=3,  # = 1 + max_retries below
+        ),
+        max_retries=2,
+        backoff_s=(0.0,),
+    )
+
+    result = await op.open()
+
+    assert result.status == OperationStatus.MAINTENANCE
+    assert op.is_in_maintenance


### PR DESCRIPTION
## Problem

Spurious `CLOSE_VERIFICATION_FAILED` alerts (reported by @dietklein in #105): on a flaky Zigbee mesh (route errors, slow Z2M reports) a confirmation arriving after the adaptive verification window is routine — but every failed attempt raised a CRITICAL notification even when the next retry succeeded.

## Design (user decisions 2026-07-17)

- **Retry cap = 5** (`max_retries` default 2 → 5), backoff keeps doubling: 1, 2, 4, 8, 16 s. After the budget the command is **definitively failed** — worst case ~3.5 min of patience per command.
- **Per-attempt window stays mean-based**: the adaptive rolling mean + 3σ (clamped 2–30 s) is unchanged. Tolerance comes from the retry budget, not from inflating the window (a monotonic max would let one 30 s outlier inflate windows forever).
- **Transient failures notify only at definitive failure**: `OPEN_FAILED` / `CLOSE_VERIFICATION_FAILED` with retries remaining log a warning and stay silent; the notification (original severity, CRITICAL for close verification) fires exactly once when the budget is exhausted.
- **Derived maintenance threshold**: default FSM `max_consecutive_failures` = 1 + max_retries, so one command's retry budget can never trip MAINTENANCE mid-command; a fully-failed command reaches MAINTENANCE exactly at its definitive failure (same UX as the field today, with more patience).

## Tests

3 new cases: default budget + derived threshold, single notification after budget exhaustion, MAINTENANCE at budget end. Full suite: 731 passed.