### PR TITLE
Fix rain miscount on accumulator sensors: credit only positive increments (#123)

### DIFF
--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -13,12 +13,12 @@ CONF_RAIN_SENSOR_TYPE = "rain_sensor_type"
 RAIN_TYPE_EVENT = "event"  # mm per event (tipping bucket pulse)
 RAIN_TYPE_DAILY_TOTAL = "daily_total"  # cumulative mm since midnight
 
-# A drop in a daily_total reading is a genuine reset (midnight rollover)
-# only when the new value is near zero. A drop that lands HIGHER than this
-# threshold is a rolling-window sensor (e.g. "24h rain") ageing out old
-# rain — crediting the residual as fresh rain wiped every deficit at 05:00
-# with clear skies (field bug, 2026-07-18).
-RAIN_RESET_MAX_MM = 1.0
+# Accumulator rain sensors (daily_total, rolling 24h, lifetime cumulative)
+# credit only positive increments between readings: a decrease is a reset,
+# a window age-out, or a glitch — never precipitation. This replaced the
+# earlier near-zero reset heuristic, which both wiped deficits at 05:00 with
+# clear skies (rolling sensor, 2026-07-18) and dropped legitimate overnight
+# rain on true daily totals (#123).
 
 # ── ET model parameters ──────────────────────────────────
 CONF_ALPHA = "alpha"

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -91,7 +91,6 @@ from .const import (
     ET_TEMP_VALID_RANGE,
     KC_ANCHOR_DAYS,
     PLANT_FAMILIES,
-    RAIN_RESET_MAX_MM,
     RAIN_TYPE_EVENT,
     SYSTEM_TYPES,
     UNUSUAL_FLOW_MAX_LPM,
@@ -697,11 +696,16 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
     def _compute_rain_delta(self) -> float:
         """Compute rain increment since last reading.
 
-        For 'event' type: the sensor value IS the delta (mm per event).
-        For 'daily_total' type: compute delta from last reading. A drop in
-        the reading is a midnight rollover (new value = fresh accumulation)
-        only when it lands near zero; a drop with a high residual is a
-        rolling-window sensor ageing out old rain and credits nothing.
+        For 'event' type: the sensor value IS the delta (mm per event), gated
+        on the sensor's last_updated timestamp so identical consecutive events
+        each count once and non-rain recomputes credit nothing.
+        For 'daily_total' (any accumulator — midnight-reset total, rolling 24h
+        window, or lifetime cumulative): credit ONLY the positive increment
+        between readings. A decrease is never precipitation — it is a reset,
+        a rolling-window age-out, or a sensor glitch — so it credits zero.
+        This single rule is correct for every accumulator without heuristics
+        and cannot resurrect old rain as phantom precipitation (field bugs
+        2026-07-18 phantom rain at 05:00 and #123 daily-total miscount).
         Converts inches to mm when the sensor reports in imperial units.
         """
         try:
@@ -734,7 +738,7 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             self._last_rain = rain_now
             return max(0.0, rain_now)
 
-        # daily_total: compute delta
+        # Accumulator: credit only the positive increment.
         if self._last_rain is None:
             # Baseline unknown (fresh boot, nothing restored): fix it from
             # the current reading without crediting — the accumulation
@@ -743,26 +747,19 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             return 0.0
         rain_delta = rain_now - self._last_rain
         if rain_delta < 0:
-            if rain_now <= RAIN_RESET_MAX_MM:
-                # Genuine reset (midnight rollover): the counter restarted
-                # near zero, so the new value is fresh accumulation.
-                rain_delta = rain_now
-            else:
-                # Rolling-window sensor (e.g. "24h rain") ageing out old
-                # rain: the residual is NOT new precipitation. Crediting it
-                # re-applied yesterday's whole rainfall as phantom rain
-                # (field bug, 2026-07-18: 13.2 mm credited at 05:00 with
-                # clear skies, every zone deficit wiped).
-                _LOGGER.debug(
-                    "Rain sensor '%s' dropped %.2f -> %.2f mm with high residual —"
-                    " rolling-window ageing, no rain credited",
-                    self._rain_sensor,
-                    self._last_rain,
-                    rain_now,
-                )
-                rain_delta = 0.0
+            # A drop is never precipitation: midnight reset, rolling-window
+            # age-out, or sensor glitch. Rebase and credit nothing — fresh
+            # rain is credited as the counter climbs again.
+            _LOGGER.debug(
+                "Rain sensor '%s' dropped %.2f -> %.2f mm — reset/age-out, no rain credited",
+                self._rain_sensor,
+                self._last_rain,
+                rain_now,
+            )
+            self._last_rain = rain_now
+            return 0.0
         self._last_rain = rain_now
-        return max(0.0, rain_delta)
+        return rain_delta
 
     def _update_from_model(self, dt_h: float) -> None:
         """Update deficit from ET model and precipitation (standalone).
@@ -898,17 +895,21 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         return deficit
 
     def _compute_backfill_rain_delta(self, rain_now: float, last_rain: float) -> float:
-        """Compute rain delta for backfill replay."""
+        """Compute rain delta for backfill replay (same rule as the live path).
+
+        Accumulators credit only the positive increment; a decrease is a
+        reset/age-out/glitch and credits nothing. Keeping this identical to
+        _compute_rain_delta means a restart mid-day replays the same balance
+        the live path produced.
+        """
         if self._rain_type == RAIN_TYPE_EVENT:
             if rain_now == last_rain:
                 return 0.0
             return max(0.0, rain_now)
 
-        # daily_total: negative delta = midnight rollover
+        # Accumulator: only positive increments are precipitation.
         rain_delta = rain_now - last_rain
-        if rain_delta < 0:
-            rain_delta = rain_now
-        return max(0.0, rain_delta)
+        return rain_delta if rain_delta > 0 else 0.0
 
     def reset(self) -> None:
         """Reset deficit to zero (called after irrigation)."""

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -198,9 +198,10 @@ class TestBackfillRainDelta:
     def test_daily_total_positive_delta(self, sensor_daily):
         assert sensor_daily._compute_backfill_rain_delta(8.0, 5.0) == 3.0
 
-    def test_daily_total_midnight_reset(self, sensor_daily):
-        # 8mm → 1mm = counter reset, delta = 1mm
-        assert sensor_daily._compute_backfill_rain_delta(1.0, 8.0) == 1.0
+    def test_daily_total_drop_credits_nothing(self, sensor_daily):
+        # 8mm → 1mm = reset/age-out: a drop is never rain, credit 0
+        # (same rule as the live path — restart replays the same balance).
+        assert sensor_daily._compute_backfill_rain_delta(1.0, 8.0) == 0.0
 
     def test_negative_rain_clamped(self, sensor_event):
         assert sensor_event._compute_backfill_rain_delta(-1.0, 0.0) == 0.0

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -417,7 +417,11 @@ class TestRainDelta:
         assert sensor._deficit == pytest.approx(5.0, abs=0.01)
 
     def test_daily_total_mode_midnight_reset(self, hass_mock, make_state):
-        """Daily total sensor resets at midnight — handle gracefully."""
+        """Daily total sensor resets at midnight — the drop credits nothing.
+
+        The day's rain was already credited as the counter climbed; the
+        reset itself is not new precipitation, so the deficit is unchanged.
+        """
         from never_dry.const import (
             CONF_RAIN_SENSOR,
             CONF_RAIN_SENSOR_TYPE,
@@ -435,7 +439,7 @@ class TestRainDelta:
         sensor._deficit = 10.0
         sensor._last_rain = 8.0  # accumulated 8mm yesterday
 
-        # Midnight reset: sensor drops to 1.0 (new day, 1mm rain)
+        # Midnight reset: sensor drops to 1.0 (new day)
         hass_mock.states.get.side_effect = lambda eid: {
             "sensor.temperature": make_state(9.0),
             "sensor.rain": make_state(1.0),
@@ -443,8 +447,9 @@ class TestRainDelta:
         sensor._last_update = datetime.now() - timedelta(seconds=1)
         sensor._on_sensor_change(MagicMock())
 
-        # Should treat 1.0 as new rain (not -7.0 delta)
-        assert sensor._deficit == pytest.approx(9.0, abs=0.01)
+        # A drop is never rain: deficit unchanged, baseline rebased to 1.0.
+        assert sensor._deficit == pytest.approx(10.0, abs=0.01)
+        assert sensor._last_rain == pytest.approx(1.0)
 
     def test_rain_zeroes_deficit(self, di_sensor, hass_mock, make_state):
         """Heavy rain should zero out the deficit (never goes negative)."""
@@ -667,8 +672,8 @@ class TestRollingWindowRainSensor:
     Field bug 2026-07-18: at 05:00 with clear skies the sensor dropped
     14.2 → 13.2 mm as yesterday's rain left the 24h window. The drop was
     read as a midnight rollover and the whole residual (13.2 mm) was
-    credited as fresh rain, wiping every zone deficit. A drop is a genuine
-    reset only when the new reading lands near zero (RAIN_RESET_MAX_MM).
+    credited as fresh rain, wiping every zone deficit. The intake now
+    credits only positive increments, so any drop credits nothing.
     """
 
     def _daily_sensor(self, hass_mock):
@@ -732,16 +737,20 @@ class TestRollingWindowRainSensor:
         assert sensor._deficit == pytest.approx(20.0, abs=0.01)
         assert sensor._last_rain == pytest.approx(0.0)
 
-    def test_midnight_reset_still_credits_new_accumulation(self, hass_mock, make_state):
-        """A true midnight rollover (drop to near zero) still credits the
-        fresh accumulation: 8.0 → 0.5 credits 0.5 mm."""
+    def test_midnight_reset_credits_increments_not_the_drop(self, hass_mock, make_state):
+        """A midnight rollover credits nothing on the drop, then credits the
+        fresh accumulation as the counter climbs: 8.0 → 0.5 (0 mm), 0.5 → 3.0
+        (2.5 mm). This is exactly the true daily-total case from #123: rain
+        that falls after the reset is credited via the positive increment."""
         sensor = self._daily_sensor(hass_mock)
         sensor._deficit = 10.0
         sensor._last_rain = 8.0
 
         self._tick(sensor, hass_mock, make_state, 0.5)
+        assert sensor._deficit == pytest.approx(10.0, abs=0.01)  # drop credits 0
 
-        assert sensor._deficit == pytest.approx(9.5, abs=0.01)
+        self._tick(sensor, hass_mock, make_state, 3.0)
+        assert sensor._deficit == pytest.approx(7.5, abs=0.01)  # +2.5 mm
 
     def test_rain_after_window_ageing_credited_normally(self, hass_mock, make_state):
         """New rain arriving after an ageing drop is credited from the


### PR DESCRIPTION
## Problem

Accumulator rain sensors (`daily_total`, rolling 24h, lifetime cumulative) guessed, on every drop in the reading, whether it was a midnight reset (credit the new value when below `RAIN_RESET_MAX_MM = 1.0`) or a rolling-window age-out (credit nothing). The heuristic failed both ways:

- **Rolling sensors** mislabeled as `daily_total` credited yesterday's residual as phantom rain, wiping deficits at 05:00 with clear skies (field bug 2026-07-18).
- **True daily totals** lost legitimate post-reset rain whenever the first reading after midnight already exceeded 1 mm — this is #123 (Claudia's Ecowitt WH2650A `Daily Rain`, a correctly-configured `total_increasing`/`mm`/`precipitation` daily total).

There was also a live-vs-backfill inconsistency: the restart backfill credited the full new value on any drop (no guard), so a mid-day restart replayed a different water balance than the live path.

## Fix

One rule for every accumulator: **credit only the positive increment** between readings. A decrease is never precipitation (reset, window age-out, or glitch), so it credits zero and rebases the baseline. Fresh rain after a reset is credited as the counter climbs again. The identical rule is applied to the backfill path. `RAIN_RESET_MAX_MM` is removed. The `event` pulse path is unchanged.

This is correct for true daily totals, rolling-24h sensors, and lifetime cumulative counters alike, with no threshold left to misfire.

## Installed base

No reconfiguration required: this is a silent, self-healing migration for all accumulator sensors. Stored deficit is restored and the rain baseline is re-fixed without crediting, so there is no discontinuity on update.

## Tests

Updated to the new semantics (a drop credits nothing; post-reset increments are credited) with an explicit #123 regression. Full suite: 753 passed; ruff format + check clean.