### PR TITLE
release: bump version to 0.11.1-beta.3

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/drake69/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.2"
+  "version": "0.11.1-beta.3"
 }


### PR DESCRIPTION
Version bump only — `0.11.1-beta.2` → `0.11.1-beta.3`.

## What this beta contains

Per-zone **site exposure** (#146), contributed by @philipgiuliani in #147: a microclimate factor (`k_mc`) that multiplies the crop coefficient, so a shaded, windy or paving-adjacent zone keeps its seasonal Kc curve instead of being frozen at one value by a constant Kc override.

It shipped complete on `develop` — code, 478 lines of tests, user manual, developer manual, scientific model, and its CHANGELOG entry. Nothing to add here but the version.

Default *Full sun, open* (×1.00) is a no-op: existing zones behave exactly as before.

## Why a beta now

The exposure presets (0.60 deep shade … 1.20 reflected heat) come from the landscape coefficient method (Costello, Matheny & Clark 2000). They are expert-judgment starting points, not measurements. Getting them in front of real gardens is the point of this release — @MetheLittle in particular has been hand-patching files onto beta.2 to try the feature, which this replaces.

## Notes

- The CHANGELOG entry stays under `[Unreleased]`: betas do not get their own section, matching beta.1 and beta.2.
- Tagging `v0.11.1-beta.3` after merge triggers `release.yml` and publishes the pre-release for HACS testers.