### PR TITLE
fix(sensor): accrue yearly rain in VWC mode (#144)

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.1"
+  "version": "0.11.1-beta.2"
 }

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -686,15 +686,23 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         dt_h = (now - self._last_update).total_seconds() / 3600.0
         self._last_update = now
 
+        # Yearly rain is a SYSTEM quantity (one sky over the whole garden),
+        # independent of the deficit model — so it must be credited in BOTH
+        # modes. It used to live only in the ET branch below, so VWC mode never
+        # accrued it and every "Rain Yearly" sensor read 0 (issue #144). The
+        # rain baseline lives on this hub, so _compute_rain_delta() runs once
+        # per tick here and its result is reused by the ET branch.
+        rain_delta = self._compute_rain_delta()
+        if rain_delta > 0:
+            self._accrue_yearly_rain(rain_delta)
+
         if self._vwc_sensor:
             self._update_from_vwc()
-            # In VWC mode, broadcast zeros — zones use VWC deficit * Kc
+            # In VWC mode, broadcast zeros — zones use VWC deficit * Kc. Rain is
+            # already credited above; the VWC probe reflects soil moisture
+            # (rain included) directly, so it is not subtracted from deficit.
             self._broadcast_to_zones(0.0, 0.0, 0.0)
         else:
-            rain_delta = self._compute_rain_delta()
-            if rain_delta > 0:
-                self._accrue_yearly_rain(rain_delta)
-
             # Push temp into the buffer (converted to °C if sensor reports °F);
             # invalid/unavailable readings are rejected, median stays stable.
             raw_state = self._hass.states.get(self._temp_sensor)

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -210,6 +210,51 @@ class TestVWCMode:
         sensor._on_sensor_change(MagicMock())
         assert sensor._deficit == 0.0
 
+    def test_vwc_mode_accrues_yearly_rain_after_rain(self, hass_mock, make_state):
+        """Regression for issue #144 — 'Yearly Rain always 0 in VWC mode'.
+
+        Yearly rain is a system-wide quantity independent of the deficit model,
+        so `_on_sensor_change` must credit it (`_compute_rain_delta` →
+        `_accrue_yearly_rain`) in BOTH modes. Previously the credit lived only
+        inside the ET-model ``else`` branch, so the VWC branch bypassed it and
+        ``yearly_rain`` stayed 0 forever, making every zone's 'Rain Yearly'
+        sensor read 0. Guards the fix that hoists the credit above the branch.
+        """
+        from never_dry.const import (
+            CONF_FIELD_CAPACITY,
+            CONF_RAIN_SENSOR,
+            CONF_ROOT_DEPTH,
+            CONF_TEMP_SENSOR,
+            CONF_VWC_SENSOR,
+        )
+        from never_dry.sensor import DrynessIndexSensor
+
+        config = {
+            CONF_TEMP_SENSOR: "sensor.temperature",
+            CONF_RAIN_SENSOR: "sensor.rain",
+            CONF_VWC_SENSOR: "sensor.vwc",
+            CONF_FIELD_CAPACITY: 0.30,
+            CONF_ROOT_DEPTH: 0.30,
+        }
+        sensor = DrynessIndexSensor(hass_mock, config)
+
+        # Steady-state rain baseline (post-restore): the next reading credits
+        # the positive increment. Mirrors test_rain_reduces_deficit (ET path).
+        sensor._last_rain = 0.0
+        sensor._last_rain_event_ts = datetime(2020, 1, 1)
+
+        # 3 mm of rain has fallen; the VWC probe still reads below capacity.
+        hass_mock.states.get.side_effect = lambda eid: {
+            "sensor.temperature": make_state(15.0),
+            "sensor.rain": make_state(3.0),
+            "sensor.vwc": make_state(0.20),
+        }[eid]
+
+        sensor._on_sensor_change(MagicMock())
+
+        # Rain fell → the yearly total must reflect it. Currently stays 0.0.
+        assert sensor.yearly_rain == pytest.approx(3.0, abs=0.01)
+
 
 class TestInvalidInputs:
     """Test handling of invalid or missing sensor data."""


### PR DESCRIPTION
## Summary

Fixes #144 — "Yearly Rain always 0 in VWC mode".

In `DrynessIndexSensor._on_sensor_change`, the yearly-rain credit
(`_compute_rain_delta` → `_accrue_yearly_rain`) lived **only** inside the
ET-model branch. VWC mode takes the other branch and bypasses it, so
`yearly_rain` stayed 0 and every zone's **Rain Yearly** sensor read 0 forever —
even with rain falling and the rain sensor tracked and firing.

## Fix

Hoist the rain-delta credit **above** the VWC/ET branch so it runs in both
modes. Yearly rain is a garden-wide quantity, independent of the deficit model.

- ET path unchanged: it reuses the same `rain_delta` for the deficit.
- VWC path: the probe already reflects soil moisture (rain included), so rain is
  **not** subtracted from the VWC deficit — only accrued to the yearly total.

Same single source also feeds the `yearly_rain_mm` restore attribute and the
zone Lovelace card rain field, so both are fixed too.

## Tests

- New regression test `test_vwc_mode_accrues_yearly_rain_after_rain` (VWC mode
  accrues yearly rain after rain).
- Full suite green locally (783 passed); ET-mode rain tests unchanged.

## Release

Bumps `manifest.json` to `0.11.1-beta.2` so this can ship on the HACS beta
channel for the reporter to validate in the field.
