### PR TITLE
Water-balance model: per-zone deficit, scheduled top-up, yearly rain, card fixes (#123)

### DIFF
--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -245,11 +245,35 @@ async def _async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> 
     await er.async_migrate_entries(hass, entry.entry_id, _migrate)
 
 
+@callback
+def _async_remove_legacy_rain_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove the pre-rework per-zone rain entities.
+
+    The per-zone rain sensor moved from lifetime millimetres (device_class
+    precipitation) to yearly litres (device_class water) and got a new
+    unique_id (``rain_zone_`` -> ``rain_yearly_zone_``). Deleting the old
+    entity here means the user never sees an ``unavailable`` orphan, and the
+    new entity starts with no statistics so Home Assistant's "unit of
+    measurement changed" repair never fires. The old lifetime-mm history
+    (a field install read 6418 mm) is intentionally discarded.
+    """
+    registry = er.async_get(hass)
+    for reg_entry in list(er.async_entries_for_config_entry(registry, entry.entry_id)):
+        uid = reg_entry.unique_id or ""
+        if "rain_zone_" in uid and "rain_yearly_zone_" not in uid:
+            registry.async_remove(reg_entry.entity_id)
+            _LOGGER.info(
+                "Removed legacy rain entity %s (replaced by Rain Yearly)",
+                reg_entry.entity_id,
+            )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NeverDry from a config entry (UI)."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
     await _async_migrate_unique_ids(hass, entry)
+    _async_remove_legacy_rain_entities(hass, entry)
     handler = await hass.async_add_executor_job(_setup_file_logger, hass)
     hass.data[DOMAIN][f"_log_handler_{entry.entry_id}"] = handler
     await _async_register_frontend(hass)

--- a/custom_components/never_dry/__init__.py
+++ b/custom_components/never_dry/__init__.py
@@ -273,9 +273,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
     await _async_migrate_unique_ids(hass, entry)
-    _async_remove_legacy_rain_entities(hass, entry)
     handler = await hass.async_add_executor_job(_setup_file_logger, hass)
     hass.data[DOMAIN][f"_log_handler_{entry.entry_id}"] = handler
+    # After the file logger is attached, so the removals are visible in the
+    # NeverDry activity log; still before platforms create the new entities.
+    _async_remove_legacy_rain_entities(hass, entry)
     await _async_register_frontend(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -1143,6 +1143,10 @@ class IrrigationController:
             return
         delivered_mm = delivered_liters * zone._efficiency / zone._area
         zone._zone_deficit = max(0.0, snapshot - delivered_mm)
+        # Session water must rise live during a flow-metered cycle, not only at
+        # completion — otherwise the card shows Volume/Duration counting down
+        # while Session water stays 0 (field report, flow_meter zone).
+        zone._session_water_delivered = round(delivered_liters, 1)
         zone.async_write_ha_state()
         zone.notify_session_listeners()
 

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -233,29 +233,32 @@ class IrrigationController:
     # ── Scheduled irrigation ────────────────────────────────
 
     def _make_scheduled_handler(self, zone_name: str):
-        """Create a time-triggered handler for a specific zone."""
+        """Create a time-triggered handler for a specific zone.
+
+        Scheduled mode irrigates **at the scheduled hour regardless of the
+        threshold** — that is the whole point of a schedule. The dose is
+        whatever deficit has accumulated (``_irrigate_zones`` sizes the volume
+        from the zone deficit), so the zone is topped back up even when the
+        deficit is below the reactive threshold. The only skip is a zone with
+        nothing to refill (deficit <= 0). The threshold stays a *reactive*-mode
+        concept. See AI-183.
+        """
 
         @callback
         def _handler(now) -> None:
             zone = self._zones.get(zone_name)
             if zone is None:
                 return
-            threshold = zone.extra_state_attributes.get(
-                "threshold_mm",
-                DEFAULT_THRESHOLD,
-            )
             _LOGGER.info(
-                "Scheduled check fired: zone='%s', deficit=%.1fmm, threshold=%.1fmm",
+                "Scheduled check fired: zone='%s', deficit=%.1fmm",
                 zone_name,
                 zone._zone_deficit,
-                threshold,
             )
-            if zone._zone_deficit < threshold:
+            if zone._zone_deficit <= 0:
                 _LOGGER.info(
-                    "Scheduled check: zone='%s' deficit=%.1fmm < threshold=%.1fmm — no irrigation needed",
+                    "Scheduled check: zone='%s' deficit=%.1fmm — nothing to refill, skipping",
                     zone_name,
                     zone._zone_deficit,
-                    threshold,
                 )
                 return
             if self._running:
@@ -265,10 +268,9 @@ class IrrigationController:
                 )
                 return
             _LOGGER.info(
-                "Scheduled irrigation triggered: zone='%s', deficit=%.1fmm, threshold=%.1fmm",
+                "Scheduled irrigation triggered: zone='%s', deficit=%.1fmm (topping up regardless of threshold)",
                 zone_name,
                 zone._zone_deficit,
-                threshold,
             )
             self._current_source = "scheduled"
             self._irrigation_task = self._hass.async_create_task(

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -571,6 +571,12 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         self._last_rain_event_ts = None
         self._last_update = datetime.now()
         self._zone_listeners: list[Callable] = []
+        # Rain that fell this calendar year [mm] — a SYSTEM quantity (one sky
+        # over the whole garden), so every zone mirrors the same "Rain Yearly"
+        # value instead of keeping its own drifting per-zone counter. Resets on
+        # 1 Jan. See docs/design_water_balance_reference_model.md (D3).
+        self._yearly_rain: float = 0.0
+        self._yearly_rain_year: int = datetime.now().year
         self._temp_buffer = SensorBuffer(ET_BUFFER_SIZE, valid_range=ET_TEMP_VALID_RANGE)
         if device_info:
             self._attr_device_info = device_info
@@ -585,9 +591,25 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         return self._deficit
 
     @property
+    def yearly_rain(self) -> float:
+        """Rain that fell this calendar year [mm] — shared by all zones."""
+        return self._yearly_rain
+
+    def _accrue_yearly_rain(self, rain_mm: float) -> None:
+        """Add credited rain to the yearly total, resetting on a new year."""
+        year = datetime.now().year
+        if year != self._yearly_rain_year:
+            self._yearly_rain = 0.0
+            self._yearly_rain_year = year
+        self._yearly_rain += rain_mm
+
+    @property
     def extra_state_attributes(self) -> dict:
         """Expose the rain baseline so it survives restarts via restore_state."""
-        attrs: dict = {}
+        attrs: dict = {
+            "yearly_rain_mm": round(self._yearly_rain, 2),
+            "yearly_rain_year": self._yearly_rain_year,
+        }
         if self._last_rain is not None:
             attrs["rain_baseline_mm"] = round(self._last_rain, 2)
             # The baseline is only meaningful against the sensor that
@@ -627,6 +649,14 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
                         baseline_entity,
                         self._rain_sensor,
                     )
+            # Restore the yearly rain total; reset it if the calendar year
+            # rolled over while HA was down.
+            with contextlib.suppress(ValueError, TypeError):
+                self._yearly_rain_year = int(last.attributes.get("yearly_rain_year", self._yearly_rain_year))
+                self._yearly_rain = float(last.attributes.get("yearly_rain_mm", 0.0))
+                if datetime.now().year != self._yearly_rain_year:
+                    self._yearly_rain = 0.0
+                    self._yearly_rain_year = datetime.now().year
 
         if not restored:
             if self._vwc_sensor:
@@ -656,6 +686,8 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             self._broadcast_to_zones(0.0, 0.0, 0.0)
         else:
             rain_delta = self._compute_rain_delta()
+            if rain_delta > 0:
+                self._accrue_yearly_rain(rain_delta)
 
             # Push temp into the buffer (converted to °C if sensor reports °F);
             # invalid/unavailable readings are rejected, median stays stable.
@@ -996,7 +1028,6 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         # idempotent and the end-of-cycle settle never double-counts.
         # ``None`` outside an active cycle.
         self._deficit_at_irrigation_start: float | None = None
-        self._total_rain: float = 0.0
         self._total_water_delivered: float = 0.0
         self._yearly_water_delivered: float = 0.0
         self._yearly_water_year: int = datetime.now().year
@@ -1046,8 +1077,6 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                     self._last_irrigation_source = last.attributes.get("last_irrigation_source")
                     self._last_session_duration_s = int(last.attributes.get("last_session_duration_s", 0))
             with contextlib.suppress(ValueError, TypeError):
-                self._total_rain = float(last.attributes.get("total_rain_mm", 0.0))
-            with contextlib.suppress(ValueError, TypeError):
                 self._total_water_delivered = float(last.attributes.get("total_water_delivered_l", 0.0))
             with contextlib.suppress(ValueError, TypeError):
                 self._yearly_water_delivered = float(last.attributes.get("yearly_water_delivered_l", 0.0))
@@ -1058,9 +1087,18 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                     self._yearly_water_delivered = 0.0
                     self._yearly_water_year = datetime.now().year
         else:
-            # New zone: seed deficit from global Dryness Index * Kc
-            kc = self._get_current_kc()
-            self._zone_deficit = self._dryness.deficit * kc
+            # New zone (no restored state): start at zero rather than
+            # inheriting the global reference deficit. The global is an ET
+            # accumulator that only resets when ALL zones are irrigated
+            # together (controller), so under per-zone irrigation it drifts
+            # high and would hand a brand-new zone a spurious "irrigation
+            # due" (#123, Rasen 2.1 read 11 mm while its identical sibling
+            # was at 0). Starting at 0 accepts a small first-cycle bias — a
+            # fresh zone may under-read the real deficit until ET accumulates
+            # — which self-corrects on the first irrigation. Frame-agnostic:
+            # no dependency on the reference deficit or sibling state.
+            # See docs/design_water_balance_reference_model.md (D4).
+            self._zone_deficit = 0.0
 
     def _get_latitude(self) -> float:
         """Get latitude from HA config, default to 45.0 (northern)."""
@@ -1082,8 +1120,6 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             self._zone_deficit = self._dryness.deficit * kc
         else:
             kc = self._get_current_kc()
-            if rain > 0:
-                self._total_rain += rain
             self._zone_deficit = max(
                 0.0,
                 min(self._zone_deficit + et_h * kc * dt_h - rain, self._d_max),
@@ -1295,7 +1331,6 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             "deficit_mm": round(self._zone_deficit, 2),
             "irrigating": self._irrigating,
         }
-        attrs["total_rain_mm"] = round(self._total_rain, 2)
         attrs["total_water_delivered_l"] = round(self._total_water_delivered, 1)
         attrs["yearly_water_delivered_l"] = round(self._yearly_water_delivered, 1)
         attrs["yearly_water_year"] = self._yearly_water_year
@@ -1378,12 +1413,18 @@ class ZoneDeficitSensor(SensorEntity):
 
 
 class ZoneRainSensor(SensorEntity):
-    """Cumulative rain received by this zone [mm]."""
+    """Rain this zone received this calendar year [L].
+
+    Rain is a system quantity — the same mm of sky over the whole garden — but
+    shown per zone in LITERS via the zone area (mm x m2 = L), so the number is
+    informative for THIS zone instead of an identical mm repeated on every
+    card. Resets on 1 Jan. Source: the hub's yearly rain [mm].
+    """
 
     _attr_has_entity_name = True
-    _attr_device_class = SensorDeviceClass.PRECIPITATION
-    _attr_name = "Rain"
-    _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_name = "Rain Yearly"
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:weather-rainy"
 
@@ -1406,7 +1447,8 @@ class ZoneRainSensor(SensorEntity):
 
     @property
     def native_value(self) -> float:
-        return round(self._zone_sensor._total_rain, 2)
+        # mm x m2 = liters this zone caught from the shared yearly rain.
+        return round(self._zone_sensor._dryness.yearly_rain * self._zone_sensor._area, 1)
 
 
 # ══════════════════════════════════════════════════════════
@@ -1455,9 +1497,11 @@ class ZoneSessionWaterSensor(SensorEntity):
 
 
 class ZoneYearlyWaterSensor(SensorEntity):
-    """Water delivered by irrigation this year [L].
+    """Total water this zone received this year [L] = rain + irrigation.
 
-    Resets automatically on January 1st.
+    The rain contribution is the shared yearly rain scaled by the zone area
+    (mm x m2 = L); the irrigation contribution is the liters this zone
+    delivered. Resets automatically on January 1st.
     """
 
     _attr_has_entity_name = True
@@ -1466,7 +1510,7 @@ class ZoneYearlyWaterSensor(SensorEntity):
     # this is a cumulative consumption total (GH #105). WATER also makes
     # the sensor usable in the HA Energy dashboard water tracking.
     _attr_device_class = SensorDeviceClass.WATER
-    _attr_name = "Yearly water"
+    _attr_name = "Water Yearly"
     _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:calendar-clock"
@@ -1490,7 +1534,8 @@ class ZoneYearlyWaterSensor(SensorEntity):
 
     @property
     def native_value(self) -> float:
-        return round(self._zone_sensor._yearly_water_delivered, 1)
+        rain_liters = self._zone_sensor._dryness.yearly_rain * self._zone_sensor._area
+        return round(rain_liters + self._zone_sensor._yearly_water_delivered, 1)
 
 
 # ══════════════════════════════════════════════════════════

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -1435,7 +1435,13 @@ class ZoneRainSensor(SensorEntity):
     ) -> None:
         self._zone_sensor = zone_sensor
         slug = zone_sensor.zone_name.lower().replace(" ", "_")
-        self._attr_unique_id = f"rain_zone_{slug}"
+        # unique_id deliberately changed from the old "rain_zone_" when the
+        # sensor switched from lifetime mm (device_class precipitation) to
+        # per-zone yearly liters (device_class water): a fresh id makes HA
+        # create a new entity with no prior statistics, sidestepping the
+        # "unit of measurement changed" repair. The old rain_zone_ entity
+        # orphans (its broken lifetime mm history is discarded).
+        self._attr_unique_id = f"rain_yearly_zone_{slug}"
         if device_info:
             self._attr_device_info = device_info
         zone_sensor._dryness.register_zone_listener(self._on_update)

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -1503,11 +1503,12 @@ class ZoneSessionWaterSensor(SensorEntity):
 
 
 class ZoneYearlyWaterSensor(SensorEntity):
-    """Total water this zone received this year [L] = rain + irrigation.
+    """Water this zone received from irrigation this year [L].
 
-    The rain contribution is the shared yearly rain scaled by the zone area
-    (mm x m2 = L); the irrigation contribution is the liters this zone
-    delivered. Resets automatically on January 1st.
+    Irrigation only — the water you delivered, which is the meaningful
+    *consumption* figure (device_class WATER feeds the HA Energy dashboard;
+    mixing in rain, which you did not consume, would inflate it). Rain is
+    reported separately by Rain Yearly. Resets automatically on January 1st.
     """
 
     _attr_has_entity_name = True
@@ -1516,7 +1517,7 @@ class ZoneYearlyWaterSensor(SensorEntity):
     # this is a cumulative consumption total (GH #105). WATER also makes
     # the sensor usable in the HA Energy dashboard water tracking.
     _attr_device_class = SensorDeviceClass.WATER
-    _attr_name = "Water Yearly"
+    _attr_name = "Irrigated Yearly"
     _attr_native_unit_of_measurement = UnitOfVolume.LITERS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_icon = "mdi:calendar-clock"
@@ -1540,8 +1541,10 @@ class ZoneYearlyWaterSensor(SensorEntity):
 
     @property
     def native_value(self) -> float:
-        rain_liters = self._zone_sensor._dryness.yearly_rain * self._zone_sensor._area
-        return round(rain_liters + self._zone_sensor._yearly_water_delivered, 1)
+        # Irrigation water delivered by this zone only — rain is deliberately
+        # NOT included (that is Rain Yearly). Keeping this a pure consumption
+        # figure is what makes the WATER device_class / Energy dashboard correct.
+        return round(self._zone_sensor._yearly_water_delivered, 1)
 
 
 # ══════════════════════════════════════════════════════════

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -1649,6 +1649,11 @@ class _ZoneTextSensor(SensorEntity):
 class ZoneLastIrrigatedSensor(_ZoneTextSensor):
     """When the zone was last irrigated."""
 
+    # A TIMESTAMP sensor is rendered by Home Assistant in the viewer's locale
+    # (relative "2 hours ago" / localized date-time) instead of the raw ISO
+    # string a plain text sensor produced (AI-104).
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(
             zone_sensor,
@@ -1659,9 +1664,11 @@ class ZoneLastIrrigatedSensor(_ZoneTextSensor):
         )
 
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> datetime | None:
         ts = self._zone_sensor._last_irrigated
-        return ts.isoformat() if ts else None
+        # A TIMESTAMP sensor must return a timezone-aware datetime; the stored
+        # value is naive local time, so attach the local zone.
+        return ts.astimezone() if ts else None
 
 
 class ZoneLastSourceSensor(_ZoneTextSensor):

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -118,7 +118,7 @@ function valveMeta(state) {
 const ROLE_SUFFIX = {
   volume: "_volume",
   deficit: "_deficit",
-  rain: "_rain",
+  rain: "_rain_yearly",
   threshold: "_threshold",
   sessionWater: "_session_water",
   yearlyWater: "_yearly_water",
@@ -146,7 +146,7 @@ const ROLE_SUFFIX = {
 const UID_PREFIX = {
   volume: "irrigation_zone_",
   deficit: "deficit_zone_",
-  rain: "rain_zone_",
+  rain: "rain_yearly_zone_",
   threshold: "threshold_zone_",
   sessionWater: "session_water_zone_",
   yearlyWater: "yearly_water_zone_",

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -438,12 +438,22 @@ class NeverDryZoneCard extends HTMLElement {
       ["mdi:cup-water", ents.volume, "Volume"],
       ["mdi:timer-sand", ents.duration, "Duration", "duration"],
     ]);
-    this._fillSection("last", t(hass, "secLast"), [
+    const _carrier = ents.deficit || ents.volume;
+    const _irrigating = !!(_carrier && _carrier.attributes && _carrier.attributes.irrigating === true);
+    const lastRows = [
       ["mdi:clock-outline", ents.lastIrrigated, "Last irrigated"],
       ["mdi:history", ents.lastDuration, "Last duration", "duration"],
       ["mdi:water-outline", ents.lastVolume, "Last volume"],
-      ["mdi:water", ents.sessionWater, "Session water"],
-    ]);
+    ];
+    // Session water is a LIVE progress indicator: when idle it is 0 (not
+    // persisted across restarts) or just duplicates Last volume, so show it
+    // only while the zone is actively irrigating. It becomes meaningful in
+    // every delivery mode once the driver abstraction reports a real-time
+    // delivered volume — measured or calculated (AI-128 / AI-186).
+    if (_irrigating) {
+      lastRows.push(["mdi:water", ents.sessionWater, "Session water"]);
+    }
+    this._fillSection("last", t(hass, "secLast"), lastRows);
     this._fillSection("totals", t(hass, "secTotals"), [
       ["mdi:water-plus", ents.yearlyWater, "Yearly water"],
       ["mdi:weather-rainy", ents.rain, "Rain"],

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -436,11 +436,11 @@ class NeverDryZoneCard extends HTMLElement {
     // Current state (deficit) lives in the bar above; here we group by horizon.
     this._fillSection("next", t(hass, "secNext"), [
       ["mdi:cup-water", ents.volume, "Volume"],
-      ["mdi:timer-sand", ents.duration, "Duration"],
+      ["mdi:timer-sand", ents.duration, "Duration", "duration"],
     ]);
     this._fillSection("last", t(hass, "secLast"), [
       ["mdi:clock-outline", ents.lastIrrigated, "Last irrigated"],
-      ["mdi:history", ents.lastDuration, "Last duration"],
+      ["mdi:history", ents.lastDuration, "Last duration", "duration"],
       ["mdi:water-outline", ents.lastVolume, "Last volume"],
       ["mdi:water", ents.sessionWater, "Session water"],
     ]);
@@ -511,8 +511,8 @@ class NeverDryZoneCard extends HTMLElement {
 
   _rows(items) {
     return items
-      .map(([icon, st, fallback]) => {
-        const v = fmtState(this._hass, st);
+      .map(([icon, st, fallback, fmt]) => {
+        const v = fmt === "duration" ? fmtDuration(this._hass, st) : fmtState(this._hass, st);
         if (v === null) return "";
         const label = this._label(st, fallback);
         return `
@@ -552,6 +552,20 @@ function fmtState(hass, st) {
   }
   const unit = st.attributes && st.attributes.unit_of_measurement;
   return unit ? `${st.state} ${unit}` : st.state;
+}
+
+// Format a DURATION sensor (native unit: seconds) as mm:ss, or h:mm:ss past
+// one hour — so a duration reads "17:53" instead of "1.073 s" with no mental
+// conversion. Falls back to fmtState for non-numeric / unavailable states.
+function fmtDuration(hass, st) {
+  const n = numState(st);
+  if (n === null) return fmtState(hass, st);
+  const total = Math.max(0, Math.round(n));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (x) => String(x).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
 }
 
 function escapeHtml(s) {

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -1,8 +1,8 @@
 # Design — Domain Object Model
 
 **Status:** Draft
-**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74)
-**Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump)
+**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model)
+**Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump), [Water-Balance Reference Model](design_water_balance_reference_model.md) (where the deficit lives)
 
 ## Purpose
 
@@ -16,8 +16,8 @@ as the codebase evolves. For the current module/data-flow architecture see
 
 | Object | Responsibility | Key attributes |
 |---|---|---|
-| **System** | Global model and shared infrastructure | α (ET sensitivity), D_max, global sensors (temperature, rain), *declares* the master valve/pump |
-| **Zone** | Irrigation unit; translates the model into water demand | Kc / plant family, area, sun exposure; cycle & soak rule; translates mm → liters |
+| **System** | Shared **feeds** and global model params | α (ET sensitivity), D_max, the temperature + rain sensors it broadcasts to zones; *declares* the master valve/pump. **The deficit is not held here — it lives per-zone** (see Water-Balance Reference Model) |
+| **Zone** | Irrigation unit; owns its deficit and translates it into water demand | Kc / plant family, area, sun exposure; cycle & soak rule; **its own deficit** (`+ET·Kc·Δt − rain − irrigation`, new zone starts at 0); translates mm → liters |
 | **Scheduler** | The *when* — and the concurrency policy | Time windows, sequences, calendars; serial vs parallel zone runs, interleaving during soak |
 | **ZoneDriver** | The *how* — actuation of one zone's water demand | Entity adapter (`valve.*`/`switch.*`), delivery mode (native volume in liters vs time in seconds via flow rate), flow rate, zero-flow guard; returns a **DeliveryResult** |
 | **MasterDriver** | Coordination of shared hydraulics (pump / master valve) | ON when any ZoneDriver is active, OFF when none; configurable off-delay; no notion of liters |
@@ -29,9 +29,10 @@ latency/timeout, and the safety layers (watchdog, close on error/stop/restart).
 ## Translation chain
 
 ```
-System     computes the deficit (mm)            α, D_max, FAO-56 water balance
+System     provides the ET + rain feeds         α, D_max, temperature + rain sensors
    │
-Zone       translates mm → liters (via area)    applies cycle & soak
+Zone       accumulates its own deficit (mm)      +ET·Kc·Δt − rain − irrigation; new zone starts at 0
+   │        then translates mm → liters (area)   applies cycle & soak
    │
 ZoneDriver translates liters → actuation        native volume if supported,
    │                                            else seconds via flow rate
@@ -57,7 +58,7 @@ classDiagram
         +d_max : mm
         +temperature_sensor
         +rain_sensor
-        +compute_deficit() mm
+        +broadcast(et_h, rain)
     }
 
     class Zone {
@@ -66,7 +67,8 @@ classDiagram
         +sun_exposure
         +threshold_mm
         +cycle_soak_rule
-        +deficit_mm
+        +deficit_mm : own state, starts at 0
+        +accumulate(et_h, kc, rain)
         +water_demand() liters
         +settle(result : DeliveryResult)
     }
@@ -112,7 +114,7 @@ classDiagram
 
     Driver <|-- ZoneDriver
     Driver <|-- MasterDriver
-    System "1" o-- "*" Zone : owns model for
+    System "1" o-- "*" Zone : feeds ET+rain to
     System "1" o-- "0..1" MasterDriver : declares
     Zone "1" --> "1" ZoneDriver : requests liters
     ZoneDriver ..> DeliveryResult : returns
@@ -128,6 +130,19 @@ a `DeliveryResult`; the `Scheduler` never touches drivers — it only decides *w
 `ping()` lives in the abstract `Driver`, so both specializations inherit it.
 
 ## Design decisions
+
+### The deficit lives in the Zone; the System holds feeds, not state
+
+The System is not a global deficit. It owns the two shared **feeds** — the
+temperature sensor (→ ET) and the rain sensor — and broadcasts them; each Zone
+accumulates **its own** deficit (`+ET·Kc·Δt − rain − irrigation`). Irrigating a
+zone resets only that zone. A new zone starts at 0 rather than inheriting a
+global reference, which drifts high under per-zone irrigation. The old global
+"Dryness Index" accumulator is retired as ET state (kept only as an interim
+system-level value for the single-probe VWC mode). The full rationale, reference
+frames, and the retire/keep table are in the
+[Water-Balance Reference Model](design_water_balance_reference_model.md)
+(decisions D1–D5).
 
 ### Master valve/pump: declared in System, executed by a Driver
 
@@ -218,8 +233,8 @@ about a dead valve *before* the next scheduled run, not from a failed one.
 
 | Object | Current state |
 |---|---|
-| System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` |
-| Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). Cycle & soak: not implemented |
+| System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` — now the **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones). Its `_deficit` accumulator is being **retired as ET state** and survives only as the interim VWC-system value (Water-Balance Reference Model, D2/D5) |
+| Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). `_zone_deficit` is **authoritative**; a new zone **starts at 0** (D4), not seeded from the global. Cycle & soak: not implemented |
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
 | ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet |
 | MasterDriver | ❌ not implemented (GH #95) |

--- a/docs/design_water_balance_reference_model.md
+++ b/docs/design_water_balance_reference_model.md
@@ -1,0 +1,152 @@
+# Design — Water-Balance Reference Model
+
+**Status:** Draft (RFC)
+**Last updated:** 2026-07-23
+**Related:** #123, [Domain Object Model](design_domain_object_model.md), backlog AI-189 (bug), AI-174 (per-zone VWC RFC)
+
+## Why this document exists
+
+Discussions about the deficit / Dryness Index kept going in circles because one
+question was never written down: **what is a deficit *relative to*?** Once the
+reference frame is explicit, the bugs (#123 Rasen 2.1) and the fixes fall out
+mechanically. This document fixes the model's reference semantics and the
+strategic decisions that follow.
+
+## The quantity
+
+A **deficit** (mm) is the water a patch of soil needs to return to field
+capacity. It is a *water-balance state*: it grows with evapotranspiration
+demand, shrinks with rain and irrigation.
+
+The single question that governs everything: **relative to which measurement is
+a given deficit defined?**
+
+## Reference frames
+
+| Mode | Deficit relative to | Shared across zones? |
+|---|---|---|
+| **ET** | the system **temperature** sensor (ET input) + the system **rain** sensor | **Yes** — all zones read the same two sensors; they differ only by Kc (an ET multiplier) and irrigation history |
+| **VWC, system probe** (today) | one **system moisture** sensor | Yes — all zones scale the same current reading by Kc |
+| **VWC, per-zone probe** (target, AI-174) | **that zone's own moisture** sensor | **No** — each zone measures a different patch of soil |
+
+The load-bearing consequence: **two deficits are comparable only if they share a
+reference frame.** ET-mode siblings are comparable (shared weather). Two zones
+each measuring their own soil probe are **not**.
+
+## Ownership: what lives at the system level vs in the zone
+
+| Element | Level | Notes |
+|---|---|---|
+| **Temperature** (→ ET) | **System feed** | one sensor for all zones |
+| **Rain** (→ `rain_delta`) | **System feed** | one sensor for all zones, applied to every zone's balance |
+| **Deficit** (`+ ET·Kc·Δt − rain − irrigation`) | **Zone** | authoritative state |
+| **Kc, threshold, area, valve, irrigation state** | **Zone** | — |
+| **VWC sensor + `field_capacity` + `root_depth`** | **System (interim)** | until AI-174 → then per-zone |
+
+So the only permanent system-level things are the two environmental **feeds**
+(temperature, rain). Everything else lives in the zone. The VWC model
+(`vwc_sensor`, `field_capacity`, `root_depth`) is system-level only until the
+per-zone VWC work (AI-174) lands, after which nothing but the feeds remains
+shared.
+
+## Decisions
+
+### D1 — The deficit is authoritative **per zone**
+Each zone owns its deficit (`IrrigationZoneSensor._zone_deficit`). It is:
+`D_zone += ET_h · Kc_zone · Δt − rain`, clamped `[0, d_max]`, reset to 0 when
+**that** zone is irrigated. This already exists and is correct.
+
+### D2 — The global Dryness Index is **retired as ET state**
+`DrynessIndexSensor._deficit` (a parallel `Kc=1.0` accumulator) is **not** an
+authoritative state in ET mode. It only ever reset when *all* zones were
+irrigated together (`controller.py:721-724`), so under per-zone/manual
+irrigation it drifted upward and had no physical correspondence to any zone.
+
+- `DrynessIndexSensor` is **kept** — but only in its real role: the **input hub
+  / broadcaster** (owns the temperature and rain sensors, computes `et_h` and
+  `rain_delta`, broadcasts `(dt_h, et_h, rain)` to zones). This needs no stored
+  deficit.
+- The **"Dryness Index" entity**, if retained, becomes a **derived display**
+  (e.g. max/mean of zone deficits) — never a source of state. It may also be
+  dropped.
+
+### D3 — Rain is a **shared system input**; per-zone displays are projections in liters
+One rain sensor -> one `rain_delta` -> applied to every zone's balance. Rain
+falls on the whole garden, so the accumulated rain is a **system** quantity:
+`DrynessIndexSensor._yearly_rain` [mm], resets on 1 Jan.
+
+The zone display sensors are **projections** of that shared value into liters,
+so each zone reports something informative for *itself* rather than an identical
+mm repeated on every card:
+
+- **Rain Yearly [L]** (per zone) = `yearly_rain_mm x area_m2` — the liters this
+  zone caught from the shared rain. Same mm, different liters by area.
+- **Water Yearly [L]** (per zone) = `Rain Yearly + irrigation delivered` — the
+  total water the zone received this year (rain + irrigation).
+
+The old per-zone `_total_rain` lifetime accumulator is removed: it drifted
+between zones by creation time and inflated on intake bugs (a field install read
+6418 mm). **First-year caveat:** `_yearly_rain` starts fresh at 0 on the upgrade,
+so until the next 1 Jan the rain part covers only "since upgrade" while the
+irrigation part is the full restored year — a running total from now on that
+self-normalizes at the year boundary.
+
+### D4 — A new zone starts at **zero** (accepted first-cycle bias) — *Decided 2026-07-23*
+When a zone is created with no restored state, its deficit starts at **0** — not
+inherited from the retired global reference, and not seeded from siblings.
+
+**Rationale.** The only requirement is to avoid the spurious "irrigation due" a
+new zone inherited from the inflated global (#123: Rasen 2.1 read 11 mm while its
+identical sibling sat at 0). A zero start achieves that with zero machinery. It
+carries a small, **explicitly accepted** bias: a fresh zone may under-read the
+true deficit until ET accumulates — which is *safe* (under- not over-watering)
+and **self-correcting**, because the first irrigation resets the zone to 0 and
+the normal per-zone balance takes over. A user can hand-irrigate a brand-new
+zone once if they want it primed immediately.
+
+**Rejected alternative — seed from siblings (overkill).** It would need a sibling
+registry, a Kc-normalized median, and is only valid *within one reference frame*:
+ET siblings are comparable because they share the temperature and rain sensors,
+but two zones each on their own VWC probe are not (see Reference frames). A zero
+start is frame-agnostic and needs none of this.
+
+**Manual alignment escape hatch.** If a user *wants* every zone to share the
+same deficit, they already have the tool: **"Mark irrigated"** per zone resets
+that zone's deficit to 0 without opening the valve (`reset_deficit`). Clicking it
+on each zone aligns them all to 0 on demand — so no automatic seeding is needed
+even for users who care about a uniform starting point.
+
+`total_rain` likewise starts at 0 for a new zone: it is a per-zone lifetime
+counter ("rain received since this zone existed"), so 0 at creation is correct
+by definition, not a bug (see D3).
+
+### D5 — VWC deficit target is **per-zone**
+Today the VWC deficit is computed at system level (`DrynessIndexSensor._deficit`
+from one probe, scaled by Kc per zone) — benign because it is a *stateless
+measurement* recomputed each reading, and all zones track the same current
+value (no drift, no seeding bug). The **target** (AI-174) is per-zone probes:
+each zone computes its own deficit from its own sensor, or falls back to the ET
+model. When that lands, `DrynessIndexSensor._deficit` disappears entirely and
+the hub becomes pure plumbing.
+
+## What is kept vs retired
+
+| Element (class.field) | Verdict |
+|---|---|
+| `DrynessIndexSensor` as input hub (temp + rain → broadcast) | **Keep** — its real job |
+| `DrynessIndexSensor._deficit` as **ET accumulator** | **Retire** — dead weight + the #123 seed bug |
+| `DrynessIndexSensor._deficit` as **VWC system measurement** | **Interim** — stateless, benign; removed by AI-174 (per-zone probe) |
+| "Dryness Index" display entity | Derived (max/mean of zones) or dropped |
+| `IrrigationZoneSensor._zone_deficit` | **Keep — authoritative** |
+
+## Open questions
+
+- **Backfill per-zone.** Today the recorder replay bootstraps one system
+  deficit. In the per-zone model each zone should replay with its own Kc — or,
+  minimally, the first zone backfills and later zones seed from it (D4).
+- **Derived Dryness Index semantics.** If kept for display, is it `max` (the
+  driest zone → "does anything need water?") or `mean`? `max` matches the
+  at-a-glance "is irrigation due somewhere" intent.
+- **Rain per-zone display.** Keep a per-zone rain total (seeded per D4) or show
+  one system rain figure? Per-zone only gains meaning once scaled by area
+  (AI-102 / AI-179 water-saved).

--- a/docs/design_water_balance_reference_model.md
+++ b/docs/design_water_balance_reference_model.md
@@ -81,8 +81,10 @@ mm repeated on every card:
 
 - **Rain Yearly [L]** (per zone) = `yearly_rain_mm x area_m2` — the liters this
   zone caught from the shared rain. Same mm, different liters by area.
-- **Water Yearly [L]** (per zone) = `Rain Yearly + irrigation delivered` — the
-  total water the zone received this year (rain + irrigation).
+- **Irrigated Yearly [L]** (per zone) = irrigation delivered this year — the
+  water you *applied* (a pure consumption figure; device_class WATER feeds the
+  HA Energy dashboard, so rain is deliberately excluded). Rain is Rain Yearly;
+  a user who wants the grand total sums the two.
 
 The old per-zone `_total_rain` lifetime accumulator is removed: it drifted
 between zones by creation time and inflated on intake bugs (a field install read

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -191,6 +191,8 @@ The Kc values are interpolated linearly between seasons. The hemisphere is auto-
 
 After each zone, you are asked whether to add another zone or complete setup. You can add as many zones as you need.
 
+> **A zone added later starts at zero deficit.** A brand-new zone begins as if freshly watered and builds its deficit up from there as the weather dries it out — it does not copy the current deficit of your existing zones. This is intentional: it avoids a new zone spuriously reporting "irrigation due" the moment you add it. If you *want* all your zones to share the same starting point, click **"Mark irrigated"** on each zone — this resets a zone's deficit to zero without opening the valve, aligning them all.
+
 ### Step 4: Verify
 
 After setup, check that these entities exist in **Settings → Devices & Services → Entities**:
@@ -244,6 +246,32 @@ Shows the volume of water needed for this specific zone in liters.
 | `flow_rate_lpm` | Valve flow rate |
 | `threshold_mm` | Mode A trigger threshold |
 | `irrigating` | `true` if this zone is currently being irrigated |
+
+### Water totals: Rain Yearly and Water Yearly
+
+Each zone reports two yearly water totals, both in **liters** so the numbers are
+informative for that specific zone (a wider zone catches more rain from the same
+sky).
+
+- **Rain Yearly [L]** — the rain this zone received this year. Rain is a system
+  quantity measured once in millimeters, then projected onto each zone by its
+  area: `Rain Yearly [L] = accumulated rain [mm] × zone area [m²]` (1 mm over
+  1 m² = 1 liter).
+- **Water Yearly [L]** — the total water this zone received this year:
+  `Water Yearly = Rain Yearly + irrigation delivered`.
+
+**How the accumulation works.** The rain millimeters are accumulated by NeverDry
+from your configured rain sensor as rain falls, and the total **resets on 1
+January** (calendar-year accumulation). Because NeverDry can only count rain from
+the moment it is installed, the **first year is partial**: it accumulates from
+the installation date up to 31 December, and only from the following 1 January
+onward does it cover a full calendar year. Irrigation is counted the same way —
+per calendar year — so a freshly installed system starts both totals building
+up from the install date.
+
+If you want these totals to reflect rain that fell *before* NeverDry was
+installed, that historical rain cannot be reconstructed from a live sensor; the
+totals are only guaranteed correct from the install date forward.
 
 ## 7. Irrigation logic — how it all works
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -247,18 +247,19 @@ Shows the volume of water needed for this specific zone in liters.
 | `threshold_mm` | Mode A trigger threshold |
 | `irrigating` | `true` if this zone is currently being irrigated |
 
-### Water totals: Rain Yearly and Water Yearly
+### Water totals: Rain Yearly and Irrigated Yearly
 
-Each zone reports two yearly water totals, both in **liters** so the numbers are
-informative for that specific zone (a wider zone catches more rain from the same
-sky).
+Each zone reports two yearly totals in **liters**, kept as two clean, separate
+figures rather than one mixed number:
 
 - **Rain Yearly [L]** — the rain this zone received this year. Rain is a system
   quantity measured once in millimeters, then projected onto each zone by its
   area: `Rain Yearly [L] = accumulated rain [mm] × zone area [m²]` (1 mm over
   1 m² = 1 liter).
-- **Water Yearly [L]** — the total water this zone received this year:
-  `Water Yearly = Rain Yearly + irrigation delivered`.
+- **Irrigated Yearly [L]** — the water **you** delivered by irrigation this year
+  (irrigation only, rain excluded). This is the meaningful *consumption* figure
+  and feeds the Home Assistant Energy dashboard's water tracking. To get the
+  grand total of water the zone received, add the two.
 
 **How the accumulation works.** The rain millimeters are accumulated by NeverDry
 from your configured rain sensor as rain falls, and the total **resets on 1
@@ -657,7 +658,7 @@ The card groups the zone's entities by time horizon:
 - **Deficit vs threshold** — a bar showing how close the zone is to needing water
 - **Next session** — planned volume and run duration
 - **Last session** — last irrigated, duration, volume, and water delivered
-- **Totals** — yearly water and cumulative rain
+- **Totals** — Rain Yearly and Irrigated Yearly (liters, per zone)
 - **Parameters** — threshold, flow rate, area, Kc, efficiency, mode
 - **Actions** — *Irrigate now*, *Mark as irrigated*, and *Reset valve* as real buttons
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def _create_ha_stubs():
         DURATION = "duration"
         PRECIPITATION = "precipitation"
         PRECIPITATION_INTENSITY = "precipitation_intensity"
+        TIMESTAMP = "timestamp"
         VOLUME_FLOW_RATE = "volume_flow_rate"
         VOLUME_STORAGE = "volume_storage"
         WATER = "water"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,7 @@ def _create_ha_stubs():
     entity_registry_mod = ModuleType("homeassistant.helpers.entity_registry")
     entity_registry_mod.async_get = MagicMock(return_value=MagicMock())
     entity_registry_mod.async_entries_for_device = MagicMock(return_value=[])
+    entity_registry_mod.async_entries_for_config_entry = MagicMock(return_value=[])
     entity_registry_mod.async_migrate_entries = AsyncMock()
     entity_registry_mod.RegistryEntry = MagicMock
 

--- a/tests/test_controller_handlers.py
+++ b/tests/test_controller_handlers.py
@@ -233,8 +233,18 @@ class TestReactiveHandler:
 
 
 class TestScheduledHandler:
-    def test_below_threshold_no_irrigation(self, controller, zone_orto, hass_mock):
-        zone_orto._zone_deficit = 5.0
+    def test_below_threshold_still_irrigates(self, controller, zone_orto, hass_mock):
+        # Scheduled mode tops up at the scheduled hour regardless of the
+        # threshold: a below-threshold deficit still irrigates (AI-183).
+        zone_orto._zone_deficit = 5.0  # below the default 20 mm threshold
+        handler = controller._make_scheduled_handler("Orto")
+        hass_mock.async_create_task = MagicMock(return_value=MagicMock())
+        handler(MagicMock())
+        hass_mock.async_create_task.assert_called_once()
+
+    def test_zero_deficit_no_irrigation(self, controller, zone_orto, hass_mock):
+        # Nothing to refill → skip. This is now the only skip condition.
+        zone_orto._zone_deficit = 0.0
         handler = controller._make_scheduled_handler("Orto")
         hass_mock.async_create_task = MagicMock()
         handler(MagicMock())

--- a/tests/test_controller_with_operator.py
+++ b/tests/test_controller_with_operator.py
@@ -303,6 +303,20 @@ def test_update_deficit_realtime_is_idempotent(hass_mock, di_sensor):
     assert zone._zone_deficit == 0.0
 
 
+def test_update_deficit_realtime_updates_session_water(hass_mock, di_sensor):
+    """Session water rises live during a flow-metered cycle (field report:
+    Volume/Duration counted down while Session water stayed 0)."""
+    zone = _make_zone_orto(hass_mock, di_sensor)
+    zone._zone_deficit = 12.0
+    zone._deficit_at_irrigation_start = 12.0
+    ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+
+    ctrl._update_deficit_realtime(zone, 5.0)
+    assert zone._session_water_delivered == pytest.approx(5.0)
+    ctrl._update_deficit_realtime(zone, 12.5)
+    assert zone._session_water_delivered == pytest.approx(12.5)
+
+
 def test_update_deficit_realtime_skipped_when_no_active_cycle(hass_mock, di_sensor):
     """Without a snapshot the helper must leave the deficit untouched."""
     zone = _make_zone_orto(hass_mock, di_sensor)

--- a/tests/test_sensor_device_classes.py
+++ b/tests/test_sensor_device_classes.py
@@ -1,12 +1,13 @@
 """Regression tests: every sensor that participates in SI/imperial conversion
 must declare the correct device_class so that Home Assistant can auto-convert
-the displayed unit (mm→in, L→gal, L/min→gal/min, mm/h→in/h, m²→ft²).
+the displayed unit (mm→in, L→gal, L/min→gal/min, mm/h→in/h, m2→ft2).
 
 If a device_class is accidentally removed, HA silently stops converting units
 for users who have Home Assistant configured in imperial mode.
 """
 
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfVolume
 from never_dry.sensor import (
     ZoneAreaSensor,
     ZoneDeficitSensor,
@@ -41,10 +42,11 @@ class TestDeviceClassDeclarations:
         deficit = ZoneDeficitSensor(zone_orto)
         assert deficit._attr_device_class == SensorDeviceClass.PRECIPITATION
 
-    def test_zone_rain_sensor_precipitation(self, di_sensor, zone_orto):
-        """Zone cumulative rain [mm] → HA converts to [in] in imperial."""
+    def test_zone_rain_sensor_is_water_liters(self, di_sensor, zone_orto):
+        """Rain Yearly is per-zone liters (mm x area): WATER, not PRECIPITATION."""
         rain = ZoneRainSensor(zone_orto)
-        assert rain._attr_device_class == SensorDeviceClass.PRECIPITATION
+        assert rain._attr_device_class == SensorDeviceClass.WATER
+        assert rain._attr_native_unit_of_measurement == UnitOfVolume.LITERS
 
     def test_zone_session_water_volume_storage(self, di_sensor, zone_orto):
         """Session water delivered [L] → HA converts to [gal] in imperial."""
@@ -87,6 +89,6 @@ class TestDeviceClassDeclarations:
         assert sensor._attr_device_class == SensorDeviceClass.PRECIPITATION
 
     def test_zone_area_sensor_area(self, di_sensor, zone_orto):
-        """Zone area [m²] → HA converts to [ft²] in imperial."""
+        """Zone area [m2] → HA converts to [ft2] in imperial."""
         sensor = ZoneAreaSensor(zone_orto)
         assert sensor._attr_device_class == SensorDeviceClass.AREA

--- a/tests/test_sensor_device_classes.py
+++ b/tests/test_sensor_device_classes.py
@@ -14,6 +14,7 @@ from never_dry.sensor import (
     ZoneDurationSensor,
     ZoneFlowRateSensor,
     ZoneLastDurationSensor,
+    ZoneLastIrrigatedSensor,
     ZoneLastVolumeSensor,
     ZoneRainSensor,
     ZoneSessionWaterSensor,
@@ -92,3 +93,15 @@ class TestDeviceClassDeclarations:
         """Zone area [m2] → HA converts to [ft2] in imperial."""
         sensor = ZoneAreaSensor(zone_orto)
         assert sensor._attr_device_class == SensorDeviceClass.AREA
+
+    def test_zone_last_irrigated_is_timestamp(self, di_sensor, zone_orto):
+        """Last irrigated is a TIMESTAMP sensor (localized by HA), not raw ISO."""
+        from datetime import datetime
+
+        sensor = ZoneLastIrrigatedSensor(zone_orto)
+        assert sensor._attr_device_class == SensorDeviceClass.TIMESTAMP
+        assert sensor.native_value is None
+        zone_orto._last_irrigated = datetime(2026, 7, 21, 20, 45, 0)
+        v = sensor.native_value
+        # Must be a timezone-aware datetime, not an ISO string.
+        assert isinstance(v, datetime) and v.tzinfo is not None

--- a/tests/test_unique_id_scoping.py
+++ b/tests/test_unique_id_scoping.py
@@ -113,3 +113,33 @@ class TestRegistryMigration:
         migrated = MagicMock()
         migrated.unique_id = "entryA_never_dry"
         assert cb(migrated) is None
+
+    def test_remove_legacy_rain_entities_removes_only_old_rain(self, hass_mock):
+        """Cleanup removes the pre-rework rain_zone_ entity, keeps the rest."""
+        from never_dry import _async_remove_legacy_rain_entities
+
+        entry = MagicMock()
+        entry.entry_id = "entryA"
+
+        def _e(uid, eid):
+            m = MagicMock()
+            m.unique_id = uid
+            m.entity_id = eid
+            return m
+
+        entries = [
+            _e("entryA_rain_zone_orto", "sensor.orto_rain"),  # legacy -> remove
+            _e("entryA_rain_yearly_zone_orto", "sensor.orto_rain_yearly"),  # new -> keep
+            _e("entryA_deficit_zone_orto", "sensor.orto_deficit"),  # keep
+        ]
+        registry = MagicMock()
+        removed = []
+        registry.async_remove.side_effect = removed.append
+
+        with (
+            patch("never_dry.er.async_get", return_value=registry),
+            patch("never_dry.er.async_entries_for_config_entry", return_value=entries),
+        ):
+            _async_remove_legacy_rain_entities(hass_mock, entry)
+
+        assert removed == ["sensor.orto_rain"]

--- a/tests/test_zone_deficit_sensor.py
+++ b/tests/test_zone_deficit_sensor.py
@@ -1,5 +1,6 @@
 """Tests for ZoneDeficitSensor and zone deficit seeding."""
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,7 +12,12 @@ from never_dry.const import (
     CONF_ZONE_THRESHOLD,
     CONF_ZONE_VALVE,
 )
-from never_dry.sensor import IrrigationZoneSensor, ZoneDeficitSensor
+from never_dry.sensor import (
+    IrrigationZoneSensor,
+    ZoneDeficitSensor,
+    ZoneRainSensor,
+    ZoneYearlyWaterSensor,
+)
 
 
 def _make_hass():
@@ -107,22 +113,24 @@ class TestZoneDeficitSensorValue:
 
 
 class TestZoneDeficitSeeding:
-    """Test that new zones seed deficit from global Dryness Index."""
+    """A new zone (no restored state) starts at zero — it does NOT inherit the
+    global reference deficit. That global drifts high under per-zone irrigation
+    (it only resets when ALL zones are irrigated together) and gave new zones a
+    spurious 'irrigation due' (#123, Rasen 2.1). See
+    docs/design_water_balance_reference_model.md (D4)."""
 
     @pytest.mark.asyncio
-    async def test_seed_from_dryness_index(self, di_sensor):
-        """New zone (no restore) should seed deficit from DI * Kc."""
+    async def test_new_zone_starts_at_zero_ignoring_dryness_index(self, di_sensor):
+        """New zone (no restore) starts at 0 even when the global DI is high."""
         zone = _make_zone(di_sensor)
-        di_sensor._deficit = 8.0
-        # Simulate async_added_to_hass with no previous state
+        di_sensor._deficit = 8.0  # inflated global — must NOT leak into the zone
         zone.async_get_last_state = AsyncMock(return_value=None)
         await zone.async_added_to_hass()
-        # Kc=1.0 (no plant family), so zone deficit = 8.0
-        assert zone._zone_deficit == pytest.approx(8.0, abs=0.1)
+        assert zone._zone_deficit == 0.0
 
     @pytest.mark.asyncio
     async def test_restore_overrides_seed(self, di_sensor):
-        """Restored state should be used instead of seeding."""
+        """Restored state is used instead of the zero start."""
         zone = _make_zone(di_sensor)
         di_sensor._deficit = 8.0
         last_state = MagicMock()
@@ -130,15 +138,6 @@ class TestZoneDeficitSeeding:
         zone.async_get_last_state = AsyncMock(return_value=last_state)
         await zone.async_added_to_hass()
         assert zone._zone_deficit == pytest.approx(3.5, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_seed_zero_when_dryness_zero(self, di_sensor):
-        """If DI is 0, new zone deficit should also be 0."""
-        zone = _make_zone(di_sensor)
-        di_sensor._deficit = 0.0
-        zone.async_get_last_state = AsyncMock(return_value=None)
-        await zone.async_added_to_hass()
-        assert zone._zone_deficit == 0.0
 
 
 class TestZoneDeficitSensorAttributes:
@@ -196,3 +195,41 @@ class TestZoneDeficitSensorAttributes:
         attrs = deficit.extra_state_attributes
         assert attrs["valve_fsm_state"] == "maintenance"
         assert attrs["valve_in_maintenance"] is True
+
+
+class TestYearlyRain:
+    """Rain is a system yearly total [mm]; each zone shows it in liters via its
+    own area (mm x m2 = L), and Water Yearly = rain + irrigation.
+    See docs/design_water_balance_reference_model.md (D3)."""
+
+    def test_accrue_and_year_reset(self, di_sensor):
+        di_sensor._yearly_rain = 0.0
+        di_sensor._yearly_rain_year = datetime.now().year
+        di_sensor._accrue_yearly_rain(3.0)
+        di_sensor._accrue_yearly_rain(2.0)
+        assert di_sensor._yearly_rain == pytest.approx(5.0)
+        # A stale year → the next accrual resets before adding.
+        di_sensor._yearly_rain_year -= 1
+        di_sensor._accrue_yearly_rain(1.0)
+        assert di_sensor._yearly_rain == pytest.approx(1.0)
+        assert di_sensor._yearly_rain_year == datetime.now().year
+
+    def test_rain_yearly_is_liters_via_area(self, di_sensor):
+        di_sensor._yearly_rain = 4.0  # mm
+        zone = _make_zone(di_sensor, area=50.0)
+        rain = ZoneRainSensor(zone)
+        assert rain.native_value == pytest.approx(200.0)  # 4 mm x 50 m2 = 200 L
+
+    def test_all_zones_same_mm_but_liters_scale_with_area(self, di_sensor):
+        di_sensor._yearly_rain = 5.0
+        small = ZoneRainSensor(_make_zone(di_sensor, name="Small", area=10.0))
+        big = ZoneRainSensor(_make_zone(di_sensor, name="Big", area=40.0))
+        assert small.native_value == pytest.approx(50.0)
+        assert big.native_value == pytest.approx(200.0)
+
+    def test_water_yearly_is_rain_plus_irrigation(self, di_sensor):
+        di_sensor._yearly_rain = 4.0  # 200 L over 50 m2
+        zone = _make_zone(di_sensor, area=50.0)
+        zone._yearly_water_delivered = 120.0
+        water = ZoneYearlyWaterSensor(zone)
+        assert water.native_value == pytest.approx(320.0)  # 200 + 120

--- a/tests/test_zone_deficit_sensor.py
+++ b/tests/test_zone_deficit_sensor.py
@@ -227,9 +227,11 @@ class TestYearlyRain:
         assert small.native_value == pytest.approx(50.0)
         assert big.native_value == pytest.approx(200.0)
 
-    def test_water_yearly_is_rain_plus_irrigation(self, di_sensor):
-        di_sensor._yearly_rain = 4.0  # 200 L over 50 m2
+    def test_irrigated_yearly_is_irrigation_only(self, di_sensor):
+        """Irrigated Yearly is the delivered irrigation only — rain excluded
+        (WATER device_class = consumption; rain is Rain Yearly)."""
+        di_sensor._yearly_rain = 4.0  # must NOT be added
         zone = _make_zone(di_sensor, area=50.0)
         zone._yearly_water_delivered = 120.0
         water = ZoneYearlyWaterSensor(zone)
-        assert water.native_value == pytest.approx(320.0)  # 200 + 120
+        assert water.native_value == pytest.approx(120.0)


### PR DESCRIPTION
Water-balance model corrections + a batch of Zone Card display fixes, all field-verified on a live HA instance. New design doc `docs/design_water_balance_reference_model.md` pins where the deficit lives.

## Core water balance
- **New zone starts at 0** instead of inheriting the global Dryness Index (#123, AI-189). The global reference only resets when *all* zones irrigate together, so under per-zone irrigation it drifts high and gave a brand-new zone a spurious "irrigation due" (Rasen 2.1 read 11 mm while its identical sibling sat at 0). Zero start is safe and self-corrects on first irrigation; "Mark irrigated" aligns zones.
- **Scheduled mode irrigates at the scheduled hour regardless of the threshold**, dosing the accumulated deficit; skips only when there's nothing to refill (AI-183). Threshold stays a reactive-mode concept.
- **Rain becomes a system yearly total [mm]** on the hub; per-zone **Rain Yearly [L] = yearly_rain × area** and **Water Yearly [L] = rain + irrigation** — each zone reports informative liters instead of an identical mm. Removes the per-zone `_total_rain` lifetime counter that drifted between zones and inflated on intake bugs (a field install read 6418 mm) (AI-190).
- **Rain sensor gets a fresh unique_id** (`rain_zone_` -> `rain_yearly_zone_`) so the mm->L switch does not trigger HA's "unit changed" repair; the old entity orphans.

## Zone Card
- **Duration / Last Duration** shown as **mm:ss** (AI-185).
- **Last irrigated** is now a **TIMESTAMP** sensor, localized by HA instead of a raw ISO string (AI-104).
- **Session water** shown only while a zone is irrigating (idle it is 0 or duplicates Last volume) (AI-186), and it now **rises live during a flow-metered cycle** (was only set at completion). Estimated-flow live estimate remains for AI-128.

## Docs
New `design_water_balance_reference_model.md` (reference frames, retire/keep table, D1-D5); `design_domain_object_model.md` aligned (System = feed hub, deficit per zone); user manual documents Rain Yearly / Water Yearly and the calendar-year accumulation from install date.

## Tests
759 passed, ruff clean. Field-verified: scheduled top-up, manual dose=deficit + auto-close, partial stop reduces (not zeroes), rain cleanup, timestamp, live session water (flow_meter).