### PR TITLE
docs: curate badges by audience (trust + support on user pages)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@ Thanks for your interest in NeverDry — a Home Assistant custom integration for
 ET-based smart irrigation. Contributions of all kinds are welcome: bug reports,
 fixes, features, documentation, and help verifying the science.
 
+<!-- CI status — for contributors (user-facing trust badges live in README) -->
+[![Tests](https://github.com/drake69/NeverDry/actions/workflows/tests.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/drake69/NeverDry/graph/badge.svg)](https://codecov.io/gh/drake69/NeverDry)
+[![HACS Validation](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml)
+[![Lint](https://github.com/drake69/NeverDry/actions/workflows/lint.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/lint.yml)
+[![Security](https://github.com/drake69/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/security.yml)
+[![Release](https://github.com/drake69/NeverDry/actions/workflows/release.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/release.yml)
+
 ## Ways to contribute
 
 - **Report a bug or request a feature** — open a GitHub issue with clear steps /

--- a/README.md
+++ b/README.md
@@ -2,17 +2,12 @@
 
 **Smart irrigation for Home Assistant** — knows exactly when your garden needs water, calculates how long to run the valve, and makes sure it actually closes.
 
-[![Tests](https://github.com/drake69/NeverDry/actions/workflows/tests.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/tests.yml)
-[![codecov](https://codecov.io/gh/drake69/NeverDry/graph/badge.svg)](https://codecov.io/gh/drake69/NeverDry)
-[![HACS Validation](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml)
-[![Release](https://github.com/drake69/NeverDry/actions/workflows/release.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/release.yml)
 [![Security](https://github.com/drake69/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/security.yml)
-[![Lint](https://github.com/drake69/NeverDry/actions/workflows/lint.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/lint.yml)
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
-[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
+[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
 [![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
 [![Downloads](https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%29)](https://github.com/drake69/NeverDry/releases)
-[![GitHub stars](https://img.shields.io/github/stars/drake69/NeverDry?style=social)](https://github.com/drake69/NeverDry/stargazers)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
+[![HA Community](https://img.shields.io/badge/Home%20Assistant-Community%20thread-41BDF5?logo=home-assistant&logoColor=white)](https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835)
 <!-- Active installs (Home Assistant analytics). Currently no data: `never_dry` is not yet listed
      in analytics.home-assistant.io/custom_integrations.json (below HA's listing threshold).
      Uncomment when it appears — the badge auto-populates:

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -91,11 +91,11 @@
     <h1>NeverDry</h1>
     <p class="tagline">Your garden tells you when it's thirsty. NeverDry listens — and makes sure the valve always closes.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/security.yml?label=security&style=flat-square" alt="Security">
         <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
         <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
+        <a href="https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835"><img src="https://img.shields.io/badge/support-HA%20Community-41BDF5?style=flat-square&logo=home-assistant&logoColor=white" alt="HA Community support"></a>
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
     <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"


### PR DESCRIPTION
## What & why

Curate the badge blocks so each page speaks to its audience — inspired by the UniFi HA add-on (few, meaningful badges, community links among them).

**User-facing pages (README + landing) = customers, not developers**
- CI-status badges (Tests, Coverage, Lint, HACS Validation, Release) are dev signals and add noise for end users.
- Instead, surface **Security** (a real trust signal for software that opens water valves — `security.yml` is green on `main`) and **HA Community** (support).

## Changes
- **README.md**: 11 → 6 badges. Removed CI-status badges and the social-stars badge (the star CTA and for-the-badge remain). Added Security + HA Community.
- **docs/gh-pages/index.html** (landing): swapped Tests/Coverage for Security + a clickable HA Community support badge; kept Release/Downloads/HACS.
- **CONTRIBUTING.md**: homed the developer CI badges (tests, codecov, hacs, lint, security, release) where contributors look.

## Notes
- Docs/landing only — no code changes.
- Landing now shows HA Community twice (top badge + bottom CTA button) intentionally; easy to drop one if preferred.