### PR TITLE
fix: scope entity unique_ids to the config entry (GH #116)

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -16,8 +16,9 @@ import pathlib
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_ZONE_NAME, CONF_ZONES, CONFIG_VERSION, DOMAIN
@@ -221,10 +222,34 @@ async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+async def _async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Prefix legacy unique_ids with the config entry id.
+
+    Up to 0.11.0-beta.1 the core sensors used static unique_ids
+    ("et_hourly_estimate", "never_dry") and the per-zone entities were
+    scoped on the zone slug only, so a second config entry collided and
+    HA silently dropped its entities (GH #116). Every unique_id is now
+    ``<entry_id>_<legacy_id>``; this migration renames the registry
+    entries of THIS config entry in place, preserving entity_id, history
+    and user customisations. Idempotent: already-prefixed ids are left
+    untouched.
+    """
+    prefix = f"{entry.entry_id}_"
+
+    @callback
+    def _migrate(reg_entry: er.RegistryEntry) -> dict[str, str] | None:
+        if reg_entry.unique_id.startswith(prefix):
+            return None
+        return {"new_unique_id": f"{prefix}{reg_entry.unique_id}"}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NeverDry from a config entry (UI)."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
+    await _async_migrate_unique_ids(hass, entry)
     handler = await hass.async_add_executor_job(_setup_file_logger, hass)
     hass.data[DOMAIN][f"_log_handler_{entry.entry_id}"] = handler
     await _async_register_frontend(hass)

--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -63,6 +63,10 @@ def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -
         if zone_conf.get("valve"):
             buttons.append(StopButton(hass, zone_name, device_info))
             buttons.append(ResetMaintenanceButton(hass, zone_name, device_info))
+    # Scope every unique_id to the config entry (GH #116) — same rule as
+    # sensor._create_entities, covered by the same registry migration.
+    for button in buttons:
+        button._attr_unique_id = f"{entry_id}_{button._attr_unique_id}"
     return buttons
 
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -325,6 +325,14 @@ def _create_entities(
                 )
             )
 
+    # Scope every unique_id to the config entry: static and slug-only ids
+    # collide across entries and HA silently drops the duplicates — the
+    # second entry was born without entities (GH #116). The registry
+    # migration in __init__._async_migrate_unique_ids renames existing
+    # installations to this format.
+    for entity in entities:
+        entity._attr_unique_id = f"{entry_id}_{entity._attr_unique_id}"
+
     return entities, di_sensor, zone_sensors
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,8 @@ def _create_ha_stubs():
     entity_registry_mod = ModuleType("homeassistant.helpers.entity_registry")
     entity_registry_mod.async_get = MagicMock(return_value=MagicMock())
     entity_registry_mod.async_entries_for_device = MagicMock(return_value=[])
+    entity_registry_mod.async_migrate_entries = AsyncMock()
+    entity_registry_mod.RegistryEntry = MagicMock
 
     # homeassistant.helpers.storage
     storage_mod = ModuleType("homeassistant.helpers.storage")

--- a/tests/test_unique_id_scoping.py
+++ b/tests/test_unique_id_scoping.py
@@ -1,0 +1,115 @@
+"""Entry-scoped unique_ids (GH #116).
+
+Up to 0.11.0-beta.1 the core sensors used static unique_ids and the
+per-zone entities were scoped on the zone slug only: a second config
+entry collided ("Platform never_dry does not generate unique IDs") and
+HA silently dropped its entities — the second controller was born
+without sensors. Every unique_id is now prefixed with the entry_id, and
+a registry migration renames existing installations in place.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from never_dry.button import _create_buttons
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+)
+from never_dry.sensor import _create_entities
+
+
+@pytest.fixture
+def two_zone_config(base_config):
+    return {
+        **base_config,
+        CONF_ZONES: [
+            {
+                CONF_ZONE_NAME: "Orto",
+                "valve": "switch.valve_orto",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_EFFICIENCY: 0.90,
+            },
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 30.0,
+                CONF_ZONE_EFFICIENCY: 0.85,
+            },
+        ],
+    }
+
+
+class TestSensorUniqueIdScoping:
+    def test_all_unique_ids_carry_the_entry_prefix(self, hass_mock, two_zone_config):
+        entities, _, _ = _create_entities(hass_mock, two_zone_config, "entryA")
+        assert entities, "factory produced no entities"
+        for e in entities:
+            assert e._attr_unique_id.startswith("entryA_"), e._attr_unique_id
+
+    def test_two_entries_with_identical_config_do_not_collide(self, hass_mock, two_zone_config):
+        """The exact GH #116 scenario: same zones on two config entries."""
+        a, _, _ = _create_entities(hass_mock, two_zone_config, "entryA")
+        b, _, _ = _create_entities(hass_mock, two_zone_config, "entryB")
+        ids_a = {e._attr_unique_id for e in a}
+        ids_b = {e._attr_unique_id for e in b}
+        assert len(ids_a) == len(a), "duplicate unique_ids within one entry"
+        assert ids_a.isdisjoint(ids_b), "unique_ids collide across entries"
+
+    def test_core_sensors_no_longer_static(self, hass_mock, two_zone_config):
+        """The two ids reported in GH #116 must not appear unprefixed."""
+        entities, _, _ = _create_entities(hass_mock, two_zone_config, "entryA")
+        ids = {e._attr_unique_id for e in entities}
+        assert "et_hourly_estimate" not in ids
+        assert "never_dry" not in ids
+        assert "entryA_et_hourly_estimate" in ids
+        assert "entryA_never_dry" in ids
+
+
+class TestButtonUniqueIdScoping:
+    def test_two_entries_with_identical_zones_do_not_collide(self, hass_mock, two_zone_config):
+        a = _create_buttons(hass_mock, two_zone_config, "entryA")
+        b = _create_buttons(hass_mock, two_zone_config, "entryB")
+        assert a, "factory produced no buttons"
+        ids_a = {x._attr_unique_id for x in a}
+        ids_b = {x._attr_unique_id for x in b}
+        assert all(i.startswith("entryA_") for i in ids_a)
+        assert ids_a.isdisjoint(ids_b)
+
+
+class TestRegistryMigration:
+    @pytest.mark.asyncio
+    async def test_migration_prefixes_legacy_ids_and_skips_migrated(self, hass_mock):
+        """The migration callback prefixes legacy ids exactly once."""
+        from never_dry import _async_migrate_unique_ids
+
+        entry = MagicMock()
+        entry.entry_id = "entryA"
+
+        captured = {}
+
+        async def _capture(hass, entry_id, cb):
+            captured["entry_id"] = entry_id
+            captured["cb"] = cb
+
+        with patch(
+            "never_dry.er.async_migrate_entries",
+            new=AsyncMock(side_effect=_capture),
+        ):
+            await _async_migrate_unique_ids(hass_mock, entry)
+
+        assert captured["entry_id"] == "entryA"
+        cb = captured["cb"]
+
+        legacy = MagicMock()
+        legacy.unique_id = "never_dry"
+        assert cb(legacy) == {"new_unique_id": "entryA_never_dry"}
+
+        legacy_zone = MagicMock()
+        legacy_zone.unique_id = "deficit_zone_orto"
+        assert cb(legacy_zone) == {"new_unique_id": "entryA_deficit_zone_orto"}
+
+        migrated = MagicMock()
+        migrated.unique_id = "entryA_never_dry"
+        assert cb(migrated) is None


### PR DESCRIPTION
## Problem

Reported in #116 (thanks @MetheLittle): adding a second config entry creates the entry but the controller has no entities.

```
Platform never_dry does not generate unique IDs. ID et_hourly_estimate already exists - ignoring sensor.neverdry_et_hourly_estimate
Platform never_dry does not generate unique IDs. ID never_dry already exists - ignoring sensor.neverdry_dryness_index
```

Root cause: the core sensors used **static** unique_ids and the per-zone sensors/buttons were scoped on the zone slug only — any second entry (or same-named zones across entries) collided, HA silently dropped the duplicates, and the zone's `via_device` pointed at a hub device that was never created. Devices were already entry-scoped; only entity unique_ids were not.

## Fix

- Every sensor and button unique_id is now `<entry_id>_<legacy_id>`, applied centrally in the platform factories (one rule, covers all 20+ entity types including linked mirrors).
- **Registry migration** in `async_setup_entry` (`er.async_migrate_entries`): legacy unique_ids of existing installations are renamed in place, idempotently — `entity_id`, history and user customisations are preserved. The Zone Lovelace card matches entities by `entity_id` suffix, so it is unaffected.

## Tests

New `test_unique_id_scoping.py` (5 cases): prefix on all entities, the exact #116 scenario (two entries, identical config → disjoint ids), static ids gone, button scoping, migration callback (legacy → prefixed, already-migrated untouched). Full suite: 736 passed.

Fixes #116