### PR TITLE
Landing redesign for adoption + download/install badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
+[![Downloads](https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%29)](https://github.com/drake69/NeverDry/releases)
 [![GitHub stars](https://img.shields.io/github/stars/drake69/NeverDry?style=social)](https://github.com/drake69/NeverDry/stargazers)
+<!-- Active installs (Home Assistant analytics). Currently no data: `never_dry` is not yet listed
+     in analytics.home-assistant.io/custom_integrations.json (below HA's listing threshold).
+     Uncomment when it appears — the badge auto-populates:
+[![Active installs](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=active%20installs&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.never_dry.total)](https://analytics.home-assistant.io/custom_integrations.json)
+-->
+
 
 If NeverDry is useful to you, **[leave a star](https://github.com/drake69/NeverDry/stargazers)** ⭐ — it helps others find the project.
 
@@ -246,9 +253,9 @@ Found a bug or have an idea? Open an issue — reports from real gardens are wha
 
 ## Support
 
-If NeverDry saves your garden (and your water bill), consider a one-time donation — or just leave a star, it costs nothing and helps others find the project:
+NeverDry is free and open source. If it's useful to you, leave a star — it costs nothing and helps others find the project:
 
-<a href="https://ko-fi.com/drake69"><img src="https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" height="35"></a>&nbsp;&nbsp;<a href="https://github.com/drake69/NeverDry/stargazers"><img src="https://img.shields.io/badge/Star_on_GitHub-24292e?style=for-the-badge&logo=github&logoColor=white" alt="Star on GitHub" height="35"></a>
+<a href="https://github.com/drake69/NeverDry/stargazers"><img src="https://img.shields.io/badge/Star_on_GitHub-24292e?style=for-the-badge&logo=github&logoColor=white" alt="Star on GitHub" height="35"></a>
 
 ---
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -18,10 +18,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -73,17 +73,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligente Bew&auml;sserung f&uuml;r Home Assistant. A wissenschaftliches Wasserbilanzmodell, das wei&szlig;, wann und wie lang Ihr Garten gegossen geh&ouml;rt.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">GitHub-Repository</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentation</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">In Home Assistant installieren</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Ein Klick &uuml;ber HACS &mdash; NeverDry ist im Standard-Repository.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Gie&szlig;t nur, wenn der Boden trocken ist</div>
+        <div>🛡️&nbsp;&nbsp;Das Ventil schlie&szlig;t immer</div>
+        <div>🌧️&nbsp;&nbsp;&Uuml;berspringt die Bew&auml;sserung nach Regen</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Nutzen Sie es bereits? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
+    </div>
 </section>
 
 <section class="features">
@@ -219,10 +240,15 @@
 
 <section class="support">
     <h2>Projekt unterst&uuml;tzen</h2>
-    <p>Wenn NeverDry Ihren Garten und Ihre Wasserrechnung rettet, erw&auml;gen Sie eine Spende:</p>
+    <p>NeverDry ist kostenlos und quelloffen &mdash; der beste Weg, es zu unterst&uuml;tzen, ist ein Stern und Weitersagen:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Kennen Sie jemanden mit Garten und Home Assistant? Sagen Sie es weiter:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
     </div>
 </section>
 

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -31,10 +31,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -86,17 +86,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligente Bew&auml;sserung f&uuml;r Home Assistant. Ein wissenschaftliches Wasserbilanzmodell, das wei&szlig;, wann und wie lange Ihr Garten gegossen werden muss.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">GitHub-Repository</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentation</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">In Home Assistant installieren</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Ein Klick &uuml;ber HACS &mdash; NeverDry ist im Standard-Repository.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Gie&szlig;t nur, wenn der Boden trocken ist</div>
+        <div>🛡️&nbsp;&nbsp;Das Ventil schlie&szlig;t immer</div>
+        <div>🌧️&nbsp;&nbsp;&Uuml;berspringt die Bew&auml;sserung nach Regen</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Nutzen Sie es bereits? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
+    </div>
 </section>
 
 <section class="features">
@@ -232,10 +253,15 @@
 
 <section class="support">
     <h2>Projekt unterst&uuml;tzen</h2>
-    <p>Wenn NeverDry Ihren Garten und Ihre Wasserrechnung rettet, erw&auml;gen Sie eine Spende:</p>
+    <p>NeverDry ist kostenlos und quelloffen &mdash; der beste Weg, es zu unterst&uuml;tzen, ist ein Stern und Weitersagen:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Auf Ko-fi unterst&uuml;tzen</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Kennen Sie jemanden mit Garten und Home Assistant? Sagen Sie es weiter:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
     </div>
 </section>
 

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -26,10 +26,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -81,17 +81,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Riego inteligente para Home Assistant. Un modelo cient&iacute;fico de balance h&iacute;drico que sabe cu&aacute;ndo y cu&aacute;nto tiempo regar tu jard&iacute;n.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">Repositorio GitHub</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentaci&oacute;n</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Instalar en Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un clic v&iacute;a HACS &mdash; NeverDry est&aacute; en el repositorio por defecto.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Riega solo cuando el suelo est&aacute; seco</div>
+        <div>🛡️&nbsp;&nbsp;La v&aacute;lvula siempre se cierra</div>
+        <div>🌧️&nbsp;&nbsp;Omite el riego despu&eacute;s de la lluvia</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentaci&oacute;n</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        &iquest;Ya lo usas? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deja una &#11088;</a> para ayudar a otros a descubrirlo.
+    </div>
 </section>
 
 <section class="features">
@@ -227,10 +248,15 @@
 
 <section class="support">
     <h2>Apoya el Proyecto</h2>
-    <p>Si NeverDry salva tu jard&iacute;n y tu factura del agua, considera una donaci&oacute;n:</p>
+    <p>NeverDry es gratuito y de c&oacute;digo abierto &mdash; la mejor forma de apoyarlo es darle una estrella y correr la voz:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoyar en Ko-fi</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deja una estrella en GitHub</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">&iquest;Conoces a alguien con un jard&iacute;n y Home Assistant? Corre la voz:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Compartir en Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Compartir en Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Compartir en X</a>
     </div>
 </section>
 

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -31,10 +31,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -86,17 +86,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irrigation intelligente pour Home Assistant. Un mod&egrave;le scientifique de bilan hydrique qui sait quand et combien de temps arroser votre jardin.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">D&eacute;p&ocirc;t GitHub</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentation</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Installer dans Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un seul clic via HACS &mdash; NeverDry est dans le d&eacute;p&ocirc;t par d&eacute;faut.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Arrose uniquement quand le sol est sec</div>
+        <div>🛡️&nbsp;&nbsp;La vanne se ferme toujours</div>
+        <div>🌧️&nbsp;&nbsp;Saute l'arrosage apr&egrave;s la pluie</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Vous l'utilisez d&eacute;j&agrave;&nbsp;? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">laissez une ⭐</a> pour aider les autres &agrave; le d&eacute;couvrir.
+    </div>
 </section>
 
 <section class="features">
@@ -232,10 +253,15 @@
 
 <section class="support">
     <h2>Soutenir le Projet</h2>
-    <p>Si NeverDry sauve votre jardin et votre facture d'eau, pensez &agrave; faire un don :</p>
+    <p>NeverDry est gratuit et open source &mdash; la meilleure fa&ccedil;on de le soutenir est de lui donner une &eacute;toile et d'en parler autour de vous&nbsp;:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Soutenir sur Ko-fi</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Laissez une &eacute;toile sur GitHub</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Vous connaissez quelqu'un avec un jardin et Home Assistant&nbsp;? Faites passer le mot&nbsp;:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partager sur Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partager sur Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partager sur X</a>
     </div>
 </section>
 

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -18,10 +18,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -73,17 +73,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Pametno navodnjavanje za Home Assistant. Znanstveni model vodne bilance koji zna kada i koliko dugo zalijevati va&scaron; vrt.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repozitorij</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokumentacija</a>
+    <!-- Primary CTA: one-click HACS install -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Instaliraj u Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Jedan klik putem HACS-a — NeverDry je u zadanom repozitoriju.</div>
+
+    <!-- Value props -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Zalijeva samo kada je tlo suho</div>
+        <div>🛡️&nbsp;&nbsp;Ventil se uvijek zatvara</div>
+        <div>🌧️&nbsp;&nbsp;Preska&ccaron;e navodnjavanje nakon ki&scaron;e</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentacija</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Ve&cacute; ga koristite? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">ostavite ⭐</a> kako bi ga drugi lak&scaron;e prona&scaron;li.
+    </div>
 </section>
 
 <section class="features">
@@ -219,10 +240,15 @@
 
 <section class="support">
     <h2>Podr&zcaron;i Projekt</h2>
-    <p>Ako NeverDry spa&scaron;ava va&scaron; vrt i ra&ccaron;un za vodu, razmislite o donaciji:</p>
+    <p>NeverDry je besplatan i otvorenog koda — najbolji na&ccaron;in da ga podr&zcaron;ite jest da mu dodijelite zvjezdicu i pro&scaron;irite glas:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Podr&scaron;ka na Ko-fi-ju</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Ostavite zvjezdicu na GitHubu</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Poznajete nekoga s vrtom i Home Assistantom? Pro&scaron;irite glas:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Podijeli na Facebooku</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Podijeli na Redditu</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Podijeli na X-u</a>
     </div>
 </section>
 

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -18,10 +18,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -73,17 +73,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligens &ouml;nt&ouml;z&eacute;s a Home Assistant-hez. Tudom&aacute;nyos v&iacute;zm&eacute;rleg modell, amely tudja, mikor &eacute;s mennyi ideig kell &ouml;nt&ouml;zni a kertj&eacute;t.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repository</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Dokument&aacute;ci&oacute;</a>
+    <!-- Primary CTA: one-click HACS install -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Telep&iacute;t&eacute;s a Home Assistant-be</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Egy kattint&aacute;s a HACS-on kereszt&uuml;l — a NeverDry az alap&eacute;rtelmezett t&aacute;rol&oacute;ban tal&aacute;lhat&oacute;.</div>
+
+    <!-- Value props -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Csak akkor &ouml;nt&ouml;z, ha a talaj sz&aacute;raz</div>
+        <div>🛡️&nbsp;&nbsp;A szelep mindig bez&aacute;r</div>
+        <div>🌧️&nbsp;&nbsp;Es&odblac; ut&aacute;n kihagyja az &ouml;nt&ouml;z&eacute;st</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokument&aacute;ci&oacute;</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        M&aacute;r haszn&aacute;lod? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">adj egy ⭐-ot</a>, hogy m&aacute;sok is r&aacute;tal&aacute;ljanak.
+    </div>
 </section>
 
 <section class="features">
@@ -219,10 +240,15 @@
 
 <section class="support">
     <h2>T&aacute;mogasd a Projektet</h2>
-    <p>Ha a NeverDry megmenti a kertedet &eacute;s a v&iacute;zsz&aacute;ml&aacute;t, fontold meg az adom&aacute;nyt:</p>
+    <p>A NeverDry ingyenes &eacute;s ny&iacute;lt forr&aacute;s&uacute; — a legjobb t&aacute;mogat&aacute;s, ha csillagot adsz neki &eacute;s tov&aacute;bbadod a h&iacute;r&eacute;t:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ T&aacute;mogat&aacute;s Ko-fi-n</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Adj csillagot a GitHubon</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Ismersz valakit, akinek kertje &eacute;s Home Assistant-je van? Add tov&aacute;bb a h&iacute;r&eacute;t:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Megoszt&aacute;s Facebookon</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Megoszt&aacute;s Redditen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Megoszt&aacute;s X-en</a>
     </div>
 </section>
 

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -32,21 +32,21 @@
         .hero {
             background: linear-gradient(135deg, var(--accent), #2980b9);
             color: white;
-            padding: 80px 20px 60px;
+            padding: 40px 20px 36px;
             text-align: center;
         }
         .hero h1 {
-            font-size: 3em;
+            font-size: 2.5em;
             font-weight: 700;
-            margin-bottom: 0.3em;
+            margin-bottom: 0.15em;
         }
         .hero .tagline {
-            font-size: 1.3em;
+            font-size: 1.2em;
             opacity: 0.9;
             max-width: 600px;
-            margin: 0 auto 1.5em;
+            margin: 0 auto 1em;
         }
-        .hero .badges { margin: 1.5em 0; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta {
             display: inline-block;
@@ -253,19 +253,37 @@
 
 <!-- Hero -->
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Your garden tells you when it's thirsty. NeverDry listens — and makes sure the valve always closes.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">GitHub Repository</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentation</a>
-    <div style="margin-top: 1.2em; font-size: 0.95em; opacity: 0.85;">
-        If NeverDry is useful to you, <a href="https://github.com/drake69/NeverDry/stargazers" style="color: white; font-weight: 600;">leave a ⭐ on GitHub</a> — it helps others find the project.
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Install in Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">One click via HACS — NeverDry is in the default repository.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Waters only when the soil is dry</div>
+        <div>🛡️&nbsp;&nbsp;The valve always closes</div>
+        <div>🌧️&nbsp;&nbsp;Skips watering after rain</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Already using it? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">leave a ⭐</a> to help others find it.
     </div>
 </section>
 
@@ -393,7 +411,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Install directly from HACS — one click:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration" data-vmtrc="InstallClicked" data-vmtrc-location="install-section">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open your Home Assistant instance and open NeverDry in HACS." height="48">
                 </a>
             </div>
@@ -483,10 +501,15 @@
 <!-- Support -->
 <section class="support">
     <h2>Support the Project</h2>
-    <p>If NeverDry saves your garden and your water bill, consider a one-time donation:</p>
+    <p>NeverDry is free and open source — the best way to support it is to star it and spread the word:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Support on Ko-fi</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Star on GitHub</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Know someone with a garden and Home Assistant? Spread the word:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Share on Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Share on Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Share on X</a>
     </div>
 </section>
 

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -31,10 +31,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -86,17 +86,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irrigazione intelligente per Home Assistant. Un modello scientifico di bilancio idrico che decide quando e quanto irrigare in base al fabbisogno reale del giardino.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">Repository GitHub</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documentazione</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Installa in Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un solo clic tramite HACS — NeverDry &egrave; nel repository predefinito.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Irriga solo quando il suolo &egrave; asciutto</div>
+        <div>🛡️&nbsp;&nbsp;La valvola si chiude sempre</div>
+        <div>🌧️&nbsp;&nbsp;Salta l'irrigazione dopo la pioggia</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentazione</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        Lo usi gi&agrave;? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">lascia una ⭐</a> per aiutare altri a scoprirlo.
+    </div>
 </section>
 
 <section class="features">
@@ -232,10 +253,15 @@
 
 <section class="support">
     <h2>Sostieni il progetto</h2>
-    <p>Se NeverDry ti aiuta a curare il giardino e a ridurre la bolletta dell'acqua, valuta una piccola donazione.</p>
+    <p>NeverDry &egrave; gratuito e open source — il modo migliore per sostenerlo &egrave; mettere una stella e farlo conoscere:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Sostieni su Ko-fi</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Lascia una stella su GitHub</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Conosci qualcuno con un giardino e Home Assistant? Fai girare la voce:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Condividi su Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Condividi su Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Condividi su X</a>
     </div>
 </section>
 

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -26,10 +26,10 @@
         .lang-bar a { color: rgba(255,255,255,0.8); text-decoration: none; font-size: 0.85em; margin-left: 12px; padding: 2px 8px; border-radius: 4px; transition: background 0.2s; }
         .lang-bar a:hover { background: rgba(255,255,255,0.15); }
         .lang-bar a.active { background: rgba(255,255,255,0.25); color: white; font-weight: 600; }
-        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 80px 20px 60px; text-align: center; }
-        .hero h1 { font-size: 3em; font-weight: 700; margin-bottom: 0.3em; }
-        .hero .tagline { font-size: 1.3em; opacity: 0.9; max-width: 600px; margin: 0 auto 1.5em; }
-        .hero .badges { margin: 1.5em 0; }
+        .hero { background: linear-gradient(135deg, var(--accent), #2980b9); color: white; padding: 40px 20px 36px; text-align: center; }
+        .hero h1 { font-size: 2.5em; font-weight: 700; margin-bottom: 0.15em; }
+        .hero .tagline { font-size: 1.2em; opacity: 0.9; max-width: 600px; margin: 0 auto 1em; }
+        .hero .badges { margin: 0.8em 0; }
         .hero .badges img { margin: 0 4px; vertical-align: middle; }
         .hero .cta { display: inline-block; background: white; color: var(--accent); padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 1.1em; margin: 0.5em; transition: transform 0.2s; }
         .hero .cta:hover { transform: translateY(-2px); }
@@ -81,17 +81,38 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="120" height="120" style="margin-bottom: 0.3em;">
+    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irriga&ccedil;&atilde;o inteligente para Home Assistant. Um modelo cient&iacute;fico de balan&ccedil;o h&iacute;drico que sabe quando e por quanto tempo regar o seu jardim.</p>
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
-    <a class="cta" href="https://github.com/drake69/NeverDry">Reposit&oacute;rio GitHub</a>
-    <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md">Documenta&ccedil;&atilde;o</a>
+    <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+       data-vmtrc="InstallClicked" data-vmtrc-location="hero"
+       style="font-size: 1.2em; padding: 14px 40px;">Instalar no Home Assistant</a>
+    <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Um clique via HACS &mdash; o NeverDry est&aacute; no reposit&oacute;rio predefinido.</div>
+
+    <!-- Value props: 3 benefici in riga, compatti (niente card nell'hero — 2026-07-22) -->
+    <div style="margin-top: 1.3em; display: flex; flex-wrap: wrap; gap: 0.6em 1.6em; justify-content: center; font-size: 1.05em; line-height: 1.35;">
+        <div>🌡️&nbsp;&nbsp;Rega apenas quando o solo est&aacute; seco</div>
+        <div>🛡️&nbsp;&nbsp;A v&aacute;lvula fecha sempre</div>
+        <div>🌧️&nbsp;&nbsp;Salta a rega depois da chuva</div>
+    </div>
+
+    <!-- Secondary links -->
+    <div style="margin-top: 1.6em;">
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documenta&ccedil;&atilde;o</a>
+    </div>
+
+    <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
+        J&aacute; o utiliza? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deixe uma ⭐</a> para ajudar outros a encontr&aacute;-lo.
+    </div>
 </section>
 
 <section class="features">
@@ -227,10 +248,15 @@
 
 <section class="support">
     <h2>Apoie o Projeto</h2>
-    <p>Se o NeverDry salva o seu jardim e a conta de &aacute;gua, considere uma doa&ccedil;&atilde;o:</p>
+    <p>O NeverDry &eacute; gratuito e de c&oacute;digo aberto &mdash; a melhor forma de o apoiar &eacute; dar-lhe uma estrela e espalhar a palavra:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" href="https://ko-fi.com/drake69">☕ Apoiar no Ko-fi</a>
         <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deixe uma estrela no GitHub</a>
+    </div>
+    <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Conhece algu&eacute;m com um jardim e Home Assistant? Espalhe a palavra:</p>
+    <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partilhar no Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partilhar no Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partilhar no X</a>
     </div>
 </section>
 


### PR DESCRIPTION
Advocacy-focused redesign of the gh-pages landing (EN + 8 translations) and README badges.

## Hero
- Install-first: one-click HACS CTA as the primary action
- Compact layout so the key message fits above the fold (no forced scroll)
- Three value-props (waters when dry / valve always closes / skips after rain)
- Zone Card screenshot removed from the hero (no context there) — kept in its dedicated section below
- Discreet star ask targeting existing users
- Downloads badge (latest stable release); HA active-installs badge added commented-out (enable once `never_dry` is listed in HA analytics)

## Support
- Ko-fi removed (adoption/advocacy focus at this stage)
- Share buttons added (Facebook / Reddit / X)

## Tracking
- Vemetric `data-vmtrc` events on all CTAs (Install / GitHub / Docs / Star / Share)

## README
- Downloads badge added, Ko-fi removed

## Translations
- Same changes propagated to it, de, at, es, fr, pt, hr, hu (all verified: no Ko-fi, downloads badge + Share present, URLs/tracking unchanged)

Docs/marketing only — no code changes.