### PR TITLE
release: v0.11.1-beta.1 — reset buttons + imperial units fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- System-wide reset buttons on the NeverDry hub device ([#142]):
+  - **Reset yearly rain** — clears the shared year-to-date rain total (behind every zone's *Rain Yearly [L]*) without waiting for 1 January. The total is a saved value that survives a restart and a plain reinstall, so this button is the way to clear a wrong figure — e.g. after switching rain sensor type.
+  - **Reset yearly water** — clears *Irrigated Yearly [L]* for every zone at once; each zone's lifetime total is preserved.
+  - Both are state-only: recorder long-term statistics (Energy dashboard) are left untouched.
+
 ### Fixed
 - Imperial units in the config flow and displays ([#139]):
   - Zone threshold help text no longer hardcodes "(mm)" — the field label already shows the user's unit (mm or in).
@@ -47,6 +53,7 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/drake
 
 [Unreleased]: https://github.com/drake69/NeverDry/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/drake69/NeverDry/releases/tag/v0.11.0
+[#142]: https://github.com/drake69/NeverDry/pull/142
 [#139]: https://github.com/drake69/NeverDry/issues/139
 [#123]: https://github.com/drake69/NeverDry/issues/123
 [#116]: https://github.com/drake69/NeverDry/issues/116

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.0"
+  "version": "0.11.1-beta.1"
 }

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -274,6 +274,22 @@ If you want these totals to reflect rain that fell *before* NeverDry was
 installed, that historical rain cannot be reconstructed from a live sensor; the
 totals are only guaranteed correct from the install date forward.
 
+**Resetting the yearly totals.** Both totals reset on their own on 1 January,
+but you can clear them at any time from the **NeverDry** hub device, which
+carries two buttons:
+
+- **Reset yearly rain** — zeroes the system-wide yearly rain total (shared by
+  every zone's *Rain Yearly [L]*). Use it if the figure is wrong — for example
+  after changing rain sensor type — instead of waiting for the new year.
+- **Reset yearly water** — zeroes *Irrigated Yearly [L]* for every zone at once.
+  Each zone's lifetime total is preserved; only the year-to-date figure resets.
+
+Both are **state-only**: they restart the counters from zero but leave your
+historical charts (Energy dashboard statistics) untouched. Note that the yearly
+rain total is kept as a saved value that survives a restart *and a plain
+reinstall* — so if a wrong figure won't go away, this button is the way to clear
+it (reinstalling the integration on its own will not).
+
 ## 7. Irrigation logic — how it all works
 
 This diagram shows the complete irrigation decision flow, from weather data to valve control.


### PR DESCRIPTION
Beta release of the 0.11.1 line.

- Bumps `manifest.json` to **0.11.1-beta.1**.
- Documents the two system-wide reset buttons (Reset yearly rain / Reset yearly water) in the user manual.
- CHANGELOG: adds the reset-buttons entry under Unreleased.

Once merged, tag `v0.11.1-beta.1` on develop triggers the release workflow
(pre-release, HACS beta channel).

Reset-button feature and imperial-units fix already merged via #142.