### PR TITLE
release: bump version to 0.11.0-beta.2

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.0-beta.1"
+  "version": "0.11.0-beta.2"
 }


### PR DESCRIPTION
## Summary

Version bump for the second beta on the HACS beta channel. Since `v0.11.0-beta.1`, `custom_components/` gained:

- **#113** — settle tracked manual sessions on entry unload (AI-160)
- **#115** — retry cap 5 with silent transient retries; CRITICAL only on definitive failure — fixes the spurious `CLOSE_VERIFICATION_FAILED` reported in #105 (AI-157)

(Also in this beta window but test/docs-only: #109 end-trigger matrix tests + public engineering docs, #114 real-operator watchdog integration test.)

Tag `v0.11.0-beta.2` will be cut from develop after merge; release workflow marks pre-release tags for the HACS beta channel.