### PR TITLE
release: bump version to 0.11.0-beta.3

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.0-beta.2"
+  "version": "0.11.0-beta.3"
 }


### PR DESCRIPTION
## Summary

Hotfix beta on the HACS beta channel. Since `v0.11.0-beta.2`:

- **#119** — rain baseline survives restarts: the whole cumulative/24h rain reading was re-credited as fresh rain at every boot, wiping the reference index and every zone deficit on rainy-day restarts (field bug found today, present in every previous release).

Tag `v0.11.0-beta.3` will be cut from develop after merge.