### PR TITLE
feat(zone): per-zone site exposure (microclimate factor) for Kc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- Per-zone **site exposure**: a microclimate factor (`k_mc`) that multiplies the crop coefficient, so a shaded, windy or paving-adjacent zone keeps its seasonal Kc curve instead of being frozen at one value by a constant Kc override ([#146]). Presets from the landscape coefficient method (0.60 deep shade … 1.20 reflected heat), plus an *Advanced (custom factor)* entry (0.1–1.5). Default *Full sun, open* (×1.00) leaves existing zones unchanged.
+- Zone Kc sensor attributes `kc_base`, `exposure` and `microclimate_factor`, so an effective Kc can be traced back to the curve and the factor it came from.
 
 ## [0.11.0] - 2026-07-26
 
@@ -43,5 +45,6 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/drake
 
 [Unreleased]: https://github.com/drake69/NeverDry/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/drake69/NeverDry/releases/tag/v0.11.0
+[#146]: https://github.com/drake69/NeverDry/issues/146
 [#123]: https://github.com/drake69/NeverDry/issues/123
 [#116]: https://github.com/drake69/NeverDry/issues/116

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ Each zone can be assigned a plant family with seasonal Kc values (northern hemis
 
 You can also set a **manual Kc override** per zone (0.1–2.0) if you know the exact value. Not sure which Kc fits your setup? Use **[NeverDry Planner](https://drake69.github.io/neverdry-planner/)** to calculate the irrigated area and the right Kc to copy directly into NeverDry.
 
+## Site Exposure
+
+Two zones can hold the same plants and still lose water at different rates — one is shaded by the house from 14:00, the other bakes next to a south-facing wall. **Site exposure** captures that with a per-zone factor that *multiplies* the Kc, so the zone keeps its seasonal curve instead of being frozen at one value by a fixed Kc override:
+
+```
+Kc_effective = Kc(plant family or override) × microclimate_factor
+```
+
+| Exposure | Factor |
+|----------|--------|
+| Deep / all-day shade | 0.60 |
+| Morning sun, afternoon shade | 0.75 |
+| Morning shade, afternoon sun | 0.85 |
+| Full sun, open (default) | 1.00 |
+| Windy / exposed | 1.15 |
+| Reflected heat (paving, south-facing wall) | 1.20 |
+| Advanced (custom factor) | 0.1–1.5, your value |
+
+The presets come from the landscape coefficient method (`K_L = k_s × k_d × k_mc`, Costello, Matheny & Clark 2000), where the plant family plays the species factor `k_s` and exposure the microclimate factor `k_mc`. Values above 1.0 are deliberate: paving and walls really do push a zone past reference ET. Leaving exposure at *Full sun, open* changes nothing, so existing zones keep behaving exactly as before.
+
 ---
 
 ## Installation
@@ -202,6 +222,8 @@ NeverDry is configured entirely through the UI — no YAML required.
 | Efficiency | No | (from type) | Override distribution efficiency [0.1–1.0] |
 | Plant family | No | — | Sets seasonal Kc profile |
 | Custom Kc | No | — | Override Kc [0.1–2.0] — use [NeverDry Planner](https://drake69.github.io/neverdry-planner/) to estimate it |
+| Site exposure | No | Full sun, open | Sun/wind exposure preset — multiplies the Kc [0.60–1.20] |
+| Custom microclimate factor | Advanced only | — | Explicit exposure factor [0.1–1.5], used when exposure is *Advanced* |
 | Guard flow rate | For timer mode | — | Valve flow rate [L/min]. Required for timer-based zones; recommended for flow-meter and volume-dosing zones too, where it drives the expected duration and the safety-timeout scaling |
 | Threshold | No | 20.0 | Mode A trigger [mm] |
 | Battery sensor | No | — | Valve battery sensor — mirrored in the zone device card |
@@ -219,7 +241,7 @@ The model is based on FAO-56 (Allen et al., 1998):
 D_zone(t) = clamp(D_zone(t-1) + ET_h × Kc × Δt − ΔP,  0,  D_max)
 
 ET_h = max(0, α × (T − T_base) / 24)     [mm/h]  evapotranspiration
-Kc   = f(day_of_year, plant_family)        [—]     crop coefficient
+Kc   = f(day_of_year, plant_family) × k_mc [—]     crop coefficient × site exposure
 ΔP   = rain_delta(sensor_type)             [mm]    precipitation increment
 V    = D_zone × Area / Efficiency          [L]     volume needed
 t    = V / FlowRate × 60                   [s]     irrigation duration

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -30,11 +30,13 @@ from .const import (
     CONF_ZONE_DELIVERY_MODE,
     CONF_ZONE_DELIVERY_TIMEOUT,
     CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_EXPOSURE,
     CONF_ZONE_FLOW_METER_SENSOR,
     CONF_ZONE_FLOW_RATE,
     CONF_ZONE_IRRIGATION_MODE,
     CONF_ZONE_IRRIGATION_TIME,
     CONF_ZONE_KC,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
     CONF_ZONE_NAME,
     CONF_ZONE_PLANT_FAMILY,
     CONF_ZONE_SYSTEM_TYPE,
@@ -47,6 +49,7 @@ from .const import (
     DEFAULT_D_MAX,
     DEFAULT_DELIVERY_MODE,
     DEFAULT_DELIVERY_TIMEOUT_S,
+    DEFAULT_EXPOSURE,
     DEFAULT_IRRIGATION_MODE,
     DEFAULT_IRRIGATION_TIME,
     DEFAULT_RAIN_SENSOR_TYPE,
@@ -56,11 +59,14 @@ from .const import (
     DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
     DOMAIN,
+    EXPOSURES,
     IRRIGATION_MODE_MANUAL,
     IRRIGATION_MODE_REACTIVE,
     IRRIGATION_MODE_SCHEDULED,
     MAX_ZONE_NAME_LENGTH,
     MAX_ZONES,
+    MICROCLIMATE_FACTOR_MAX,
+    MICROCLIMATE_FACTOR_MIN,
     PLANT_FAMILIES,
     RAIN_TYPE_DAILY_TOTAL,
     RAIN_TYPE_EVENT,
@@ -275,6 +281,21 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
             vol.Optional(CONF_ZONE_KC): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=0.1, max=2.0, step=0.05, mode="box")
             ),
+            vol.Optional(CONF_ZONE_EXPOSURE, default=DEFAULT_EXPOSURE): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(EXPOSURES.keys()),
+                    translation_key="exposure",
+                    mode="dropdown",
+                )
+            ),
+            vol.Optional(CONF_ZONE_MICROCLIMATE_FACTOR): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MICROCLIMATE_FACTOR_MIN,
+                    max=MICROCLIMATE_FACTOR_MAX,
+                    step=0.05,
+                    mode="box",
+                )
+            ),
             vol.Optional(CONF_ZONE_FLOW_RATE): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=2.0 if is_imperial else 1.0,
@@ -360,6 +381,22 @@ def _confirm_zone_schema() -> vol.Schema:
     return vol.Schema({vol.Required("confirm", default=False): bool})
 
 
+def _exposure_errors(user_input: dict) -> dict[str, str]:
+    """Reject a factor-driven exposure ('Advanced') without a factor.
+
+    A missing factor resolves to a neutral 1.0, so the zone would silently
+    behave as if no exposure had been picked. Keyed on the EXPOSURES ``None``
+    marker like ``resolve_microclimate_factor``; an exposure missing from the
+    table is left to the resolver's fallback.
+    """
+    exposure = user_input.get(CONF_ZONE_EXPOSURE)
+    if exposure not in EXPOSURES or EXPOSURES[exposure]["factor"] is not None:
+        return {}
+    if user_input.get(CONF_ZONE_MICROCLIMATE_FACTOR) is None:
+        return {CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required"}
+    return {}
+
+
 def _coerce_delivery_mode(user_input: dict) -> dict:
     """Downgrade delivery_mode to estimated_flow when the required sensor is missing."""
     dm = user_input.get(CONF_ZONE_DELIVERY_MODE)
@@ -402,6 +439,7 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             name = user_input.get(CONF_ZONE_NAME, "")
             mode = user_input.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
+            exposure_errors = _exposure_errors(user_input)
             if len(name) > MAX_ZONE_NAME_LENGTH:
                 errors[CONF_ZONE_NAME] = "zone_name_too_long"
             elif len(self._zones) >= MAX_ZONES:
@@ -412,6 +450,8 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_ZONE_FLOW_METER_SENSOR] = "flow_meter_required"
             elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
                 errors[CONF_ZONE_VOLUME_ENTITY] = "volume_entity_required"
+            elif exposure_errors:
+                errors.update(exposure_errors)
             else:
                 zone_metric = _zone_input_to_metric(user_input, imperial)
                 self._pending_warnings = _unusual_zone_values(zone_metric, imperial)
@@ -550,6 +590,13 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                     data_schema=_zone_schema_initial(imperial),
                     errors={"base": "zone_already_exists"},
                 )
+            exposure_errors = _exposure_errors(user_input)
+            if exposure_errors:
+                return self.async_show_form(
+                    step_id="add_zone",
+                    data_schema=_zone_schema_initial(imperial),
+                    errors=exposure_errors,
+                )
             self._pending_warnings = _unusual_zone_values(user_input, imperial)
             if self._pending_warnings:
                 self._pending_zone = user_input
@@ -611,15 +658,22 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         )
 
         imperial = _is_imperial(self.hass)
+        errors: dict[str, str] = {}
         if user_input is not None:
             user_input = _zone_input_to_metric(user_input, imperial)
-            user_input = _coerce_delivery_mode(user_input)
-            self._pending_warnings = _unusual_zone_values(user_input, imperial)
-            if self._pending_warnings:
-                self._pending_zone = user_input
-                self._pending_action = "edit"
-                return await self.async_step_confirm_zone()
-            return self._save_edited_zone(user_input)
+            errors = _exposure_errors(user_input)
+            if not errors:
+                user_input = _coerce_delivery_mode(user_input)
+                self._pending_warnings = _unusual_zone_values(user_input, imperial)
+                if self._pending_warnings:
+                    self._pending_zone = user_input
+                    self._pending_action = "edit"
+                    return await self.async_step_confirm_zone()
+                return self._save_edited_zone(user_input)
+            # Seed the redrawn form from what was submitted, not merged over
+            # the stored zone: a cleared optional is absent from user_input, so
+            # a merge would resurrect the factor this error asks for.
+            cur = dict(user_input)
 
         area_unit = "ft²" if imperial else "m²"
         flow_unit = "gal/h" if imperial else "L/h"
@@ -656,6 +710,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             SYSTEM_TYPE_MANUAL,
         ]
         pf_opts = list(PLANT_FAMILIES.keys())
+        ex_opts = list(EXPOSURES.keys())
         ent_sw = selector.EntitySelectorConfig(domain="switch")
         ent_sn = selector.EntitySelectorConfig(domain="sensor")
         ent_nr = selector.EntitySelectorConfig(domain="number")
@@ -730,6 +785,27 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                     selector.NumberSelectorConfig(
                         min=0.1,
                         max=2.0,
+                        step=0.05,
+                        mode="box",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_EXPOSURE,
+                    default=_d(CONF_ZONE_EXPOSURE, DEFAULT_EXPOSURE),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=ex_opts,
+                        translation_key="exposure",
+                        mode="dropdown",
+                    )
+                ),
+                vol.Optional(
+                    CONF_ZONE_MICROCLIMATE_FACTOR,
+                    default=_d(CONF_ZONE_MICROCLIMATE_FACTOR),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MICROCLIMATE_FACTOR_MIN,
+                        max=MICROCLIMATE_FACTOR_MAX,
                         step=0.05,
                         mode="box",
                     )
@@ -811,6 +887,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="edit_zone_detail",
             data_schema=schema,
+            errors=errors,
             description_placeholders={"zone_name": self._edit_zone_name},
         )
 

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -38,6 +38,8 @@ CONF_ZONE_THRESHOLD = "threshold"
 CONF_ZONE_SYSTEM_TYPE = "system_type"
 CONF_ZONE_PLANT_FAMILY = "plant_family"
 CONF_ZONE_KC = "kc"
+CONF_ZONE_EXPOSURE = "exposure"
+CONF_ZONE_MICROCLIMATE_FACTOR = "microclimate_factor"
 CONF_ZONE_DELIVERY_MODE = "delivery_mode"
 CONF_ZONE_VOLUME_ENTITY = "volume_entity"
 CONF_ZONE_FLOW_METER_SENSOR = "flow_meter_sensor"
@@ -88,6 +90,41 @@ PLANT_FAMILIES = {
 }
 
 KC_ANCHOR_DAYS = (15, 105, 196, 288)
+
+# ── Site exposure (microclimate factor, kmc) ─────────────
+# Landscape coefficient method: KL = ks * kd * kmc (Costello et al. 2000).
+# The plant family is ks, this is kmc — multiplied onto the Kc so a shaded
+# zone keeps its seasonal curve instead of being frozen by a constant Kc
+# override (#146). Above 1.0 is intentional: paving and walls push a zone
+# past reference ET.
+EXPOSURE_DEEP_SHADE = "deep_shade"
+EXPOSURE_MORNING_SUN = "morning_sun"
+EXPOSURE_AFTERNOON_SUN = "afternoon_sun"
+EXPOSURE_FULL_SUN = "full_sun"
+EXPOSURE_WINDY = "windy"
+EXPOSURE_REFLECTED_HEAT = "reflected_heat"
+EXPOSURE_CUSTOM = "custom"
+
+# ``factor: None`` reads the value from CONF_ZONE_MICROCLIMATE_FACTOR
+# instead; the resolver and the flow guard both key off that marker, not the
+# "custom" name. ``label`` is developer-facing only, as in PLANT_FAMILIES:
+# the dropdown text comes from selector.exposure in the translations.
+EXPOSURES = {
+    EXPOSURE_DEEP_SHADE: {"label": "Deep / all-day shade", "factor": 0.60},
+    EXPOSURE_MORNING_SUN: {"label": "Morning sun, afternoon shade", "factor": 0.75},
+    EXPOSURE_AFTERNOON_SUN: {"label": "Morning shade, afternoon sun", "factor": 0.85},
+    EXPOSURE_FULL_SUN: {"label": "Full sun, open", "factor": 1.00},
+    EXPOSURE_WINDY: {"label": "Windy / exposed", "factor": 1.15},
+    EXPOSURE_REFLECTED_HEAT: {"label": "Reflected heat (paving, south-facing wall)", "factor": 1.20},
+    EXPOSURE_CUSTOM: {"label": "Advanced (custom factor)", "factor": None},
+}
+
+DEFAULT_EXPOSURE = EXPOSURE_FULL_SUN
+DEFAULT_MICROCLIMATE_FACTOR = 1.0
+# Floored above zero: at 0 the deficit never accrues, so every irrigation
+# trigger goes silent with nothing in the UI to explain why.
+MICROCLIMATE_FACTOR_MIN = 0.1
+MICROCLIMATE_FACTOR_MAX = 1.5
 
 # ── Valve delivery modes ────────────────────────────────
 DELIVERY_MODE_VOLUME_PRESET = "volume_preset"

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_ZONE_DELIVERY_MODE,
     CONF_ZONE_DELIVERY_TIMEOUT,
     CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_EXPOSURE,
     CONF_ZONE_FLOW_METER_SENSOR,
     CONF_ZONE_FLOW_RATE,
     CONF_ZONE_HW_MAX_DURATION_PAYLOAD,
@@ -63,6 +64,7 @@ from .const import (
     CONF_ZONE_IRRIGATION_MODE,
     CONF_ZONE_IRRIGATION_TIME,
     CONF_ZONE_KC,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
     CONF_ZONE_NAME,
     CONF_ZONE_PLANT_FAMILY,
     CONF_ZONE_SYSTEM_TYPE,
@@ -79,6 +81,7 @@ from .const import (
     DEFAULT_FIELD_CAPACITY,
     DEFAULT_INTER_ZONE_DELAY,
     DEFAULT_KC,
+    DEFAULT_MICROCLIMATE_FACTOR,
     DEFAULT_RAIN_SENSOR_TYPE,
     DEFAULT_ROOT_DEPTH,
     DEFAULT_T_BASE,
@@ -89,7 +92,10 @@ from .const import (
     ET_BUFFER_MIN_READINGS,
     ET_BUFFER_SIZE,
     ET_TEMP_VALID_RANGE,
+    EXPOSURES,
     KC_ANCHOR_DAYS,
+    MICROCLIMATE_FACTOR_MAX,
+    MICROCLIMATE_FACTOR_MIN,
     PLANT_FAMILIES,
     RAIN_TYPE_EVENT,
     SYSTEM_TYPES,
@@ -176,23 +182,71 @@ def _to_celsius(state) -> float | None:
 # ══════════════════════════════════════════════════════════
 
 
+def _as_finite_float(value) -> float | None:
+    """Parse ``value`` to a finite float, or ``None`` if it is not one."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def resolve_microclimate_factor(
+    exposure: str | None,
+    custom_factor: float | None = None,
+) -> float:
+    """Resolve a zone's microclimate factor (kmc) from its exposure setting.
+
+    Presets carry their own factor; a ``None`` table factor (custom) reads
+    ``custom_factor``, clamped to the MIN/MAX bounds.
+
+    Total by design: anything unset, unknown or non-numeric gives a neutral
+    1.0 — never 0, which would freeze the deficit, and never an exception,
+    which would abort setup for every zone in the entry. Callers log the
+    fallback in their own context.
+    """
+    if not isinstance(exposure, str) or exposure not in EXPOSURES:
+        return DEFAULT_MICROCLIMATE_FACTOR
+    preset = EXPOSURES[exposure]["factor"]
+    if preset is not None:
+        return preset
+
+    value = _as_finite_float(custom_factor)
+    if value is None:
+        return DEFAULT_MICROCLIMATE_FACTOR
+    return min(max(value, MICROCLIMATE_FACTOR_MIN), MICROCLIMATE_FACTOR_MAX)
+
+
 def compute_kc(
     day_of_year: int,
     plant_family: str | None,
     manual_kc: float | None,
     latitude: float = 45.0,
+    microclimate_factor: float = DEFAULT_MICROCLIMATE_FACTOR,
 ) -> float:
-    """Compute the crop coefficient for a given day of year.
+    """Compute the effective crop coefficient for a given day of year.
 
-    Priority: manual_kc > plant_family seasonal profile > DEFAULT_KC (1.0).
+    ``Kc = base * microclimate_factor``, base being
+    manual_kc > plant_family seasonal profile > DEFAULT_KC (1.0).
 
-    The seasonal profile uses 4 anchor points (winter, spring, summer,
-    autumn) with linear interpolation.  For southern hemisphere
-    (latitude < 0) the day is shifted by 182 days.
+    The factor applies to both bases on purpose: it describes the site, not
+    the planting, so a shaded zone keeps its seasonal shape (#146).
     """
-    if manual_kc is not None:
-        return manual_kc
+    base = _seasonal_kc(day_of_year, plant_family, latitude) if manual_kc is None else manual_kc
+    return round(base * microclimate_factor, 4)
 
+
+def _seasonal_kc(
+    day_of_year: int,
+    plant_family: str | None,
+    latitude: float = 45.0,
+) -> float:
+    """Interpolate a plant family's seasonal Kc profile for a day of year.
+
+    The profile uses 4 anchor points (winter, spring, summer, autumn) with
+    linear interpolation.  For southern hemisphere (latitude < 0) the day
+    is shifted by 182 days. Unknown or missing family: DEFAULT_KC (1.0).
+    """
     if plant_family is None or plant_family not in PLANT_FAMILIES:
         return DEFAULT_KC
 
@@ -1033,9 +1087,43 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._yearly_water_year: int = datetime.now().year
         self._session_water_delivered: float = 0.0
 
-        # Kc: manual override > plant family seasonal profile > 1.0
+        # Kc: manual override > plant family seasonal profile > 1.0,
+        # scaled by the site-exposure microclimate factor (kmc).
         self._plant_family = zone_config.get(CONF_ZONE_PLANT_FAMILY)
         self._manual_kc = zone_config.get(CONF_ZONE_KC)
+        self._exposure = zone_config.get(CONF_ZONE_EXPOSURE)
+        configured_factor = zone_config.get(CONF_ZONE_MICROCLIMATE_FACTOR)
+        self._microclimate_factor = resolve_microclimate_factor(self._exposure, configured_factor)
+        zone_label = zone_config.get(CONF_ZONE_NAME, "?")
+        if self._exposure is not None and self._exposure not in EXPOSURES:
+            _LOGGER.warning(
+                "Zone '%s': unknown exposure %r — using a neutral microclimate factor of %.2f",
+                zone_label,
+                self._exposure,
+                self._microclimate_factor,
+            )
+        elif self._exposure is not None and EXPOSURES[self._exposure]["factor"] is None:
+            # Against the parsed value: a stored "0.65" resolves to 0.65 and
+            # must not warn about itself.
+            if self._microclimate_factor != _as_finite_float(configured_factor):
+                _LOGGER.warning(
+                    "Zone '%s': custom microclimate factor %r is missing or outside [%.2f, %.2f], using %.2f instead",
+                    zone_label,
+                    configured_factor,
+                    MICROCLIMATE_FACTOR_MIN,
+                    MICROCLIMATE_FACTOR_MAX,
+                    self._microclimate_factor,
+                )
+        elif configured_factor is not None:
+            # The number field is shown for every exposure, so leave a trace
+            # when a preset silently wins over it.
+            _LOGGER.debug(
+                "Zone '%s': exposure %r is a preset (%.2f), ignoring microclimate factor %r",
+                zone_label,
+                self._exposure,
+                self._microclimate_factor,
+                configured_factor,
+            )
 
         # Per-zone deficit
         self._zone_deficit = 0.0
@@ -1108,7 +1196,15 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             return 45.0
 
     def _get_current_kc(self) -> float:
-        """Compute the current Kc for this zone."""
+        """Effective Kc for this zone (base * exposure).
+
+        Derived from ``_get_base_kc()`` so the two values published side by
+        side in the attributes can never come from different days.
+        """
+        return round(self._get_base_kc() * self._microclimate_factor, 4)
+
+    def _get_base_kc(self) -> float:
+        """Kc before the site-exposure factor (plant family curve or override)."""
         doy = datetime.now().timetuple().tm_yday
         return compute_kc(doy, self._plant_family, self._manual_kc, self._get_latitude())
 
@@ -1320,7 +1416,10 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             "system_type": self._system_type,
             "plant_family": self._plant_family,
             "kc": round(kc, 3),
+            "kc_base": round(self._get_base_kc(), 3),
             "kc_override": self._manual_kc,
+            "exposure": self._exposure,
+            "microclimate_factor": self._microclimate_factor,
             "area_m2": self._area,
             "efficiency": self._efficiency,
             "flow_rate_lpm": self._flow_rate,
@@ -1855,7 +1954,7 @@ class ZoneEfficiencySensor(_ZoneTextSensor):
 
 
 class ZoneKcSensor(_ZoneTextSensor):
-    """Current crop coefficient Kc."""
+    """Current crop coefficient Kc (effective: base curve * site exposure)."""
 
     def __init__(self, zone_sensor, device_info=None):
         super().__init__(
@@ -1874,6 +1973,20 @@ class ZoneKcSensor(_ZoneTextSensor):
     @property
     def native_value(self) -> float:
         return round(self._zone_sensor._get_current_kc(), 3)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Break the effective Kc into its two factors.
+
+        A shaded zone reads 0.53 in October; this shows it as the 0.70 lawn
+        curve times a 0.75 exposure factor.
+        """
+        zone = self._zone_sensor
+        return {
+            "kc_base": round(zone._get_base_kc(), 3),
+            "exposure": zone._exposure,
+            "microclimate_factor": zone._microclimate_factor,
+        }
 
 
 # ══════════════════════════════════════════════════════════

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -35,6 +35,8 @@
           "efficiency": "Custom efficiency (overrides system type default)",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc (overrides plant family)",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Valve flow rate (estimated_flow only)",
           "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
           "volume_entity": "Volume target entity (volume_preset only)",
@@ -52,6 +54,8 @@
           "efficiency": "Leave empty to use the system type default. Set to override",
           "plant_family": "Select the type of plants in this zone. Sets a seasonal crop coefficient (Kc) that adjusts water demand throughout the year",
           "kc": "Leave empty to use the plant family seasonal profile. Set to override with a fixed Kc value (0.1–2.0)",
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)",
           "flow_rate_lpm": "Water flow rate of the valve in liters per minute. Required for estimated_flow mode. Measure with a bucket and stopwatch",
           "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
@@ -81,6 +85,7 @@
       "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
       "flow_meter_required": "Flow meter sensor is required for flow_meter delivery mode",
       "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "microclimate_factor_required": "A custom microclimate factor is required when site exposure is set to Advanced",
       "zone_already_exists": "A zone with this name already exists"
     },
     "abort": {
@@ -120,6 +125,8 @@
           "efficiency": "Custom efficiency",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Valve flow rate",
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
@@ -127,6 +134,10 @@
           "irrigation_mode": "Irrigation mode",
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
+        },
+        "data_description": {
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)"
         }
       },
       "confirm_zone": {
@@ -153,6 +164,8 @@
           "efficiency": "Custom efficiency",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Valve flow rate",
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
@@ -160,6 +173,10 @@
           "irrigation_mode": "Irrigation mode",
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
+        },
+        "data_description": {
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)"
         }
       },
       "check_zones": {
@@ -172,6 +189,9 @@
           "zone_to_remove": "Zone to remove"
         }
       }
+    },
+    "error": {
+      "microclimate_factor_required": "A custom microclimate factor is required when site exposure is set to Advanced"
     },
     "abort": {
       "no_zones": "No zones configured"
@@ -218,6 +238,17 @@
         "estimated_flow": "Simple on/off — timer-based (default)",
         "flow_meter": "Valve with flow meter sensor",
         "volume_preset": "Smart valve with volume dosing"
+      }
+    },
+    "exposure": {
+      "options": {
+        "deep_shade": "Deep / all-day shade (×0.60)",
+        "morning_sun": "Morning sun, afternoon shade (×0.75)",
+        "afternoon_sun": "Morning shade, afternoon sun (×0.85)",
+        "full_sun": "Full sun, open (×1.00 — default)",
+        "windy": "Windy / exposed (×1.15)",
+        "reflected_heat": "Reflected heat — paving, south-facing wall (×1.20)",
+        "custom": "Advanced (custom factor)"
       }
     }
   }

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -35,6 +35,8 @@
           "efficiency": "Custom efficiency (overrides system type default)",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc (overrides plant family)",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Guard flow rate (all modes; required for estimated_flow)",
           "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
           "volume_entity": "Volume target entity (volume_preset only)",
@@ -52,6 +54,8 @@
           "efficiency": "Leave empty to use the system type default. Set to override",
           "plant_family": "Select the type of plants in this zone. Sets a seasonal crop coefficient (Kc) that adjusts water demand throughout the year",
           "kc": "Leave empty to use the plant family seasonal profile. Set to override with a fixed Kc value (0.1–2.0)",
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)",
           "flow_rate_lpm": "Water flow rate of the valve in liters per hour (gal/h in imperial). Required for estimated_flow mode; recommended for flow_meter and volume_preset, where it drives the expected duration and the safety-timeout scaling (will become required in a future release). Measure with a bucket and stopwatch",
           "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
           "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
@@ -81,6 +85,7 @@
       "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
       "flow_meter_required": "Flow meter sensor is required for flow_meter delivery mode",
       "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "microclimate_factor_required": "A custom microclimate factor is required when site exposure is set to Advanced",
       "zone_already_exists": "A zone with this name already exists"
     },
     "abort": {
@@ -124,6 +129,8 @@
           "efficiency": "Custom efficiency",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Valve flow rate",
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
@@ -131,6 +138,10 @@
           "irrigation_mode": "Irrigation mode",
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
+        },
+        "data_description": {
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)"
         }
       },
       "confirm_zone": {
@@ -157,6 +168,8 @@
           "efficiency": "Custom efficiency",
           "plant_family": "Plant family",
           "kc": "Custom crop coefficient Kc",
+          "exposure": "Site exposure",
+          "microclimate_factor": "Custom microclimate factor (Advanced only)",
           "flow_rate_lpm": "Valve flow rate",
           "flow_meter_sensor": "Flow meter sensor",
           "volume_entity": "Volume target entity",
@@ -164,6 +177,10 @@
           "irrigation_mode": "Irrigation mode",
           "threshold": "Irrigation threshold",
           "irrigation_time": "Daily irrigation time"
+        },
+        "data_description": {
+          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value",
+          "microclimate_factor": "Only used when exposure is \"Advanced (custom factor)\". Range 0.1–1.5. Above 1.0 for zones that exceed reference ET (paving, south-facing wall)"
         }
       },
       "check_zones": {
@@ -176,6 +193,9 @@
           "zone_to_remove": "Zone to remove"
         }
       }
+    },
+    "error": {
+      "microclimate_factor_required": "A custom microclimate factor is required when site exposure is set to Advanced"
     },
     "abort": {
       "no_zones": "No zones configured"
@@ -222,6 +242,17 @@
         "estimated_flow": "Simple on/off — timer-based (default)",
         "flow_meter": "Valve with flow meter sensor",
         "volume_preset": "Smart valve with volume dosing"
+      }
+    },
+    "exposure": {
+      "options": {
+        "deep_shade": "Deep / all-day shade (×0.60)",
+        "morning_sun": "Morning sun, afternoon shade (×0.75)",
+        "afternoon_sun": "Morning shade, afternoon sun (×0.85)",
+        "full_sun": "Full sun, open (×1.00 — default)",
+        "windy": "Windy / exposed (×1.15)",
+        "reflected_heat": "Reflected heat — paving, south-facing wall (×1.20)",
+        "custom": "Advanced (custom factor)"
       }
     }
   }

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -35,6 +35,8 @@
           "efficiency": "Efficienza personalizzata (sovrascrive il valore predefinito del tipo di impianto)",
           "plant_family": "Famiglia di piante",
           "kc": "Coefficiente colturale Kc personalizzato (sovrascrive la famiglia di piante)",
+          "exposure": "Esposizione del sito",
+          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
           "flow_rate_lpm": "Portata di guardia (tutte le modalità; richiesta per estimated_flow)",
           "flow_meter_sensor": "Sensore del flussometro (solo per flow_meter)",
           "volume_entity": "Entità target del volume (solo per volume_preset)",
@@ -52,6 +54,8 @@
           "efficiency": "Lascia vuoto per utilizzare il valore predefinito del tipo di impianto. Imposta per sovrascriverlo",
           "plant_family": "Seleziona il tipo di piante in questa zona. Imposta un coefficiente colturale stagionale (Kc) che adatta il fabbisogno idrico durante l'anno",
           "kc": "Lascia vuoto per utilizzare il profil stagionale della famiglia di piante. Imposta per sovrascriverlo con un valore Kc fisso (0.1–2.0)",
+          "exposure": "Quanto sole e vento riceve questa zona rispetto a un'area aperta. Moltiplica il Kc, così la zona mantiene la sua curva stagionale invece di essere bloccata su un valore fisso",
+          "microclimate_factor": "Usato solo quando l'esposizione è «Avanzato (fattore personalizzato)». Intervallo 0.1–1.5. Sopra 1.0 per le zone che superano l'ET di riferimento (pavimentazione, muro esposto a sud)",
           "flow_rate_lpm": "Portata d'acqua della valvola in litri all'ora (gal/h in imperiale). Richiesta per la modalità estimated_flow; raccomandata per flow_meter e volume_preset, dove determina la durata prevista e la scalatura del timeout di sicurezza (diventerà obbligatoria in una release futura). Misurala con un secchio e un cronometro",
           "flow_meter_sensor": "Entità sensore che rileva i litri cumulativi erogati. Richiesto per la modalità flow_meter",
           "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
@@ -81,6 +85,7 @@
       "flow_rate_required": "La portata è richiesta per la modalità di erogazione estimated_flow",
       "flow_meter_required": "Il sensore del flussometro è richiesto per la modalità di erogazione flow_meter",
       "volume_entity_required": "L'entità del volume è richiesta per la modalità di erogazione volume_preset",
+      "microclimate_factor_required": "È richiesto un fattore microclima personalizzato quando l'esposizione del sito è impostata su Avanzato",
       "zone_already_exists": "Esiste già una zona con questo nome"
     },
     "abort": {
@@ -124,6 +129,8 @@
           "efficiency": "Efficienza personalizzata",
           "plant_family": "Famiglia di piante",
           "kc": "Coefficiente colturale Kc personalizzato",
+          "exposure": "Esposizione del sito",
+          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
           "flow_rate_lpm": "Portata della valvola",
           "flow_meter_sensor": "Sensore del flussometro",
           "volume_entity": "Entità target del volume",
@@ -131,6 +138,10 @@
           "irrigation_mode": "Modalità di irrigazione",
           "threshold": "Soglia di irrigazione",
           "irrigation_time": "Orario di irrigazione giornaliero"
+        },
+        "data_description": {
+          "exposure": "Quanto sole e vento riceve questa zona rispetto a un'area aperta. Moltiplica il Kc, così la zona mantiene la sua curva stagionale invece di essere bloccata su un valore fisso",
+          "microclimate_factor": "Usato solo quando l'esposizione è «Avanzato (fattore personalizzato)». Intervallo 0.1–1.5. Sopra 1.0 per le zone che superano l'ET di riferimento (pavimentazione, muro esposto a sud)"
         }
       },
       "confirm_zone": {
@@ -157,6 +168,8 @@
           "efficiency": "Efficienza personalizzata",
           "plant_family": "Famiglia di piante",
           "kc": "Coefficiente colturale Kc personalizzato",
+          "exposure": "Esposizione del sito",
+          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
           "flow_rate_lpm": "Portata della valvola",
           "flow_meter_sensor": "Sensore del flussometro",
           "volume_entity": "Entità target del volume",
@@ -164,6 +177,10 @@
           "irrigation_mode": "Modalità di irrigazione",
           "threshold": "Soglia di irrigazione",
           "irrigation_time": "Orario di irrigazione giornaliero"
+        },
+        "data_description": {
+          "exposure": "Quanto sole e vento riceve questa zona rispetto a un'area aperta. Moltiplica il Kc, così la zona mantiene la sua curva stagionale invece di essere bloccata su un valore fisso",
+          "microclimate_factor": "Usato solo quando l'esposizione è «Avanzato (fattore personalizzato)». Intervallo 0.1–1.5. Sopra 1.0 per le zone che superano l'ET di riferimento (pavimentazione, muro esposto a sud)"
         }
       },
       "check_zones": {
@@ -176,6 +193,9 @@
           "zone_to_remove": "Zona da rimuovere"
         }
       }
+    },
+    "error": {
+      "microclimate_factor_required": "È richiesto un fattore microclima personalizzato quando l'esposizione del sito è impostata su Avanzato"
     },
     "abort": {
       "no_zones": "Nessuna zona configurata"
@@ -222,6 +242,17 @@
         "estimated_flow": "Semplice On/Off (calcolo del tempo in base alla portata)",
         "flow_meter": "Valvola con sensore flussometro",
         "volume_preset": "Valvola smart con dosaggio a volume"
+      }
+    },
+    "exposure": {
+      "options": {
+        "deep_shade": "Ombra profonda / tutto il giorno (×0.60)",
+        "morning_sun": "Sole al mattino, ombra al pomeriggio (×0.75)",
+        "afternoon_sun": "Ombra al mattino, sole al pomeriggio (×0.85)",
+        "full_sun": "Pieno sole, area aperta (×1.00 — predefinito)",
+        "windy": "Ventoso / esposto (×1.15)",
+        "reflected_heat": "Calore riflesso — pavimentazione, muro a sud (×1.20)",
+        "custom": "Avanzato (fattore personalizzato)"
       }
     }
   }

--- a/docs/design/scientific-model.md
+++ b/docs/design/scientific-model.md
@@ -161,6 +161,43 @@ t_irr = V / Q            [min]
 | Pop-up sprinklers | 0.60 – 0.75 |
 | Manual / hose | 0.50 – 0.70 |
 
+### 4.2 Site exposure (microclimate factor)
+
+The per-zone `Kc` above is the product of a planting term and a site term,
+following the landscape coefficient method of Costello et al. (2000) [38]:
+
+```
+K_L      = k_s · k_d · k_mc
+Kc_zone  = Kc(doy, plant_family | manual override) · k_mc
+```
+
+`k_s` (species) is what the plant-family seasonal profile represents; `k_mc`
+(microclimate) is the zone's site exposure — shade, wind, or heat radiated
+back from paving and walls. `k_d` (density) is not modelled: residential
+zones are configured as whole irrigated areas, so canopy density is already
+folded into the family profile.
+
+The factor multiplies the planting term rather than replacing it, which is
+the point of the parameter: a constant `Kc` freezes a shaded zone at one
+season's value, and the resulting error is largest in autumn (a lawn shaded
+from 14:00 drifts ~33% high by mid-October), precisely when over-watering
+shaded turf promotes disease.
+
+`k_mc` presets span 0.60 (deep shade) to 1.20 (reflected heat), with 1.00
+for the open, reference-like condition. The source literature gives
+0.5 – 0.9 for shaded and wind-sheltered sites and values above 1.0 for
+paved or wall-adjacent sites, where advective heating pushes a planting past
+reference ET. The specific preset values are **expert judgment, not
+validated measurements** (see §6.2).
+
+In VWC mode the zone deficit is `D_zone = D_ref · Kc_zone`, so `k_mc` rides
+along with `Kc` there too. The reference probe sits in one spot, not in each
+zone, so scaling it per zone is the existing premise of that mode rather than
+something the factor introduces. `Kc_zone` combines multiplicatively with a
+manual override, so a high override and an above-1.0 exposure do multiply out
+(2.0 × 1.20 = 2.4); this is deliberately not capped, since capping would
+silently contradict two explicit user choices.
+
 ## 5. Scheduling modes
 
 | Aspect | Mode A — Threshold | Mode B — Daily deficit-based |
@@ -200,6 +237,13 @@ for slow sensors (>15 min/reading) consider a moving average via HA's
 or substrate field capacity. Volume estimate assumes uniform distribution
 over area `A`; use a separate zone per distinct area.
 
+**Microclimate factor** — the exposure presets (§4.2) are expert-judgment
+values in the range the landscape coefficient method describes, not
+site-measured coefficients, and they are *static*: a shade fraction is
+itself seasonal, since a low autumn sun throws a longer, earlier shadow. A
+template sensor driven by `sun.sun` would make the factor self-correcting;
+that is deliberately left as a follow-up to the static presets.
+
 **Rain sensor** — wrong `rain_sensor_type` causes large errors: `event` on a
 cumulative sensor subtracts the full daily total each update; `daily_total`
 on an event sensor misses all but the first of a run of equal values. Rain
@@ -220,7 +264,7 @@ sensor as an action condition.
 
 ## 7. References
 
-37 citations. Each entry carries a
+38 citations. Each entry carries a
 DOI link where one exists, otherwise the official landing-page URL; see §0 for
 how these links were obtained and verified. Items without a registered DOI
 (FAO/ASCE reports, datasheets, web docs) link to their canonical page instead.
@@ -276,6 +320,9 @@ how these links were obtained and verified. Items without a registered DOI
 36. HA Developer Documentation — SensorEntity. https://developers.home-assistant.io/docs/core/entity/sensor
 37. HACS Integration publishing guide. https://hacs.xyz/docs/publish/integration
 
+### Landscape coefficients
+38. Costello L.R., Matheny N.P., Clark J.R., Jones K.S. (2000). *A Guide to Estimating Irrigation Water Needs of Landscape Plantings in California: The Landscape Coefficient Method and WUCOLS III.* University of California Cooperative Extension & California Department of Water Resources. — https://cimis.water.ca.gov/Content/PDF/wucols00.pdf — **link verification caveat:** title/authors/year/publisher confirmed against corroborating institutional pages (UC/CalWEP), not against the PDF body, which the retrieval tooling could not render as text. Treat as landing-page-level verification (§0 step 5), pending a reader check of Part 1 §2 for the `K_L = k_s · k_d · k_mc` definition and the `k_mc` table.
+
 ---
 
 ## Revision history
@@ -284,3 +331,4 @@ how these links were obtained and verified. Items without a registered DOI
 |---|---|
 | 2026-04 | Initial — model specification (v0.1.0). |
 | 2026-06 | Restructured as a standalone note; references verified against primary sources. |
+| 2026-08 | Added §4.2 site exposure (microclimate factor, #146), its limitation in §6.2, and ref 38. |

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -120,7 +120,7 @@ D_ref(t) = clamp( D_ref(t-1) + ET_h · Δt - ΔP,  0,  D_max )
 ### 2.4 Per-zone deficit accumulation (with Kc)
 
 ```
-D_zone(t) = clamp( D_zone(t-1) + ET_h · Kc(doy, family) · Δt - ΔP,  0,  D_max )
+D_zone(t) = clamp( D_zone(t-1) + ET_h · Kc_eff(doy, family, exposure) · Δt - ΔP,  0,  D_max )
 ```
 
 | Item | Value |
@@ -128,7 +128,7 @@ D_zone(t) = clamp( D_zone(t-1) + ET_h · Kc(doy, family) · Δt - ΔP,  0,  D_ma
 | **Class** | `IrrigationZoneSensor` |
 | **Method** | `_on_et_update()` |
 | **Kc source** | `compute_kc()` module-level function |
-| **Parameters** | `plant_family`, `kc` (manual override), `hass.config.latitude` |
+| **Parameters** | `plant_family`, `kc` (manual override), `exposure` / `microclimate_factor`, `hass.config.latitude` |
 | **Rain** | Receives `ΔP` (rain delta) from `DrynessIndexSensor` broadcast |
 
 Each zone accumulates independently. Rain delta reduces all zone deficits equally. Only the irrigated zone's deficit resets after irrigation.
@@ -136,16 +136,38 @@ Each zone accumulates independently. Rain delta reduces all zone deficits equall
 ### 2.5 Crop coefficient computation
 
 ```
-Kc = compute_kc(day_of_year, plant_family, manual_kc, latitude)
+Kc = compute_kc(day_of_year, plant_family, manual_kc, latitude, microclimate_factor)
+   = base(day_of_year, plant_family, manual_kc) · microclimate_factor
 ```
 
 | Item | Value |
 |------|-------|
 | **Function** | `compute_kc()` (module-level in `sensor.py`) |
-| **Priority** | `manual_kc > plant_family seasonal profile > DEFAULT_KC (1.0)` |
-| **Interpolation** | Linear between 4 seasonal anchors (days 15, 105, 196, 288) |
+| **Base priority** | `manual_kc > plant_family seasonal profile > DEFAULT_KC (1.0)` |
+| **Interpolation** | Linear between 4 seasonal anchors (days 15, 105, 196, 288), in `_seasonal_kc()` |
 | **Hemisphere** | Southern (latitude < 0): day shifted by 182 days |
 | **Plant families** | Defined in `const.py` `PLANT_FAMILIES` dict (10 families) |
+
+#### Site exposure (microclimate factor, k_mc)
+
+Landscape coefficient method (Costello, Matheny & Clark 2000): `K_L = k_s · k_d · k_mc`.
+The plant family supplies `k_s`; the zone's site exposure supplies `k_mc`.
+
+| Item | Value |
+|------|-------|
+| **Function** | `resolve_microclimate_factor(exposure, custom_factor)` (pure, in `sensor.py`) |
+| **Config keys** | `exposure` (preset key), `microclimate_factor` (number, `exposure == "custom"` only) |
+| **Presets** | `const.py` `EXPOSURES` dict — 0.60 (deep shade) … 1.20 (reflected heat), plus `custom` |
+| **Applied to** | The base Kc **including** a manual override — exposure describes the site, not the planting |
+| **Bounds** | `[MICROCLIMATE_FACTOR_MIN, MICROCLIMATE_FACTOR_MAX]` = `[0.1, 1.5]`, clamped |
+| **Fallback** | Unset / unknown / non-numeric → `DEFAULT_MICROCLIMATE_FACTOR` (1.0), never 0 |
+| **Resolved** | Once in `IrrigationZoneSensor.__init__` (config is static per reload) |
+
+The floor above zero is load-bearing: at `k_mc = 0` the deficit never accrues, so
+reactive irrigation, the monitoring notification and `_check_deficit_anomaly()`
+would all go quiet with nothing in the UI to explain it. The config flow rejects
+`custom` without a factor (`microclimate_factor_required`) for the same reason —
+silently resolving to 1.0 would look like the exposure had never been set.
 
 ### 2.6 Deficit from VWC (direct measurement)
 
@@ -249,7 +271,8 @@ All configuration keys (`CONF_*`), service names (`SERVICE_*`), system types, pl
 
 | Element | Type | Purpose |
 |---------|------|---------|
-| `compute_kc()` | Function | Pure function: Kc from day, family, override, latitude |
+| `compute_kc()` | Function | Pure function: effective Kc from day, family, override, latitude, microclimate factor |
+| `resolve_microclimate_factor()` | Function | Pure function: site-exposure preset (or custom value) → k_mc |
 | `ETSensor` | Class (1 instance) | Instantaneous ET rate [mm/h] |
 | `DrynessIndexSensor` | Class (1 instance) | Reference deficit [mm] at Kc=1.0, RestoreEntity |
 | `IrrigationZoneSensor` | Class (N instances) | Per-zone deficit, volume [L], duration [s], RestoreEntity |
@@ -375,7 +398,8 @@ python3 -m pytest tests/ -v
 | `test_never_dry_sensor.py` | Reference deficit accumulation, reset, VWC mode, invalid inputs |
 | `test_volume_duration.py` | Per-zone volume/duration, zone attributes, multi-zone independence |
 | `test_controller.py` | Valve control, sequential irrigation, emergency stop, monitoring, system types |
-| `test_kc.py` | `compute_kc()` (anchors, interpolation, hemisphere, override), per-zone deficit tracking |
+| `test_kc.py` | `compute_kc()` (anchors, interpolation, hemisphere, override, microclimate factor), `resolve_microclimate_factor()`, per-zone deficit tracking |
+| `test_zone_exposure.py` | Exposure preset table, `custom`-without-factor guard in every zone form |
 
 Async controller tests require `pytest-asyncio` (skipped if not installed).
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -79,6 +79,8 @@ Different plants need different amounts of water. NeverDry assigns a **crop coef
 
 The Kc varies seasonally — plants need less water in winter than in summer. NeverDry interpolates between 4 seasonal values automatically and adjusts for your hemisphere based on your Home Assistant location.
 
+Two zones can hold the same plants and still dry out at different rates — one loses the sun behind the house at 14:00, the other sits against a south-facing wall. That is what **site exposure** is for: a per-zone factor that multiplies the Kc, so the zone keeps its seasonal shape instead of being pinned to one number. See [Site exposure](#site-exposure) below.
+
 ### Two scheduling modes
 
 | Mode | When it triggers | Best for |
@@ -158,6 +160,8 @@ For each zone, the wizard asks:
 | **Efficiency override** | No | Custom efficiency (0.1–1.0). Overrides the system type default. |
 | **Plant family** | No | Type of plants in this zone — sets a seasonal crop coefficient (Kc) that adjusts water demand throughout the year. See table below. |
 | **Custom Kc** | No | Override Kc (0.1–2.0). If set, overrides the plant family seasonal profile. |
+| **Site exposure** | No | How much sun and wind this zone gets compared to an open site. Multiplies the Kc. Default *Full sun, open* (×1.00) changes nothing. See table below. |
+| **Custom microclimate factor** | For *Advanced* | Explicit exposure factor (0.1–1.5). Only used when site exposure is set to *Advanced (custom factor)*, and required in that case. |
 | **Guard flow rate (L/min)** | For `estimated_flow` | Measured valve flow rate. Required for `estimated_flow`; strongly recommended for `flow_meter` and `volume_preset` too — it drives the expected-duration estimate and lets the safety timeout scale with large deficits (it will become required in a future release). Measure with a bucket and stopwatch. |
 | **Threshold (mm)** | No | Deficit threshold for Mode A triggering (default: 20.0 mm) |
 
@@ -186,6 +190,43 @@ For each zone, the wizard asks:
 | Mixed garden (default) | 0.40 | 0.70 | 0.90 | 0.55 |
 
 The Kc values are interpolated linearly between seasons. The hemisphere is auto-detected from your Home Assistant location settings — in the southern hemisphere, the seasonal profile is automatically flipped.
+
+#### Site exposure
+
+The plant family says *what* grows in the zone. Site exposure says *where* the zone is: shaded, open, windy, or up against hot paving. It is applied as a multiplier on top of the Kc:
+
+```
+Kc_effective = Kc (plant family or custom override) × exposure factor
+```
+
+| Exposure | Factor | Pick it when |
+|----------|--------|--------------|
+| Deep / all-day shade | 0.60 | The zone never gets direct sun (north side, under dense canopy) |
+| Morning sun, afternoon shade | 0.75 | Sun until roughly midday, then shaded by a building or trees |
+| Morning shade, afternoon sun | 0.85 | Shaded early, then exposed through the hottest hours |
+| **Full sun, open (default)** | **1.00** | Open lawn or bed with no shading and no unusual wind |
+| Windy / exposed | 1.15 | Rooftop, ridge, or a channelled wind that dries the zone out fast |
+| Reflected heat (paving, south-facing wall) | 1.20 | Bordered by paving, gravel, or a wall that radiates heat back |
+| Advanced (custom factor) | your value, 0.1–1.5 | You have measured or calculated your own factor |
+
+**Why not just lower the Kc?** Because a fixed Kc freezes the zone at one season's value. For an east-facing lawn that loses the sun at 14:00, a manual `Kc = 0.70` is about right in August and drifts badly from there:
+
+| Date | Seasonal Kc (lawn) | With exposure ×0.75 | Frozen Kc 0.70 |
+|------|--------------------|---------------------|----------------|
+| Aug 5 | 0.93 | 0.70 | correct |
+| Sep 15 | 0.80 | 0.60 | +17% |
+| Oct 15 | 0.70 | 0.53 | +33% |
+| Nov 15 | 0.62 | 0.46 | +52% |
+
+The error peaks in autumn, exactly when over-watering shaded turf invites disease.
+
+The presets come from the landscape coefficient method (`K_L = k_s × k_d × k_mc`, Costello, Matheny & Clark 2000): the plant family provides the species factor `k_s`, exposure provides the microclimate factor `k_mc`. They are expert-judgment starting points, not measurements — adjust them for your garden and report back what works.
+
+**Notes:**
+- The factor applies to a **custom Kc as well**, since exposure describes the site rather than the planting. If you set `Kc = 0.80` and *Deep shade*, the zone runs at 0.48. The two multiply out, so a high custom Kc with an above-1.0 exposure can exceed the 0.1–2.0 range of the Kc field itself (2.0 × 1.20 = 2.4). That is not capped, on purpose: both numbers are your explicit choice.
+- Values **above 1.0** are intentional. A zone against hot paving genuinely exceeds reference ET.
+- The zone's **Kc sensor** shows the effective value, with `kc_base`, `exposure`, and `microclimate_factor` as attributes so you can see how it was composed.
+- Leaving exposure at *Full sun, open* is a no-op — existing zones behave exactly as before.
 
 ### Step 3: Add more zones or finish
 
@@ -237,8 +278,11 @@ Shows the volume of water needed for this specific zone in liters.
 | `duration_s` | Expected valve run time [seconds] — from the live flow-meter rate while irrigating (reads as remaining time), otherwise from the configured guard flow rate; 0 if neither is available |
 | `deficit_mm` | This zone's current deficit [mm] (per-zone, not shared) |
 | `plant_family` | Plant family key (e.g., "lawn", "vegetables") |
-| `kc` | Current crop coefficient (varies seasonally) |
+| `kc` | Current **effective** crop coefficient (seasonal, after site exposure) |
+| `kc_base` | Crop coefficient before site exposure (plant family curve or manual override) |
 | `kc_override` | Manual Kc override value, if set |
+| `exposure` | Site exposure key (e.g., "morning_sun"), or `null` if unset |
+| `microclimate_factor` | Resolved exposure multiplier applied to `kc_base` |
 | `valve` | Associated valve entity |
 | `system_type` | Irrigation system type |
 | `area_m2` | Zone area |

--- a/tests/test_kc.py
+++ b/tests/test_kc.py
@@ -1,18 +1,29 @@
 """Tests for crop coefficient (Kc) computation and per-zone deficit tracking."""
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 from never_dry.const import (
     CONF_ZONE_AREA,
     CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_EXPOSURE,
     CONF_ZONE_FLOW_RATE,
     CONF_ZONE_KC,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
     CONF_ZONE_NAME,
     CONF_ZONE_PLANT_FAMILY,
     CONF_ZONE_VALVE,
+    EXPOSURE_CUSTOM,
+    EXPOSURE_DEEP_SHADE,
+    EXPOSURE_FULL_SUN,
+    EXPOSURE_MORNING_SUN,
+    EXPOSURE_REFLECTED_HEAT,
+    EXPOSURES,
+    MICROCLIMATE_FACTOR_MAX,
+    MICROCLIMATE_FACTOR_MIN,
 )
-from never_dry.sensor import IrrigationZoneSensor, compute_kc
+from never_dry.sensor import IrrigationZoneSensor, compute_kc, resolve_microclimate_factor
 
 # ══════════════════════════════════════════════════════════
 #  compute_kc pure function
@@ -117,6 +128,110 @@ class TestComputeKcSouthernHemisphere:
 
 
 # ══════════════════════════════════════════════════════════
+#  resolve_microclimate_factor — exposure preset → kmc
+# ══════════════════════════════════════════════════════════
+
+
+class TestResolveMicroclimateFactor:
+    """Exposure presets resolve to their table factor; anything odd → 1.0."""
+
+    def test_presets_match_the_table(self):
+        for key, preset in EXPOSURES.items():
+            if preset["factor"] is not None:
+                assert resolve_microclimate_factor(key) == preset["factor"]
+
+    def test_default_full_sun_is_neutral(self):
+        assert resolve_microclimate_factor(EXPOSURE_FULL_SUN) == 1.0
+
+    def test_unset_exposure_is_neutral(self):
+        assert resolve_microclimate_factor(None) == 1.0
+
+    def test_unknown_exposure_is_neutral(self):
+        assert resolve_microclimate_factor("under_a_rock") == 1.0
+
+    def test_preset_ignores_a_stale_custom_value(self):
+        """The dropdown wins: a leftover number never overrides a preset."""
+        assert resolve_microclimate_factor(EXPOSURE_DEEP_SHADE, 1.2) == 0.60
+
+    def test_custom_uses_the_number(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, 0.42) == 0.42
+
+    def test_custom_accepts_above_one(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, 1.35) == 1.35
+
+    def test_custom_without_a_number_is_neutral(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, None) == 1.0
+
+    def test_custom_with_garbage_is_neutral(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, "shady") == 1.0
+
+    def test_zero_is_floored_not_honoured(self):
+        """At 0 the deficit never accrues and every trigger goes silent."""
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, 0.0) == MICROCLIMATE_FACTOR_MIN
+
+    def test_negative_is_floored(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, -3.0) == MICROCLIMATE_FACTOR_MIN
+
+    def test_above_max_is_clamped(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, 99.0) == MICROCLIMATE_FACTOR_MAX
+
+    def test_infinite_is_neutral(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, float("inf")) == 1.0
+
+    def test_nan_is_neutral(self):
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, float("nan")) == 1.0
+
+    def test_numeric_string_is_honoured(self):
+        """A hand-edited .storage entry stores "0.65" rather than 0.65."""
+        assert resolve_microclimate_factor(EXPOSURE_CUSTOM, "0.65") == 0.65
+
+    def test_unhashable_exposure_is_neutral(self):
+        """Must not raise: __init__ would abort setup for every zone in the entry."""
+        assert resolve_microclimate_factor(["deep_shade"]) == 1.0
+        assert resolve_microclimate_factor({"a": 1}) == 1.0
+
+    def test_non_string_exposure_is_neutral(self):
+        assert resolve_microclimate_factor(0.75) == 1.0
+
+
+# ══════════════════════════════════════════════════════════
+#  compute_kc * microclimate factor
+# ══════════════════════════════════════════════════════════
+
+
+class TestComputeKcMicroclimate:
+    """The exposure factor multiplies the Kc instead of replacing it."""
+
+    def test_default_factor_leaves_kc_untouched(self):
+        assert compute_kc(196, "lawn", None, 45.0) == compute_kc(196, "lawn", None, 45.0, 1.0)
+
+    def test_factor_scales_the_family_curve(self):
+        # lawn mid-summer = 1.00, morning-sun exposure = 0.75
+        assert compute_kc(196, "lawn", None, 45.0, 0.75) == pytest.approx(0.75, abs=0.001)
+
+    def test_factor_scales_the_manual_override(self):
+        """Site exposure describes the site, not the planting — it applies to both."""
+        assert compute_kc(196, "lawn", 0.80, 45.0, 0.75) == pytest.approx(0.60, abs=0.001)
+
+    def test_factor_above_one_raises_kc(self):
+        # lawn mid-summer 1.00 * reflected heat 1.20
+        assert compute_kc(196, "lawn", None, 45.0, 1.20) == pytest.approx(1.20, abs=0.001)
+
+    def test_seasonal_shape_is_preserved(self):
+        """The point of #146: a shaded zone tracks the season, a frozen Kc does not."""
+        factor = 0.75
+        august = compute_kc(217, "lawn", None, 45.0, factor)
+        october = compute_kc(288, "lawn", None, 45.0, factor)
+        assert august > october
+        # October: lawn autumn anchor 0.70 * 0.75 = 0.525 — where a frozen
+        # manual Kc of 0.70 would over-water by ~33%.
+        assert october == pytest.approx(0.525, abs=0.001)
+
+    def test_no_family_no_override_scales_default(self):
+        assert compute_kc(196, None, None, 45.0, 0.60) == pytest.approx(0.60, abs=0.001)
+
+
+# ══════════════════════════════════════════════════════════
 #  Per-zone deficit tracking
 # ══════════════════════════════════════════════════════════
 
@@ -128,7 +243,7 @@ def _make_hass():
     return hass
 
 
-def _make_zone_sensor(di_sensor, plant_family=None, kc=None):
+def _make_zone_sensor(di_sensor, plant_family=None, kc=None, exposure=None, microclimate_factor=None):
     """Helper for zone sensors with Kc config."""
     zone_config = {
         CONF_ZONE_NAME: "Test",
@@ -141,6 +256,10 @@ def _make_zone_sensor(di_sensor, plant_family=None, kc=None):
         zone_config[CONF_ZONE_PLANT_FAMILY] = plant_family
     if kc is not None:
         zone_config[CONF_ZONE_KC] = kc
+    if exposure is not None:
+        zone_config[CONF_ZONE_EXPOSURE] = exposure
+    if microclimate_factor is not None:
+        zone_config[CONF_ZONE_MICROCLIMATE_FACTOR] = microclimate_factor
     return IrrigationZoneSensor(_make_hass(), zone_config, di_sensor)
 
 
@@ -224,3 +343,99 @@ class TestKcInAttributes:
         attrs = zone.extra_state_attributes
         assert attrs["kc"] == 1.0
         assert attrs["plant_family"] is None
+
+
+class TestZoneExposure:
+    """Site exposure on the zone sensor: resolution, deficit, attributes."""
+
+    def test_no_exposure_keeps_previous_behaviour(self, di_sensor):
+        zone = _make_zone_sensor(di_sensor, plant_family="lawn")
+        assert zone._microclimate_factor == 1.0
+        assert zone._get_current_kc() == zone._get_base_kc()
+
+    def test_preset_scales_the_zone_kc(self, di_sensor):
+        shaded = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_MORNING_SUN)
+        open_site = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_FULL_SUN)
+        assert shaded._get_current_kc() == pytest.approx(open_site._get_current_kc() * 0.75, abs=0.001)
+        # The base curve is untouched — only the effective Kc moves.
+        assert shaded._get_base_kc() == open_site._get_base_kc()
+
+    def test_custom_factor_is_used(self, di_sensor):
+        zone = _make_zone_sensor(
+            di_sensor,
+            plant_family="lawn",
+            exposure=EXPOSURE_CUSTOM,
+            microclimate_factor=0.65,
+        )
+        assert zone._microclimate_factor == 0.65
+
+    def test_custom_without_value_falls_back_to_neutral(self, di_sensor):
+        zone = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_CUSTOM)
+        assert zone._microclimate_factor == 1.0
+
+    def test_unknown_exposure_falls_back_to_neutral(self, di_sensor):
+        zone = _make_zone_sensor(di_sensor, plant_family="lawn", exposure="mystery")
+        assert zone._microclimate_factor == 1.0
+
+    def test_numeric_string_factor_does_not_warn(self, di_sensor, caplog):
+        """The stored value was honoured, so a 'using X instead' warning would lie."""
+        zone = _make_zone_sensor(
+            di_sensor,
+            plant_family="lawn",
+            exposure=EXPOSURE_CUSTOM,
+            microclimate_factor="0.65",
+        )
+        assert zone._microclimate_factor == 0.65
+        assert "microclimate factor" not in caplog.text
+
+    def test_out_of_range_factor_warns(self, di_sensor, caplog):
+        with caplog.at_level(logging.WARNING):
+            zone = _make_zone_sensor(
+                di_sensor,
+                plant_family="lawn",
+                exposure=EXPOSURE_CUSTOM,
+                microclimate_factor=9.0,
+            )
+        assert zone._microclimate_factor == MICROCLIMATE_FACTOR_MAX
+        assert "outside" in caplog.text
+
+    def test_effective_kc_stays_consistent_with_base(self, di_sensor):
+        """kc must always equal kc_base * factor — the attributes explain each other."""
+        zone = _make_zone_sensor(di_sensor, plant_family="vegetables", exposure=EXPOSURE_REFLECTED_HEAT)
+        attrs = zone.extra_state_attributes
+        assert attrs["kc"] == pytest.approx(attrs["kc_base"] * attrs["microclimate_factor"], abs=0.001)
+
+    def test_two_identical_zones_differ_by_exposure_only(self, di_sensor):
+        """The #146 use case: same lawn, one shaded from 14:00."""
+        sunny = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_FULL_SUN)
+        shaded = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_MORNING_SUN)
+        sunny._on_et_update(dt_h=1.0, et_h=0.20, rain=0.0)
+        shaded._on_et_update(dt_h=1.0, et_h=0.20, rain=0.0)
+        assert shaded._zone_deficit == pytest.approx(sunny._zone_deficit * 0.75, abs=0.001)
+
+    def test_exposure_scales_deficit_in_vwc_mode(self, di_sensor):
+        """VWC mode multiplies the reference deficit by the same effective Kc."""
+        di_sensor._deficit = 10.0
+        zone = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_DEEP_SHADE)
+        zone._on_et_update(dt_h=0.0, et_h=0.0, rain=0.0)
+        assert zone._zone_deficit == pytest.approx(10.0 * zone._get_current_kc(), abs=0.001)
+
+    def test_reflected_heat_raises_the_deficit(self, di_sensor):
+        hot = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_REFLECTED_HEAT)
+        open_site = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_FULL_SUN)
+        hot._on_et_update(dt_h=1.0, et_h=0.20, rain=0.0)
+        open_site._on_et_update(dt_h=1.0, et_h=0.20, rain=0.0)
+        assert hot._zone_deficit > open_site._zone_deficit
+
+    def test_exposure_in_attributes(self, di_sensor):
+        zone = _make_zone_sensor(di_sensor, plant_family="lawn", exposure=EXPOSURE_MORNING_SUN)
+        attrs = zone.extra_state_attributes
+        assert attrs["exposure"] == EXPOSURE_MORNING_SUN
+        assert attrs["microclimate_factor"] == 0.75
+        assert attrs["kc"] == pytest.approx(attrs["kc_base"] * 0.75, abs=0.002)
+
+    def test_attributes_without_exposure(self, di_sensor):
+        attrs = _make_zone_sensor(di_sensor, plant_family="lawn").extra_state_attributes
+        assert attrs["exposure"] is None
+        assert attrs["microclimate_factor"] == 1.0
+        assert attrs["kc"] == attrs["kc_base"]

--- a/tests/test_zone_exposure.py
+++ b/tests/test_zone_exposure.py
@@ -1,0 +1,259 @@
+"""Tests for the per-zone site exposure (microclimate factor) config flow.
+
+The exposure dropdown is a preset table, so the only input that can go
+wrong is "Advanced (custom factor)" without a factor: it would resolve to a
+neutral 1.0 at runtime and the zone would silently behave as if no
+exposure had been selected. Every entry point into a zone form must reject
+it (initial setup, add zone, edit zone).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from never_dry import config_flow as cf
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_EXPOSURE,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
+    CONF_ZONE_NAME,
+    CONF_ZONES,
+    DEFAULT_EXPOSURE,
+    EXPOSURE_CUSTOM,
+    EXPOSURE_DEEP_SHADE,
+    EXPOSURE_MORNING_SUN,
+    EXPOSURES,
+    MICROCLIMATE_FACTOR_MAX,
+    MICROCLIMATE_FACTOR_MIN,
+)
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry"
+
+
+def _entry(zones):
+    entry = MagicMock()
+    entry.entry_id = "abc"
+    entry.data = {CONF_ZONES: zones}
+    return entry
+
+
+@pytest.fixture(autouse=True)
+def _patch_flow_env(monkeypatch):
+    """Same stub set as test_zone_config_guards, plus what the edit form needs."""
+    monkeypatch.setattr(cf, "_is_imperial", lambda hass: False)
+    monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "UNDEFINED", object(), raising=False)
+    # edit_zone_detail builds its schema inline, so every selector lookup
+    # has to be answered.
+    monkeypatch.setattr(cf, "selector", MagicMock())
+    monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial: None)
+
+    def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "errors": errors,
+            "description_placeholders": description_placeholders,
+        }
+
+    def _create_entry(self, *, data=None, title=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    for klass in (cf.NeverDryConfigFlow, cf.NeverDryOptionsFlow):
+        monkeypatch.setattr(klass, "async_show_form", _show_form, raising=False)
+        monkeypatch.setattr(klass, "async_create_entry", _create_entry, raising=False)
+
+
+class TestExposureTable:
+    """The preset table itself."""
+
+    def test_default_exposure_is_neutral(self):
+        assert EXPOSURES[DEFAULT_EXPOSURE]["factor"] == 1.0
+
+    def test_custom_entry_has_no_preset_factor(self):
+        assert EXPOSURES[EXPOSURE_CUSTOM]["factor"] is None
+
+    def test_range_extends_above_one(self):
+        """Paved and wall-adjacent zones genuinely exceed reference ET."""
+        factors = [p["factor"] for p in EXPOSURES.values() if p["factor"] is not None]
+        assert max(factors) > 1.0
+        assert min(factors) > 0.0
+
+    def test_presets_fit_the_custom_field_bounds(self):
+        """A preset the custom field could not express would be inconsistent."""
+        for key, preset in EXPOSURES.items():
+            if preset["factor"] is not None:
+                assert MICROCLIMATE_FACTOR_MIN <= preset["factor"] <= MICROCLIMATE_FACTOR_MAX, key
+
+    def test_every_preset_has_a_translated_label(self):
+        """``label`` is dev-facing: the dropdown text comes from the translations."""
+        en = json.loads((_COMPONENT / "translations" / "en.json").read_text(encoding="utf-8"))
+        assert set(EXPOSURES) == set(en["selector"]["exposure"]["options"])
+
+
+class TestExposureErrors:
+    """The pure validation helper."""
+
+    def test_preset_is_clean(self):
+        assert cf._exposure_errors({CONF_ZONE_EXPOSURE: EXPOSURE_DEEP_SHADE}) == {}
+
+    def test_unset_exposure_is_clean(self):
+        assert cf._exposure_errors({}) == {}
+
+    def test_custom_without_factor_is_rejected(self):
+        errors = cf._exposure_errors({CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM})
+        assert errors == {CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required"}
+
+    def test_custom_with_factor_is_clean(self):
+        zone = {CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM, CONF_ZONE_MICROCLIMATE_FACTOR: 0.7}
+        assert cf._exposure_errors(zone) == {}
+
+    def test_preset_with_a_stale_factor_is_clean(self):
+        """A leftover number is ignored at runtime, not an error."""
+        zone = {CONF_ZONE_EXPOSURE: EXPOSURE_MORNING_SUN, CONF_ZONE_MICROCLIMATE_FACTOR: 0.7}
+        assert cf._exposure_errors(zone) == {}
+
+
+class TestInitialFlowExposure:
+    """Initial setup: the zone step blocks on a factorless custom exposure."""
+
+    @pytest.mark.asyncio
+    async def test_custom_without_factor_shows_error(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+            },
+        )
+
+        assert result["step_id"] == "zone"
+        assert result["errors"] == {CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required"}
+        assert flow._zones == []
+
+    @pytest.mark.asyncio
+    async def test_exposure_is_stored(self, hass_mock):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_MORNING_SUN,
+            },
+        )
+
+        assert result["step_id"] == "add_another"
+        assert flow._zones[0][CONF_ZONE_EXPOSURE] == EXPOSURE_MORNING_SUN
+
+    @pytest.mark.asyncio
+    async def test_custom_with_factor_is_stored_unconverted(self, hass_mock):
+        """The factor is dimensionless — no metric conversion may touch it."""
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        await flow.async_step_zone(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+                CONF_ZONE_MICROCLIMATE_FACTOR: 0.65,
+            },
+        )
+
+        assert flow._zones[0][CONF_ZONE_MICROCLIMATE_FACTOR] == 0.65
+
+
+class TestOptionsFlowExposure:
+    """add_zone / edit_zone_detail apply the same guard."""
+
+    @pytest.mark.asyncio
+    async def test_add_zone_custom_without_factor_shows_error(self, hass_mock):
+        flow = cf.NeverDryOptionsFlow(_entry([]))
+        flow.hass = hass_mock
+
+        result = await flow.async_step_add_zone(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+            },
+        )
+
+        assert result["step_id"] == "add_zone"
+        assert result["errors"] == {CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required"}
+
+    @pytest.mark.asyncio
+    async def test_add_zone_with_preset_saves(self, hass_mock):
+        entry = _entry([])
+        flow = cf.NeverDryOptionsFlow(entry)
+        flow.hass = hass_mock
+
+        result = await flow.async_step_add_zone(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_DEEP_SHADE,
+            },
+        )
+
+        assert result["type"] == "create_entry"
+        saved = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert saved[CONF_ZONES][0][CONF_ZONE_EXPOSURE] == EXPOSURE_DEEP_SHADE
+
+    @pytest.mark.asyncio
+    async def test_edit_zone_custom_without_factor_shows_error(self, hass_mock):
+        zone = {CONF_ZONE_NAME: "Prato", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 10.0}
+        flow = cf.NeverDryOptionsFlow(_entry([zone]))
+        flow.hass = hass_mock
+        flow._edit_zone_name = "Prato"
+
+        result = await flow.async_step_edit_zone_detail(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+            },
+        )
+
+        assert result["step_id"] == "edit_zone_detail"
+        assert result["errors"] == {CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required"}
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_edit_zone_saves_exposure(self, hass_mock):
+        zone = {CONF_ZONE_NAME: "Prato", CONF_ZONE_AREA: 20.0, CONF_ZONE_FLOW_RATE: 10.0}
+        flow = cf.NeverDryOptionsFlow(_entry([zone]))
+        flow.hass = hass_mock
+        flow._edit_zone_name = "Prato"
+
+        result = await flow.async_step_edit_zone_detail(
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 20.0,
+                CONF_ZONE_FLOW_RATE: 600.0,
+                CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+                CONF_ZONE_MICROCLIMATE_FACTOR: 1.2,
+            },
+        )
+
+        assert result["type"] == "create_entry"
+        saved = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        edited = saved[CONF_ZONES][0]
+        assert edited[CONF_ZONE_EXPOSURE] == EXPOSURE_CUSTOM
+        assert edited[CONF_ZONE_MICROCLIMATE_FACTOR] == 1.2


### PR DESCRIPTION
Implements the per-zone microclimate factor from #146.

`compute_kc()` returned a manual override early, so a zone with a custom Kc never saw its seasonal curve. The site term is now multiplicative:

    Kc_effective = Kc(family curve | manual override) * k_mc

Exposed as a **Site exposure** dropdown, not a raw coefficient, with presets from the landscape coefficient method (Costello et al. 2000) where the plant family plays `k_s`:

| Exposure | Factor |
|---|---|
| Deep / all-day shade | 0.60 |
| Morning sun, afternoon shade | 0.75 |
| Morning shade, afternoon sun | 0.85 |
| Full sun, open (default) | 1.00 |
| Windy / exposed | 1.15 |
| Reflected heat (paving, south-facing wall) | 1.20 |
| Advanced (custom factor) | 0.1 to 1.5 |

Decisions on the open questions:

- **Applies to a manual Kc too**, not just the family curve. Exposure describes the site, not the planting. `kc_base` is published next to `kc` so an override stays legible.
- **Static presets.** A `sun.sun`-driven factor is a follow-up, noted as a limitation in the model doc.
- **Both names kept:** `exposure` is what the dropdown asks, `microclimate_factor` is the literature term and the numeric field.
- **Preset values as proposed.** Expert judgment, not measurements. This is the least certain part, feedback welcome.

Floored at 0.1: at 0 the deficit never accrues and every irrigation trigger goes quiet with nothing in the UI. *Advanced* without a factor is a form error for the same reason.

Default *Full sun, open* (1.00), so existing zones are unchanged and no migration is needed.

I am currently running this on my own installation and will report back with field results.

Closes #146