### PR TITLE
ci: bump github/codeql-action to v4.37.4 (init + analyze together)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:python"


### PR DESCRIPTION
Supersedes #148 and #149 — please close them in favour of this one.

## Why not merge the Dependabot PRs

Dependabot raises one PR per action path, so #148 bumps `codeql-action/init` and #149 bumps `codeql-action/analyze`. Neither can be merged on its own: the two steps must run the same version, and CodeQL fails hard when they do not.

From the run on #148:

```
##[warning] Not all workflow steps that use `github/codeql-action` actions use the same version.
##[error]   Loaded a configuration file for version '4.37.4', but running version '4.37.3'
##[error]   analyze post-action step failed
```

Merging either one — and both are `BLOCKED`, so it would take `--admin` over a red check — would leave `main` with a security workflow that fails on every run.

## What this does

Bumps both `uses:` lines to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4) in one commit, so CI verifies the pair together. These are the only two `codeql-action` references in the repo.

`develop` still carries v4.37.3 on both lines — consistent, so nothing is broken there; it picks this up at the next back-merge.