### PR TITLE
release: bump version to 0.11.0-beta.4

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.0-beta.3"
+  "version": "0.11.0-beta.4"
 }


### PR DESCRIPTION
Version bump for beta.4, shipping the three fixes merged in #121:
- Phantom rain from rolling 24h rain sensors
- Full ET bypass in VWC mode
- Zone card unique_id button resolution