### PR TITLE
feat(reset): system-wide yearly rain & water reset buttons (+ imperial units fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+- Imperial units in the config flow and displays ([#139]):
+  - Zone threshold help text no longer hardcodes "(mm)" — the field label already shows the user's unit (mm or in).
+  - Deficit, threshold and ET sensors now declare a display precision, so imperial users see meaningful decimals instead of values rounded to whole inches.
+  - Reconfiguring a zone in imperial is now stable: threshold and max-deficit round-trip through inches without drifting on every edit.
 
 ## [0.11.0] - 2026-07-26
 
@@ -43,5 +47,6 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/drake
 
 [Unreleased]: https://github.com/drake69/NeverDry/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/drake69/NeverDry/releases/tag/v0.11.0
+[#139]: https://github.com/drake69/NeverDry/issues/139
 [#123]: https://github.com/drake69/NeverDry/issues/123
 [#116]: https://github.com/drake69/NeverDry/issues/116

--- a/custom_components/never_dry/button.py
+++ b/custom_components/never_dry/button.py
@@ -21,6 +21,8 @@ from .const import (
     SERVICE_IRRIGATE_ZONE,
     SERVICE_MARK_IRRIGATED,
     SERVICE_RESET_VALVE,
+    SERVICE_RESET_YEARLY_RAIN,
+    SERVICE_RESET_YEARLY_WATER,
     SERVICE_STOP_ZONE,
 )
 
@@ -30,6 +32,13 @@ def _zone_device_info(entry_id: str, zone_name: str) -> DeviceInfo:
     slug = zone_name.lower().replace(" ", "_")
     return DeviceInfo(
         identifiers={(DOMAIN, f"{entry_id}_{slug}")},
+    )
+
+
+def _hub_device_info(entry_id: str) -> DeviceInfo:
+    """Device info matching the NeverDry hub device created in sensor.py."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry_id)},
     )
 
 
@@ -53,7 +62,7 @@ async def async_setup_entry(
 
 
 def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -> list[ButtonEntity]:
-    """Create button entities for each configured zone."""
+    """Create button entities for each configured zone plus the system hub."""
     buttons: list[ButtonEntity] = []
     for zone_conf in config.get(CONF_ZONES, []):
         zone_name = zone_conf[CONF_ZONE_NAME]
@@ -63,6 +72,12 @@ def _create_buttons(hass: HomeAssistant, config: dict, entry_id: str = "yaml") -
         if zone_conf.get("valve"):
             buttons.append(StopButton(hass, zone_name, device_info))
             buttons.append(ResetMaintenanceButton(hass, zone_name, device_info))
+    # System-wide reset buttons live on the NeverDry hub device, not on any
+    # single zone: yearly rain is one value for the whole garden, and the
+    # water reset fans out across every zone (AI-206).
+    hub_device = _hub_device_info(entry_id)
+    buttons.append(ResetYearlyRainButton(hass, hub_device))
+    buttons.append(ResetYearlyWaterButton(hass, hub_device))
     # Scope every unique_id to the config entry (GH #116) — same rule as
     # sensor._create_entities, covered by the same registry migration.
     for button in buttons:
@@ -164,3 +179,39 @@ class ResetMaintenanceButton(ButtonEntity):
             SERVICE_RESET_VALVE,
             {ATTR_ZONE_NAME: self._zone_name},
         )
+
+
+class ResetYearlyRainButton(ButtonEntity):
+    """Hub button to clear the year-to-date rain total (system-wide)."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:weather-rainy"
+
+    def __init__(self, hass: HomeAssistant, device_info: DeviceInfo | None = None) -> None:
+        self._hass = hass
+        self._attr_name = "Reset yearly rain"
+        self._attr_unique_id = "reset_yearly_rain"
+        if device_info:
+            self._attr_device_info = device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press — reset the system-wide yearly rain total."""
+        await self._hass.services.async_call(DOMAIN, SERVICE_RESET_YEARLY_RAIN, {})
+
+
+class ResetYearlyWaterButton(ButtonEntity):
+    """Hub button to clear every zone's year-to-date irrigated-water total."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:water-off"
+
+    def __init__(self, hass: HomeAssistant, device_info: DeviceInfo | None = None) -> None:
+        self._hass = hass
+        self._attr_name = "Reset yearly water"
+        self._attr_unique_id = "reset_yearly_water"
+        if device_info:
+            self._attr_device_info = device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press — reset yearly water delivered for all zones."""
+        await self._hass.services.async_call(DOMAIN, SERVICE_RESET_YEARLY_WATER, {})

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -108,7 +108,7 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
     t_unit = "°F" if is_imperial else "°C"
     d_unit = "in" if is_imperial else "mm"
     t_base_default = _c_to_f(DEFAULT_T_BASE) if is_imperial else DEFAULT_T_BASE
-    d_max_default = round(DEFAULT_D_MAX * _MM_TO_IN, 1) if is_imperial else DEFAULT_D_MAX
+    d_max_default = round(DEFAULT_D_MAX * _MM_TO_IN, 2) if is_imperial else DEFAULT_D_MAX
 
     return vol.Schema(
         {
@@ -145,7 +145,7 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
                 selector.NumberSelectorConfig(
                     min=0.5 if is_imperial else 10.0,
                     max=20.0 if is_imperial else 500.0,
-                    step=0.5 if is_imperial else 10.0,
+                    step=0.01 if is_imperial else 10.0,
                     mode="box",
                     unit_of_measurement=d_unit,
                 )
@@ -162,7 +162,7 @@ def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
     t_stored = current.get(CONF_T_BASE, DEFAULT_T_BASE)
     d_stored = current.get(CONF_D_MAX, DEFAULT_D_MAX)
     t_display = _c_to_f(t_stored) if is_imperial else t_stored
-    d_display = round(d_stored * _MM_TO_IN, 1) if is_imperial else d_stored
+    d_display = round(d_stored * _MM_TO_IN, 2) if is_imperial else d_stored
 
     return vol.Schema(
         {
@@ -210,7 +210,7 @@ def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
                 selector.NumberSelectorConfig(
                     min=0.5 if is_imperial else 10.0,
                     max=20.0 if is_imperial else 500.0,
-                    step=0.5 if is_imperial else 10.0,
+                    step=0.01 if is_imperial else 10.0,
                     mode="box",
                     unit_of_measurement=d_unit,
                 )
@@ -224,7 +224,7 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
     area_unit = "ft²" if is_imperial else "m²"
     flow_unit = "gal/h" if is_imperial else "L/h"
     depth_unit = "in" if is_imperial else "mm"
-    threshold_default = round(DEFAULT_THRESHOLD * _MM_TO_IN, 1) if is_imperial else DEFAULT_THRESHOLD
+    threshold_default = round(DEFAULT_THRESHOLD * _MM_TO_IN, 2) if is_imperial else DEFAULT_THRESHOLD
 
     return vol.Schema(
         {
@@ -308,7 +308,7 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                 selector.NumberSelectorConfig(
                     min=0.1 if is_imperial else 1.0,
                     max=4.0 if is_imperial else 100.0,
-                    step=0.1 if is_imperial else 1.0,
+                    step=0.01 if is_imperial else 1.0,
                     mode="box",
                     unit_of_measurement=depth_unit,
                 )
@@ -642,7 +642,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
 
         def _d_threshold(fallback):
             v = cur.get(CONF_ZONE_THRESHOLD, fallback)
-            return round(v * _MM_TO_IN, 1) if (imperial and v is not None) else v
+            return round(v * _MM_TO_IN, 2) if (imperial and v is not None) else v
 
         dm_opts = [
             DELIVERY_MODE_ESTIMATED_FLOW,
@@ -793,7 +793,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                     selector.NumberSelectorConfig(
                         min=0.1 if imperial else 1.0,
                         max=4.0 if imperial else 100.0,
-                        step=0.1 if imperial else 1.0,
+                        step=0.01 if imperial else 1.0,
                         mode="box",
                         unit_of_measurement=depth_unit,
                     )

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -106,6 +106,8 @@ FLOW_METER_POLL_INTERVAL_S = 2
 
 # ── Services ─────────────────────────────────────────────
 SERVICE_RESET = "reset"
+SERVICE_RESET_YEARLY_RAIN = "reset_yearly_rain"
+SERVICE_RESET_YEARLY_WATER = "reset_yearly_water"
 SERVICE_IRRIGATE_ZONE = "irrigate_zone"
 SERVICE_IRRIGATE_ALL = "irrigate_all"
 SERVICE_STOP = "stop"

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -347,6 +347,30 @@ class IrrigationController:
             zs.reset_deficit("service_reset")
             zs.async_write_ha_state()
 
+    async def _handle_reset_yearly_rain(self, call: ServiceCall) -> None:
+        """Clear the year-to-date rain total [mm] — system-wide.
+
+        The total lives on the Dryness Index as a restore attribute and the
+        per-zone "Rain Yearly [L]" sensors derive from it, so resetting it
+        here re-anchors every zone's yearly-rain display to zero.
+        """
+        if self._is_throttled("reset_yearly_rain"):
+            return
+        self._dryness.reset_yearly_rain()
+        self._dryness.async_write_ha_state()
+
+    async def _handle_reset_yearly_water(self, call: ServiceCall) -> None:
+        """Clear the year-to-date irrigated-water total [L] for every zone.
+
+        The counter is per-zone, so this fans out across all zones of this
+        controller; the lifetime total is preserved.
+        """
+        if self._is_throttled("reset_yearly_water"):
+            return
+        for zs in self._zones.values():
+            zs.reset_yearly_water()
+            zs.async_write_ha_state()
+
     async def _handle_set_deficit(self, call: ServiceCall) -> None:
         """Set deficit to a specific value [mm] — for testing and manual correction."""
         deficit_mm = float(call.data.get(ATTR_DEFICIT_MM, 0.0))

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -496,6 +496,9 @@ class ETSensor(SensorEntity):
     _attr_unique_id = "et_hourly_estimate"
     _attr_device_class = SensorDeviceClass.PRECIPITATION_INTENSITY
     _attr_native_unit_of_measurement = UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR
+    # Native precision in mm/h; HA scales up the decimals automatically when the
+    # user's unit system converts to in/h (issue #139).
+    _attr_suggested_display_precision = 2
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:sun-thermometer"
 
@@ -547,6 +550,9 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
     _attr_unique_id = "never_dry"
     _attr_device_class = SensorDeviceClass.PRECIPITATION
     _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
+    # Native precision in mm; HA scales up the decimals automatically when the
+    # user's unit system converts to inches (issue #139).
+    _attr_suggested_display_precision = 1
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-percent-alert"
 
@@ -1368,6 +1374,9 @@ class ZoneDeficitSensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.PRECIPITATION
     _attr_name = "Deficit"
     _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
+    # Native precision in mm; HA scales up the decimals automatically when the
+    # user's unit system converts to inches (issue #139).
+    _attr_suggested_display_precision = 1
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-percent-alert"
 
@@ -1799,6 +1808,9 @@ class ZoneThresholdSensor(_ZoneTextSensor):
 
     _attr_device_class = SensorDeviceClass.PRECIPITATION
     _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
+    # Native precision in mm; HA scales up the decimals automatically when the
+    # user's unit system converts to inches (issue #139).
+    _attr_suggested_display_precision = 1
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -954,6 +954,19 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         self._deficit = 0.0
         self._last_update = datetime.now()
 
+    def reset_yearly_rain(self) -> None:
+        """Clear the year-to-date rain total [mm] — system-wide.
+
+        Zeroes the source counter the "Rain Yearly [L]" zone sensors derive
+        from and re-anchors the calendar year, so a fresh restore attribute is
+        written on the next ``async_write_ha_state``. Needed because the total
+        persists as a restore attribute that survives a plain reinstall
+        (GH forum: yearly rain stuck after switching rain sensor type).
+        Historical recorder statistics are left untouched.
+        """
+        self._yearly_rain = 0.0
+        self._yearly_rain_year = datetime.now().year
+
     def set_deficit_mm(self, value: float) -> None:
         """Set deficit to an arbitrary value [mm] — intended for testing/debugging."""
         self._deficit = max(0.0, min(float(value), self._d_max))
@@ -1229,6 +1242,17 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     def set_deficit_mm(self, value: float) -> None:
         """Set zone deficit to an arbitrary value [mm] — intended for testing/debugging."""
         self._zone_deficit = max(0.0, min(float(value), self._d_max))
+
+    def reset_yearly_water(self) -> None:
+        """Clear this zone's year-to-date irrigated-water total [L].
+
+        Zeroes the counter behind the "Yearly Water" sensor and re-anchors the
+        calendar year, so a fresh restore attribute is written on the next
+        ``async_write_ha_state``. The lifetime ``total_water_delivered_l`` is
+        left untouched — only the yearly total, mirroring the yearly-rain reset.
+        """
+        self._yearly_water_delivered = 0.0
+        self._yearly_water_year = datetime.now().year
 
     def reset_deficit(self, source: str = "unknown", delivered_liters: float | None = None) -> None:
         """Reset this zone's deficit to zero (called after irrigation).

--- a/custom_components/never_dry/services.py
+++ b/custom_components/never_dry/services.py
@@ -33,6 +33,8 @@ from .const import (
     SERVICE_MARK_IRRIGATED,
     SERVICE_RESET,
     SERVICE_RESET_VALVE,
+    SERVICE_RESET_YEARLY_RAIN,
+    SERVICE_RESET_YEARLY_WATER,
     SERVICE_SET_DEFICIT,
     SERVICE_STOP,
     SERVICE_STOP_ZONE,
@@ -55,6 +57,8 @@ _GLOBAL: dict[str, str] = {
     SERVICE_STOP: "_handle_stop",
     SERVICE_IRRIGATE_ALL: "_handle_irrigate_all",
     SERVICE_RESET: "_handle_reset",
+    SERVICE_RESET_YEARLY_RAIN: "_handle_reset_yearly_rain",
+    SERVICE_RESET_YEARLY_WATER: "_handle_reset_yearly_water",
 }
 
 

--- a/custom_components/never_dry/services.yaml
+++ b/custom_components/never_dry/services.yaml
@@ -2,6 +2,23 @@ reset:
   name: Reset deficit
   description: Reset the soil water deficit to zero (typically called after irrigation completes).
 
+reset_yearly_rain:
+  name: Reset yearly rain
+  description: >
+    Reset the year-to-date rain total to zero (system-wide). The total is a
+    single value shared by every zone's "Rain Yearly" sensor and normally
+    resets on its own on 1 January. Use this to clear a wrong value — for
+    example after switching rain sensor type — without waiting for the new
+    year or reinstalling. Historical statistics are left untouched.
+
+reset_yearly_water:
+  name: Reset yearly water
+  description: >
+    Reset the year-to-date irrigated-water total to zero for every zone. Each
+    zone keeps its own yearly counter and normally resets on 1 January; this
+    clears them all at once. The lifetime total delivered per zone and
+    historical statistics are left untouched.
+
 irrigate_zone:
   name: Irrigate zone
   description: >

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -56,7 +56,7 @@
           "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
           "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level (mm) that triggers automatic irrigation for this zone",
+          "threshold": "Deficit level that triggers automatic irrigation for this zone",
           "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -56,7 +56,7 @@
           "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
           "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level (mm) that triggers automatic irrigation for this zone",
+          "threshold": "Deficit level that triggers automatic irrigation for this zone",
           "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
         }
       },

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -56,7 +56,7 @@
           "flow_meter_sensor": "Entità sensore che rileva i litri cumulativi erogati. Richiesto per la modalità flow_meter",
           "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
           "delivery_timeout": "Tempo massimo di attesa per l'erogazione con flow_meter o volume_preset prima di forzare la chiusura della valvola (limite di sicurezza)",
-          "threshold": "Livello di deficit (mm) che attiva l'irrigazione automatica per questa zona",
+          "threshold": "Livello di deficit che attiva l'irrigazione automatica per questa zona",
           "irrigation_time": "Ora del giorno in cui NeverDry verifica il deficit e irriga se supera la soglia. Lascia vuoto per disabilitare la pianificazione automatica"
         }
       },

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -7,6 +7,8 @@ from never_dry.button import (
     IrrigateButton,
     MarkIrrigatedButton,
     ResetMaintenanceButton,
+    ResetYearlyRainButton,
+    ResetYearlyWaterButton,
     StopButton,
     _create_buttons,
 )
@@ -17,8 +19,13 @@ from never_dry.const import (
     DOMAIN,
     SERVICE_IRRIGATE_ZONE,
     SERVICE_MARK_IRRIGATED,
+    SERVICE_RESET_YEARLY_RAIN,
+    SERVICE_RESET_YEARLY_WATER,
     SERVICE_STOP_ZONE,
 )
+
+# Every config grows two system-wide hub buttons (reset yearly rain + water).
+HUB_BUTTONS = 2
 
 
 class TestButtonCreation:
@@ -32,7 +39,7 @@ class TestButtonCreation:
             ]
         }
         buttons = _create_buttons(hass_mock, config)
-        assert len(buttons) == 4  # MarkIrrigated + Irrigate per zone
+        assert len(buttons) == 4 + HUB_BUTTONS  # MarkIrrigated + Irrigate per zone + hub
 
     def test_button_types(self, hass_mock):
         config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
@@ -40,21 +47,27 @@ class TestButtonCreation:
         assert isinstance(buttons[0], MarkIrrigatedButton)
         assert isinstance(buttons[1], IrrigateButton)
 
-    def test_no_buttons_without_zones(self, hass_mock):
+    def test_only_hub_buttons_without_zones(self, hass_mock):
         buttons = _create_buttons(hass_mock, {})
-        assert len(buttons) == 0
+        assert len(buttons) == HUB_BUTTONS
 
-    def test_no_buttons_empty_zones(self, hass_mock):
+    def test_only_hub_buttons_empty_zones(self, hass_mock):
         buttons = _create_buttons(hass_mock, {CONF_ZONES: []})
-        assert len(buttons) == 0
+        assert len(buttons) == HUB_BUTTONS
 
     def test_valve_zone_gets_stop_and_reset_buttons(self, hass_mock):
         config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto", "valve": "switch.valve_orto"}]}
         buttons = _create_buttons(hass_mock, config)
-        # Mark + Irrigate + Stop + Reset
-        assert len(buttons) == 4
+        # Mark + Irrigate + Stop + Reset per zone, plus the hub buttons
+        assert len(buttons) == 4 + HUB_BUTTONS
         assert any(isinstance(b, StopButton) for b in buttons)
         assert any(isinstance(b, ResetMaintenanceButton) for b in buttons)
+
+    def test_hub_reset_buttons_always_created(self, hass_mock):
+        config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
+        buttons = _create_buttons(hass_mock, config)
+        assert any(isinstance(b, ResetYearlyRainButton) for b in buttons)
+        assert any(isinstance(b, ResetYearlyWaterButton) for b in buttons)
 
 
 class TestButtonProperties:
@@ -132,19 +145,27 @@ class TestStopButton:
 class TestButtonDeviceInfo:
     """Test device_info grouping."""
 
-    def test_buttons_have_device_info_from_create(self, hass_mock):
+    def test_zone_buttons_have_zone_device_hub_buttons_have_hub_device(self, hass_mock):
         config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
         buttons = _create_buttons(hass_mock, config, entry_id="test_entry")
         for btn in buttons:
             assert hasattr(btn, "_attr_device_info")
-            assert (DOMAIN, "test_entry_orto") in btn._attr_device_info["identifiers"]
+            identifiers = btn._attr_device_info["identifiers"]
+            if isinstance(btn, (ResetYearlyRainButton, ResetYearlyWaterButton)):
+                assert (DOMAIN, "test_entry") in identifiers  # hub device
+            else:
+                assert (DOMAIN, "test_entry_orto") in identifiers  # zone device
 
     def test_buttons_without_entry_id_have_yaml_device(self, hass_mock):
         config = {CONF_ZONES: [{CONF_ZONE_NAME: "Orto"}]}
         buttons = _create_buttons(hass_mock, config)
         for btn in buttons:
             assert hasattr(btn, "_attr_device_info")
-            assert (DOMAIN, "yaml_orto") in btn._attr_device_info["identifiers"]
+            identifiers = btn._attr_device_info["identifiers"]
+            if isinstance(btn, (ResetYearlyRainButton, ResetYearlyWaterButton)):
+                assert (DOMAIN, "yaml") in identifiers  # hub device
+            else:
+                assert (DOMAIN, "yaml_orto") in identifiers  # zone device
 
 
 class TestIrrigateButton:
@@ -173,4 +194,50 @@ class TestIrrigateButton:
             DOMAIN,
             SERVICE_IRRIGATE_ZONE,
             {ATTR_ZONE_NAME: "Orto"},
+        )
+
+
+class TestResetYearlyRainButton:
+    """The hub button that clears the system-wide yearly rain total."""
+
+    def test_unique_id(self, hass_mock):
+        assert ResetYearlyRainButton(hass_mock)._attr_unique_id == "reset_yearly_rain"
+
+    def test_name(self, hass_mock):
+        assert ResetYearlyRainButton(hass_mock)._attr_name == "Reset yearly rain"
+
+    @pytest.mark.asyncio
+    async def test_press_calls_reset_yearly_rain_service(self, hass_mock):
+        hass_mock.services.async_call = AsyncMock()
+        btn = ResetYearlyRainButton(hass_mock)
+
+        await btn.async_press()
+
+        hass_mock.services.async_call.assert_called_once_with(
+            DOMAIN,
+            SERVICE_RESET_YEARLY_RAIN,
+            {},
+        )
+
+
+class TestResetYearlyWaterButton:
+    """The hub button that clears every zone's yearly irrigated-water total."""
+
+    def test_unique_id(self, hass_mock):
+        assert ResetYearlyWaterButton(hass_mock)._attr_unique_id == "reset_yearly_water"
+
+    def test_name(self, hass_mock):
+        assert ResetYearlyWaterButton(hass_mock)._attr_name == "Reset yearly water"
+
+    @pytest.mark.asyncio
+    async def test_press_calls_reset_yearly_water_service(self, hass_mock):
+        hass_mock.services.async_call = AsyncMock()
+        btn = ResetYearlyWaterButton(hass_mock)
+
+        await btn.async_press()
+
+        hass_mock.services.async_call.assert_called_once_with(
+            DOMAIN,
+            SERVICE_RESET_YEARLY_WATER,
+            {},
         )

--- a/tests/test_controller_handlers.py
+++ b/tests/test_controller_handlers.py
@@ -310,3 +310,79 @@ class TestRegisterServicesMode:
         ctrl = IrrigationController(hass_mock, di_sensor, [zone])
         ctrl.register_services()
         assert len(di_sensor._zone_listeners) > before
+
+
+# ═══════════════════════════════════════════════
+#  _handle_reset_yearly_rain / _handle_reset_yearly_water
+# ═══════════════════════════════════════════════
+
+
+class TestHandleResetYearlyRain:
+    @pytest.mark.asyncio
+    async def test_clears_dryness_yearly_rain(self, controller, di_sensor):
+        di_sensor._yearly_rain = 1500.0
+        await controller._handle_reset_yearly_rain(_make_call({}))
+        assert di_sensor._yearly_rain == 0.0
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_deficit(self, controller, di_sensor):
+        di_sensor._deficit = 12.0
+        di_sensor._yearly_rain = 800.0
+        await controller._handle_reset_yearly_rain(_make_call({}))
+        assert di_sensor._deficit == 12.0  # deficit is a separate concern
+
+    @pytest.mark.asyncio
+    async def test_throttled_call_is_a_noop(self, controller, di_sensor):
+        di_sensor._yearly_rain = 500.0
+        with patch.object(controller, "_is_throttled", return_value=True):
+            await controller._handle_reset_yearly_rain(_make_call({}))
+        assert di_sensor._yearly_rain == 500.0  # skipped while throttled
+
+
+class TestHandleResetYearlyWater:
+    @pytest.mark.asyncio
+    async def test_clears_every_zone_yearly_water(self, controller, zone_orto, zone_prato):
+        zone_orto._yearly_water_delivered = 320.0
+        zone_prato._yearly_water_delivered = 90.0
+        await controller._handle_reset_yearly_water(_make_call({}))
+        assert zone_orto._yearly_water_delivered == 0.0
+        assert zone_prato._yearly_water_delivered == 0.0
+
+    @pytest.mark.asyncio
+    async def test_preserves_lifetime_total(self, controller, zone_orto):
+        zone_orto._yearly_water_delivered = 320.0
+        zone_orto._total_water_delivered = 5000.0
+        await controller._handle_reset_yearly_water(_make_call({}))
+        assert zone_orto._total_water_delivered == 5000.0  # lifetime meter untouched
+
+    @pytest.mark.asyncio
+    async def test_throttled_call_is_a_noop(self, controller, zone_orto):
+        zone_orto._yearly_water_delivered = 200.0
+        with patch.object(controller, "_is_throttled", return_value=True):
+            await controller._handle_reset_yearly_water(_make_call({}))
+        assert zone_orto._yearly_water_delivered == 200.0
+
+
+# ═══════════════════════════════════════════════
+#  DrynessIndexSensor.reset_yearly_rain / IrrigationZoneSensor.reset_yearly_water
+# ═══════════════════════════════════════════════
+
+
+class TestResetYearlyRainMethod:
+    def test_zeroes_total_and_reanchors_year(self, di_sensor):
+        di_sensor._yearly_rain = 1234.0
+        di_sensor._yearly_rain_year = 2020
+        di_sensor.reset_yearly_rain()
+        assert di_sensor._yearly_rain == 0.0
+        assert di_sensor._yearly_rain_year >= 2026  # re-anchored to current year
+
+
+class TestResetYearlyWaterMethod:
+    def test_zeroes_yearly_keeps_total(self, zone_orto):
+        zone_orto._yearly_water_delivered = 77.0
+        zone_orto._total_water_delivered = 999.0
+        zone_orto._yearly_water_year = 2020
+        zone_orto.reset_yearly_water()
+        assert zone_orto._yearly_water_delivered == 0.0
+        assert zone_orto._total_water_delivered == 999.0
+        assert zone_orto._yearly_water_year >= 2026

--- a/tests/test_multi_controller_services.py
+++ b/tests/test_multi_controller_services.py
@@ -19,6 +19,8 @@ from never_dry.const import (
     CONF_ZONE_VALVE,
     DOMAIN,
     SERVICE_IRRIGATE_ZONE,
+    SERVICE_RESET_YEARLY_RAIN,
+    SERVICE_RESET_YEARLY_WATER,
 )
 from never_dry.controller import IrrigationController
 from never_dry.sensor import IrrigationZoneSensor
@@ -185,7 +187,7 @@ class TestRegistrationLifecycle:
         first_count = hass_mock.services.async_register.call_count
         svc.async_setup_services(hass_mock)
 
-        assert first_count == 8
+        assert first_count == 10
         assert hass_mock.services.async_register.call_count == first_count
 
     def test_registers_all_services(self, hass_mock):
@@ -196,7 +198,9 @@ class TestRegistrationLifecycle:
 
         registered = {c.args[1] for c in hass_mock.services.async_register.call_args_list}
         assert SERVICE_IRRIGATE_ZONE in registered
-        assert len(registered) == 8
+        assert SERVICE_RESET_YEARLY_RAIN in registered
+        assert SERVICE_RESET_YEARLY_WATER in registered
+        assert len(registered) == 10
 
     def test_unload_keeps_services_while_controllers_remain(self, hass_mock, two_controllers):
         hass_mock.data[DOMAIN][svc._SERVICES_REGISTERED] = True
@@ -212,7 +216,7 @@ class TestRegistrationLifecycle:
 
         svc.async_unload_services(hass_mock)
 
-        assert hass_mock.services.async_remove.call_count == 8
+        assert hass_mock.services.async_remove.call_count == 10
         assert svc._SERVICES_REGISTERED not in hass_mock.data[DOMAIN]
 
     @pytest.mark.asyncio

--- a/tests/test_sensor_device_classes.py
+++ b/tests/test_sensor_device_classes.py
@@ -105,3 +105,22 @@ class TestDeviceClassDeclarations:
         v = sensor.native_value
         # Must be a timezone-aware datetime, not an ISO string.
         assert isinstance(v, datetime) and v.tzinfo is not None
+
+
+class TestDisplayPrecision:
+    """The mm length sensors must declare suggested_display_precision so HA shows
+    decimals — and, crucially, scales the decimals up when converting mm→in for
+    imperial users (issue #139: values were rounded to integers, useless in in).
+    """
+
+    def test_et_sensor_precision(self, et_sensor):
+        assert et_sensor._attr_suggested_display_precision == 2
+
+    def test_dryness_index_precision(self, di_sensor):
+        assert di_sensor._attr_suggested_display_precision == 1
+
+    def test_zone_deficit_precision(self, di_sensor, zone_orto):
+        assert ZoneDeficitSensor(zone_orto)._attr_suggested_display_precision == 1
+
+    def test_zone_threshold_precision(self, di_sensor, zone_orto):
+        assert ZoneThresholdSensor(zone_orto)._attr_suggested_display_precision == 1

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -14,8 +14,13 @@ from never_dry.const import (
     CONF_ZONE_AREA,
     CONF_ZONE_FLOW_RATE,
     CONF_ZONE_THRESHOLD,
+    DEFAULT_D_MAX,
+    DEFAULT_THRESHOLD,
 )
 from never_dry.controller import IrrigationController
+from never_dry.unit_convert import (
+    MM_TO_IN as _MM_TO_IN,
+)
 from never_dry.unit_convert import (
     c_to_f as _c_to_f,
 )
@@ -28,6 +33,13 @@ from never_dry.unit_convert import (
 from never_dry.unit_convert import (
     zone_input_to_metric as _zone_input_to_metric,
 )
+
+
+# Mirrors the config-flow display rounding (config_flow.py: 2 decimals for
+# inches, issue #139). Kept here so the round-trip test guards the actual UI
+# behaviour without importing the flow (which needs HA fixtures).
+def _mm_to_display_in(mm: float) -> float:
+    return round(mm * _MM_TO_IN, 2)
 
 
 class TestTemperatureConversion:
@@ -95,6 +107,36 @@ class TestZoneInputToMetric:
         data = {CONF_ZONE_AREA: 100.0}
         _zone_input_to_metric(data, is_imperial=True)
         assert data[CONF_ZONE_AREA] == 100.0
+
+
+class TestImperialReconfigureRoundTrip:
+    """Issue #139.3: reconfiguring a zone in imperial must be STABLE — reopening
+    the edit form shows the same inches value the user set, and saving it does
+    not drift the stored mm. With 2-decimal display rounding this is idempotent;
+    with the old 1-decimal rounding every reconfigure nudged the value.
+    """
+
+    def test_threshold_reconfigure_is_idempotent(self):
+        # Metric stored value -> what the imperial form shows...
+        display1 = _mm_to_display_in(DEFAULT_THRESHOLD)
+        # ...what saving it stores back in mm...
+        stored1 = _zone_input_to_metric({CONF_ZONE_THRESHOLD: display1}, is_imperial=True)[CONF_ZONE_THRESHOLD]
+        # ...and reopening the form again.
+        display2 = _mm_to_display_in(stored1)
+        assert display2 == display1  # no manual re-fixing needed on every edit
+
+    def test_d_max_reconfigure_is_idempotent(self):
+        display1 = _mm_to_display_in(DEFAULT_D_MAX)
+        stored1 = _sensors_input_to_metric({CONF_D_MAX: display1}, is_imperial=True)[CONF_D_MAX]
+        display2 = _mm_to_display_in(stored1)
+        assert display2 == display1
+
+    def test_threshold_roundtrip_drift_bounded(self):
+        # First mm -> in(2dp) -> mm conversion must stay within half a display
+        # step (0.01 in = 0.254 mm -> <= 0.13 mm), far tighter than the old 1 dp.
+        display = _mm_to_display_in(DEFAULT_THRESHOLD)
+        stored = _zone_input_to_metric({CONF_ZONE_THRESHOLD: display}, is_imperial=True)[CONF_ZONE_THRESHOLD]
+        assert stored == pytest.approx(DEFAULT_THRESHOLD, abs=0.13)
 
 
 class TestControllerRateToLpm:


### PR DESCRIPTION
## Summary
Adds two hub-level reset buttons so users can clear year-to-date totals that
persist as restore attributes and survive a plain reinstall — the case raised
on the HA community forum (yearly rain stuck at 1500 L after switching rain
sensor type).

This branch chains on top of the imperial-units fix, so the PR carries both.

## Commits
- **fix: imperial units in config flow and displays (#139)** — pre-existing fix, chained.
- **feat(reset): system-wide yearly rain and water reset buttons** — this work.

## Reset buttons (new)
- **Reset yearly rain** → `never_dry.reset_yearly_rain`: zeroes
  `DrynessIndexSensor._yearly_rain` and re-anchors the year, so the shared
  "Rain Yearly" total restarts at 0 and a fresh restore attribute is written.
- **Reset yearly water** → `never_dry.reset_yearly_water`: fans out across all
  zones, zeroing each zone's yearly water delivered while preserving the
  lifetime total.

Both live on the NeverDry hub device, are throttled, and are **state-only** —
recorder long-term statistics (Energy Dashboard) are left untouched.

## Tests
- New: hub button creation/press + controller handlers + sensor reset methods.
- Updated service-count assertions (8 → 10).
- Full suite green, ruff check + format clean.

Covers the global-rain/water part of the reset-buttons backlog item; per-zone
reset remains follow-up.