### PR TITLE
Fix phantom rain from rolling 24h sensors, full ET bypass in VWC mode, zone card button resolution

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -156,7 +156,7 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
 
 
 def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
-    """ET parameters form for options flow, with stored metric values pre-filled."""
+    """System sensors + ET parameters form for options flow, pre-filled from the entry."""
     t_unit = "°F" if is_imperial else "°C"
     d_unit = "in" if is_imperial else "mm"
     t_stored = current.get(CONF_T_BASE, DEFAULT_T_BASE)
@@ -166,6 +166,28 @@ def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
 
     return vol.Schema(
         {
+            vol.Required(
+                CONF_TEMP_SENSOR,
+                description={"suggested_value": current.get(CONF_TEMP_SENSOR)},
+            ): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor", device_class="temperature")),
+            vol.Required(
+                CONF_RAIN_SENSOR,
+                description={"suggested_value": current.get(CONF_RAIN_SENSOR)},
+            ): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
+            vol.Optional(
+                CONF_RAIN_SENSOR_TYPE,
+                default=current.get(CONF_RAIN_SENSOR_TYPE, DEFAULT_RAIN_SENSOR_TYPE),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[RAIN_TYPE_EVENT, RAIN_TYPE_DAILY_TOTAL],
+                    translation_key="rain_sensor_type",
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(
+                CONF_VWC_SENSOR,
+                description={"suggested_value": current.get(CONF_VWC_SENSOR)},
+            ): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
             vol.Optional(CONF_ALPHA, default=current.get(CONF_ALPHA, DEFAULT_ALPHA)): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0.05,
@@ -495,6 +517,11 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             user_input = _sensors_input_to_metric(user_input, imperial)
             new_data = {**self._config_entry.data, **user_input}
+            # An optional entity field cleared by the user is simply absent
+            # from user_input — the merge above would silently keep the old
+            # value, so drop it explicitly.
+            if CONF_VWC_SENSOR not in user_input:
+                new_data.pop(CONF_VWC_SENSOR, None)
             if new_data != dict(self._config_entry.data):
                 changed = [k for k in new_data if new_data[k] != self._config_entry.data.get(k)]
                 _LOGGER.debug("Config updated via model_params — changed keys: %s", changed)

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -13,6 +13,13 @@ CONF_RAIN_SENSOR_TYPE = "rain_sensor_type"
 RAIN_TYPE_EVENT = "event"  # mm per event (tipping bucket pulse)
 RAIN_TYPE_DAILY_TOTAL = "daily_total"  # cumulative mm since midnight
 
+# A drop in a daily_total reading is a genuine reset (midnight rollover)
+# only when the new value is near zero. A drop that lands HIGHER than this
+# threshold is a rolling-window sensor (e.g. "24h rain") ageing out old
+# rain — crediting the residual as fresh rain wiped every deficit at 05:00
+# with clear skies (field bug, 2026-07-18).
+RAIN_RESET_MAX_MM = 1.0
+
 # ── ET model parameters ──────────────────────────────────
 CONF_ALPHA = "alpha"
 CONF_T_BASE = "t_base"

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -262,9 +262,14 @@ def _create_entities(
 ) -> tuple[list[SensorEntity], DrynessIndexSensor, list[IrrigationZoneSensor]]:
     """Create sensor entities from a config dict (shared by YAML and UI)."""
     hub_device = _hub_device_info(entry_id)
-    et_sensor = ETSensor(hass, config, hub_device)
     di_sensor = DrynessIndexSensor(hass, config, hub_device)
-    entities: list[SensorEntity] = [et_sensor, di_sensor]
+    entities: list[SensorEntity] = []
+    # In VWC mode the ET model is bypassed entirely — an "ET Hourly
+    # Estimate" entity that keeps updating from temperature reads as if
+    # the model were still active (tester report, 2026-07-18).
+    if not config.get(CONF_VWC_SENSOR):
+        entities.append(ETSensor(hass, config, hub_device))
+    entities.append(di_sensor)
 
     zone_sensors: list[IrrigationZoneSensor] = []
     for zone_conf in config.get(CONF_ZONES, []):
@@ -625,7 +630,13 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
                     )
 
         if not restored:
-            await self._backfill_from_recorder()
+            if self._vwc_sensor:
+                # The backfill replays the ET/rain water balance, which is
+                # the wrong model here: the first VWC reading sets the
+                # observed deficit directly.
+                _LOGGER.info("VWC mode: skipping ET-model backfill")
+            else:
+                await self._backfill_from_recorder()
 
         tracked = [self._temp_sensor, self._rain_sensor]
         if self._vwc_sensor:

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -91,6 +91,7 @@ from .const import (
     ET_TEMP_VALID_RANGE,
     KC_ANCHOR_DAYS,
     PLANT_FAMILIES,
+    RAIN_RESET_MAX_MM,
     RAIN_TYPE_EVENT,
     SYSTEM_TYPES,
     UNUSUAL_FLOW_MAX_LPM,
@@ -585,6 +586,10 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         attrs: dict = {}
         if self._last_rain is not None:
             attrs["rain_baseline_mm"] = round(self._last_rain, 2)
+            # The baseline is only meaningful against the sensor that
+            # produced it: on restore it is discarded if the configured
+            # rain sensor has changed in the meantime.
+            attrs["rain_baseline_entity"] = self._rain_sensor
         return attrs
 
     async def async_added_to_hass(self) -> None:
@@ -602,9 +607,22 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             # event timestamp instead.
             if self._rain_type != RAIN_TYPE_EVENT:
                 baseline = last.attributes.get("rain_baseline_mm")
-                if baseline is not None:
+                baseline_entity = last.attributes.get("rain_baseline_entity")
+                if baseline is not None and baseline_entity == self._rain_sensor:
                     with contextlib.suppress(ValueError, TypeError):
                         self._last_rain = float(baseline)
+                elif baseline is not None:
+                    # Baseline from a different (or unknown, pre-upgrade)
+                    # rain sensor: comparing it with the new sensor's scale
+                    # would credit phantom rain. Drop it — the next reading
+                    # fixes a fresh baseline without crediting.
+                    _LOGGER.info(
+                        "Rain baseline %s mm belongs to '%s', configured sensor is '%s'"
+                        " — discarding, rebaselining on next reading",
+                        baseline,
+                        baseline_entity,
+                        self._rain_sensor,
+                    )
 
         if not restored:
             await self._backfill_from_recorder()
@@ -669,8 +687,10 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         """Compute rain increment since last reading.
 
         For 'event' type: the sensor value IS the delta (mm per event).
-        For 'daily_total' type: compute delta from last reading, handling
-        midnight rollover (rain_now < last_rain → new accumulation).
+        For 'daily_total' type: compute delta from last reading. A drop in
+        the reading is a midnight rollover (new value = fresh accumulation)
+        only when it lands near zero; a drop with a high residual is a
+        rolling-window sensor ageing out old rain and credits nothing.
         Converts inches to mm when the sensor reports in imperial units.
         """
         try:
@@ -712,8 +732,24 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             return 0.0
         rain_delta = rain_now - self._last_rain
         if rain_delta < 0:
-            # Sensor reset (midnight rollover) — treat new value as fresh
-            rain_delta = rain_now
+            if rain_now <= RAIN_RESET_MAX_MM:
+                # Genuine reset (midnight rollover): the counter restarted
+                # near zero, so the new value is fresh accumulation.
+                rain_delta = rain_now
+            else:
+                # Rolling-window sensor (e.g. "24h rain") ageing out old
+                # rain: the residual is NOT new precipitation. Crediting it
+                # re-applied yesterday's whole rainfall as phantom rain
+                # (field bug, 2026-07-18: 13.2 mm credited at 05:00 with
+                # clear skies, every zone deficit wiped).
+                _LOGGER.debug(
+                    "Rain sensor '%s' dropped %.2f -> %.2f mm with high residual —"
+                    " rolling-window ageing, no rain credited",
+                    self._rain_sensor,
+                    self._last_rain,
+                    rain_now,
+                )
+                rain_delta = 0.0
         self._last_rain = rain_now
         return max(0.0, rain_delta)
 

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -101,9 +101,13 @@
         }
       },
       "model_params": {
-        "title": "ET Model Parameters",
-        "description": "Adjust the evapotranspiration model. Changes take effect immediately.",
+        "title": "System Sensors & ET Model",
+        "description": "Change the input sensors or adjust the evapotranspiration model. Changes take effect immediately.",
         "data": {
+          "temperature_sensor": "Temperature sensor",
+          "rain_sensor": "Rain sensor",
+          "rain_sensor_type": "Rain sensor type",
+          "vwc_sensor": "Soil moisture sensor (optional)",
           "alpha": "ET coefficient (α)",
           "t_base": "Base temperature",
           "d_max": "Maximum deficit cap"

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -101,9 +101,13 @@
         }
       },
       "model_params": {
-        "title": "Parametri del Modello ET",
-        "description": "Regola il modello di evapotraspirazione. Le modifiche hanno effetto immediato.",
+        "title": "Sensori di sistema e modello ET",
+        "description": "Cambia i sensori di ingresso o regola il modello di evapotraspirazione. Le modifiche hanno effetto immediato.",
         "data": {
+          "temperature_sensor": "Sensore di temperatura",
+          "rain_sensor": "Sensore di pioggia",
+          "rain_sensor_type": "Tipo di sensore di pioggia",
+          "vwc_sensor": "Sensore di umidità del suolo (opzionale)",
           "alpha": "Coefficiente ET (α)",
           "t_base": "Temperatura di base",
           "d_max": "Limite massimo del deficit"

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -219,9 +219,13 @@ class NeverDryZoneCard extends HTMLElement {
       // 1) Preferred: stable unique_id prefix.
       const uid = uidMap && uidMap[ent.entity_id];
       if (uid) {
+        // unique_ids are entry-scoped since GH #116
+        // ("<entry_id>_irrigate_<zone>"): strip the entry prefix before
+        // matching, but keep trying the raw uid for unmigrated installs.
+        const bare = uid.slice(uid.indexOf("_") + 1);
         let matched = false;
         for (const [role, prefix] of uidRoles) {
-          if (!out[role] && uid.startsWith(prefix)) {
+          if (!out[role] && (uid.startsWith(prefix) || bare.startsWith(prefix))) {
             out[role] = st;
             matched = true;
             break;

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -836,3 +836,57 @@ class TestRainBaselineEntityGuard:
         )
         await sensor.async_added_to_hass()
         assert sensor._last_rain is None
+
+
+class TestVwcModeBypassesEtModel:
+    """With a VWC sensor configured the ET model must be fully bypassed.
+
+    Tester report 2026-07-18: the 'ET Hourly Estimate' entity kept
+    updating from temperature and the recorder backfill replayed the
+    ET/rain water balance even in VWC mode — both suggested the ET model
+    was still driving the deficit.
+    """
+
+    def test_et_entity_not_created_in_vwc_mode(self, hass_mock, base_config):
+        from never_dry.const import CONF_VWC_SENSOR
+        from never_dry.sensor import ETSensor, _create_entities
+
+        entities, _, _ = _create_entities(
+            hass_mock,
+            {**base_config, CONF_VWC_SENSOR: "sensor.soil_vwc"},
+            "entryA",
+        )
+        assert not any(isinstance(e, ETSensor) for e in entities)
+
+    def test_et_entity_created_without_vwc(self, hass_mock, base_config):
+        from never_dry.sensor import ETSensor, _create_entities
+
+        entities, _, _ = _create_entities(hass_mock, base_config, "entryA")
+        assert any(isinstance(e, ETSensor) for e in entities)
+
+    @pytest.mark.asyncio
+    async def test_backfill_skipped_in_vwc_mode(self, hass_mock, base_config):
+        from unittest.mock import AsyncMock
+
+        from never_dry.const import CONF_VWC_SENSOR
+
+        sensor = DrynessIndexSensor(
+            hass_mock,
+            {**base_config, CONF_VWC_SENSOR: "sensor.soil_vwc"},
+        )
+        sensor.async_write_ha_state = MagicMock()
+        sensor._backfill_from_recorder = AsyncMock()
+        sensor.async_get_last_state = AsyncMock(return_value=None)
+        await sensor.async_added_to_hass()
+        sensor._backfill_from_recorder.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_backfill_still_runs_without_vwc(self, hass_mock, base_config):
+        from unittest.mock import AsyncMock
+
+        sensor = DrynessIndexSensor(hass_mock, base_config)
+        sensor.async_write_ha_state = MagicMock()
+        sensor._backfill_from_recorder = AsyncMock()
+        sensor.async_get_last_state = AsyncMock(return_value=None)
+        await sensor.async_added_to_hass()
+        sensor._backfill_from_recorder.assert_awaited_once()

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -659,3 +659,180 @@ class TestRainBaselineAcrossRestart:
         assert "rain_baseline_mm" not in sensor.extra_state_attributes
         sensor._last_rain = 14.2
         assert sensor.extra_state_attributes["rain_baseline_mm"] == pytest.approx(14.2)
+
+
+class TestRollingWindowRainSensor:
+    """A rolling accumulation sensor (e.g. '24h rain') ages out old rain.
+
+    Field bug 2026-07-18: at 05:00 with clear skies the sensor dropped
+    14.2 → 13.2 mm as yesterday's rain left the 24h window. The drop was
+    read as a midnight rollover and the whole residual (13.2 mm) was
+    credited as fresh rain, wiping every zone deficit. A drop is a genuine
+    reset only when the new reading lands near zero (RAIN_RESET_MAX_MM).
+    """
+
+    def _daily_sensor(self, hass_mock):
+        from never_dry.const import (
+            CONF_RAIN_SENSOR,
+            CONF_RAIN_SENSOR_TYPE,
+            CONF_TEMP_SENSOR,
+            RAIN_TYPE_DAILY_TOTAL,
+        )
+        from never_dry.sensor import DrynessIndexSensor
+
+        return DrynessIndexSensor(
+            hass_mock,
+            {
+                CONF_TEMP_SENSOR: "sensor.temperature",
+                CONF_RAIN_SENSOR: "sensor.rain",
+                CONF_RAIN_SENSOR_TYPE: RAIN_TYPE_DAILY_TOTAL,
+            },
+        )
+
+    def _tick(self, sensor, hass_mock, make_state, rain_value):
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(9.0),  # T == T_base → ET = 0
+            "sensor.rain": make_state(rain_value),
+        }[eid]
+        sensor._last_update = datetime.now() - timedelta(seconds=1)
+        sensor._on_sensor_change(MagicMock())
+
+    def test_window_ageing_drop_credits_nothing(self, hass_mock, make_state):
+        """The exact field scenario: 14.2 → 13.2 must credit 0 mm."""
+        sensor = self._daily_sensor(hass_mock)
+        sensor._deficit = 54.25
+        sensor._last_rain = 14.2
+
+        self._tick(sensor, hass_mock, make_state, 13.2)
+
+        assert sensor._deficit == pytest.approx(54.25, abs=0.01)
+        # Baseline follows the reading so later drops credit nothing either.
+        assert sensor._last_rain == pytest.approx(13.2)
+
+    def test_gradual_window_decay_credits_nothing(self, hass_mock, make_state):
+        """Step-by-step ageing (13.2 → 10.0 → 4.0 → 1.5) credits nothing."""
+        sensor = self._daily_sensor(hass_mock)
+        sensor._deficit = 20.0
+        sensor._last_rain = 13.2
+
+        for reading in (10.0, 4.0, 1.5):
+            self._tick(sensor, hass_mock, make_state, reading)
+
+        assert sensor._deficit == pytest.approx(20.0, abs=0.01)
+        assert sensor._last_rain == pytest.approx(1.5)
+
+    def test_decay_to_zero_credits_nothing(self, hass_mock, make_state):
+        """Window fully drained (13.2 → 0.0) credits nothing."""
+        sensor = self._daily_sensor(hass_mock)
+        sensor._deficit = 20.0
+        sensor._last_rain = 13.2
+
+        self._tick(sensor, hass_mock, make_state, 0.0)
+
+        assert sensor._deficit == pytest.approx(20.0, abs=0.01)
+        assert sensor._last_rain == pytest.approx(0.0)
+
+    def test_midnight_reset_still_credits_new_accumulation(self, hass_mock, make_state):
+        """A true midnight rollover (drop to near zero) still credits the
+        fresh accumulation: 8.0 → 0.5 credits 0.5 mm."""
+        sensor = self._daily_sensor(hass_mock)
+        sensor._deficit = 10.0
+        sensor._last_rain = 8.0
+
+        self._tick(sensor, hass_mock, make_state, 0.5)
+
+        assert sensor._deficit == pytest.approx(9.5, abs=0.01)
+
+    def test_rain_after_window_ageing_credited_normally(self, hass_mock, make_state):
+        """New rain arriving after an ageing drop is credited from the
+        rebased baseline: 14.2 → 13.2 (ageing), then 13.2 → 16.2 → 3 mm."""
+        sensor = self._daily_sensor(hass_mock)
+        sensor._deficit = 10.0
+        sensor._last_rain = 14.2
+
+        self._tick(sensor, hass_mock, make_state, 13.2)
+        self._tick(sensor, hass_mock, make_state, 16.2)
+
+        assert sensor._deficit == pytest.approx(7.0, abs=0.01)
+
+
+class TestRainBaselineEntityGuard:
+    """A restored rain baseline is only valid for the sensor that wrote it.
+
+    After the rain sensor becomes editable from the options flow, a
+    baseline persisted by the OLD sensor must not be compared against the
+    NEW sensor's readings — the scales are unrelated and the difference
+    would be credited as phantom rain.
+    """
+
+    def _daily_sensor(self, hass_mock, rain_entity="sensor.rain"):
+        from never_dry.const import (
+            CONF_RAIN_SENSOR,
+            CONF_RAIN_SENSOR_TYPE,
+            CONF_TEMP_SENSOR,
+            RAIN_TYPE_DAILY_TOTAL,
+        )
+        from never_dry.sensor import DrynessIndexSensor
+
+        sensor = DrynessIndexSensor(
+            hass_mock,
+            {
+                CONF_TEMP_SENSOR: "sensor.temperature",
+                CONF_RAIN_SENSOR: rain_entity,
+                CONF_RAIN_SENSOR_TYPE: RAIN_TYPE_DAILY_TOTAL,
+            },
+        )
+        sensor.async_write_ha_state = MagicMock()
+        return sensor
+
+    def _last_state(self, attributes):
+        last = MagicMock()
+        last.state = "10.0"
+        last.attributes = attributes
+        return last
+
+    def test_baseline_entity_exposed_in_attributes(self, hass_mock):
+        sensor = self._daily_sensor(hass_mock)
+        sensor._last_rain = 14.2
+        assert sensor.extra_state_attributes["rain_baseline_entity"] == "sensor.rain"
+
+    @pytest.mark.asyncio
+    async def test_matching_entity_baseline_restored(self, hass_mock):
+        from unittest.mock import AsyncMock
+
+        sensor = self._daily_sensor(hass_mock)
+        sensor.async_get_last_state = AsyncMock(
+            return_value=self._last_state(
+                {"rain_baseline_mm": 14.2, "rain_baseline_entity": "sensor.rain"},
+            )
+        )
+        await sensor.async_added_to_hass()
+        assert sensor._last_rain == pytest.approx(14.2)
+
+    @pytest.mark.asyncio
+    async def test_changed_entity_baseline_discarded(self, hass_mock):
+        from unittest.mock import AsyncMock
+
+        sensor = self._daily_sensor(hass_mock, rain_entity="sensor.new_rain")
+        sensor.async_get_last_state = AsyncMock(
+            return_value=self._last_state(
+                {"rain_baseline_mm": 14.2, "rain_baseline_entity": "sensor.old_rain"},
+            )
+        )
+        await sensor.async_added_to_hass()
+        # Baseline belongs to the old sensor → None sentinel: the next
+        # reading fixes a fresh baseline without crediting.
+        assert sensor._last_rain is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_baseline_without_entity_discarded(self, hass_mock):
+        """Pre-upgrade states have no rain_baseline_entity: safer to drop
+        the baseline once than to risk comparing across sensors."""
+        from unittest.mock import AsyncMock
+
+        sensor = self._daily_sensor(hass_mock)
+        sensor.async_get_last_state = AsyncMock(
+            return_value=self._last_state({"rain_baseline_mm": 14.2}),
+        )
+        await sensor.async_added_to_hass()
+        assert sensor._last_rain is None


### PR DESCRIPTION
## Summary

Three field-verified fixes from the 2026-07-18 debugging session:

### 1. Phantom rain from rolling-window rain sensors
At 05:00 with clear skies every zone deficit was wiped: the '24h rain' sensor dropped 14.2 → 13.2 mm as yesterday's rain aged out of its rolling window, the drop was read as a midnight rollover, and the whole residual (13.2 mm) was credited as fresh rain. A drop in a daily_total reading now counts as a genuine reset only when the new value lands near zero (RAIN_RESET_MAX_MM = 1.0 mm); higher residuals credit nothing and only rebase the baseline.

### 2. System sensors editable from the options flow
Temperature, rain, rain type and VWC sensors could only be set at initial setup — changing them required recreating the integration (tester report). They are now editable in the model_params options step. Since the rain baseline is only meaningful against the sensor that wrote it, it is persisted together with its entity_id (rain_baseline_entity) and discarded on restore if the configured sensor changed.

### 3. Full ET bypass in VWC mode (tester report)
With vwc_sensor configured, the 'ET Hourly Estimate' entity kept publishing temperature-based estimates and the recorder backfill replayed the ET/rain water balance — both suggested the ET model was still active. The ET entity is no longer created in VWC mode and the backfill is skipped.

### 4. Zone card: unique_id matching broken by entry-scoped ids
Since the GH #116 migration every unique_id carries the entry_id prefix, so the card's preferred unique_id matching never fired and zones survived on the entity_id-suffix fallback; zones with legacy word-order entity_ids (button.irrigate_giardino_melino) escaped that too, leaving Irrigate/Mark buttons disabled. The entry prefix is now stripped before matching (raw uid still tried for unmigrated installs).

## Testing
- 753 unit tests passing (14 new: rolling-window rain, baseline entity guard, VWC bypass)
- Field-verified on the production garden instance: no phantom rain across restart, rain_baseline_entity exposed, zone card buttons active again after hard refresh