### PR TITLE
Domain object model: write the five objects, give the deficit one owner

### DIFF
--- a/custom_components/never_dry/actuator.py
+++ b/custom_components/never_dry/actuator.py
@@ -246,6 +246,14 @@ _OPERATION_FOR_FAILURE: dict[FailureKind, str] = {
     FailureKind.CLOSE_LEAK: "close",
 }
 
+# For each command, the normalized entity level that already satisfies it and the
+# observation that confirms it. Used to confirm by *level* instead of waiting for
+# a state-change *edge* that a switch already in that state will never emit.
+_CONFIRM_FOR_CMD: dict[ValveEvent, tuple[str, ValveEvent]] = {
+    ValveEvent.CMD_OPEN: ("on", ValveEvent.OBS_SWITCH_ON),
+    ValveEvent.CMD_CLOSE: ("off", ValveEvent.OBS_SWITCH_OFF),
+}
+
 
 # ── The abstract actuator (the model's ``Driver``) ─────────────────────────
 
@@ -533,13 +541,44 @@ class Actuator(abc.ABC):
         return None
 
     async def _run_cycle(self, cmd: ValveEvent, terminals: tuple[ValveState, ...]) -> OperationResult:
-        """Dispatch ``cmd`` and await the resulting cycle completion."""
+        """Dispatch ``cmd`` and await the resulting cycle completion.
+
+        After dispatching, if the actuator already reads the *level* the command
+        asks for, synthesize the confirming observation instead of waiting for a
+        state-change *edge*: a ``switch.*``/``valve.*`` already in the target
+        state emits no fresh event, so the FSM would wait on an edge that never
+        comes and time out into a spurious ``OPEN_FAILED``/``CLOSE_*`` — which,
+        across retries, escalates a *physically working* valve to MAINTENANCE
+        (field incident: zone 'Giardino Pino', a Zigbee valve whose confirmation
+        lagged the tight adaptive timeout). Confirming by level makes an
+        already-open/closed valve report success without forcing actuation. When
+        a real edge does arrive it is a harmless noop — the FSM has already left
+        the awaited state.
+        """
         loop = asyncio.get_event_loop()
         self._completion = loop.create_future()
         self._expected_terminal = terminals
         self._cmd_start_time = monotonic()
         await self._dispatch(cmd)
+        if not self._completion.done():
+            await self._confirm_if_already_at_level(cmd)
         return await self._completion
+
+    async def _confirm_if_already_at_level(self, cmd: ValveEvent) -> None:
+        """Confirm ``cmd`` from the current entity *level* when no edge will come.
+
+        Reads the normalized state (a level, not an edge). If it already matches
+        the level the command targets, dispatch the confirming observation so the
+        FSM completes at once. The synthetic confirmation goes straight to the FSM
+        and is never recorded as a latency sample, so it cannot skew the adaptive
+        timeout.
+        """
+        confirm = _CONFIRM_FOR_CMD.get(cmd)
+        if confirm is None:
+            return
+        target_level, obs_event = confirm
+        if self._read_normalized_state() == target_level:
+            await self._dispatch(obs_event)
 
     def _is_retryable(self, outcome: OperationResult) -> bool:
         """``True`` if ``outcome`` describes a transient (comms) failure."""

--- a/custom_components/never_dry/actuator.py
+++ b/custom_components/never_dry/actuator.py
@@ -161,6 +161,10 @@ class DeliveryQuality(StrEnum):
     PARTIAL = "partial"
     DELAYED = "delayed"
     LOW_CONFIDENCE = "low_confidence"
+    # The user hand-watered and pressed "Mark irrigated": the amount is assumed
+    # (the recommended liters), declared by a human rather than measured. Used by
+    # :class:`ManualActuator` for valve-less, hand-watered plants.
+    DECLARED = "declared"
 
 
 class DeliveryMode(StrEnum):
@@ -1349,3 +1353,95 @@ class MasterActuator(Actuator):
         """Cancel the off-linger, then unload the base actuator."""
         self._cancel_linger()
         super().async_unload()
+
+
+# ── Manual actuator (a valve-less "how": a human with a watering can) ───────
+
+
+class ManualActuator:
+    """A valve-less actuator for hand-watered plants (house plants).
+
+    The third materialization of the domain's "how": there is no hardware to
+    drive. Instead of opening a valve it raises an **alert** when a zone's deficit
+    says water is due, and the delivery completes when the user presses **Mark
+    irrigated**. It deliberately does *not* extend :class:`Actuator` — that base
+    is all valve machinery (FSM, switch commands, watchdog, liveness), none of
+    which applies to a human with a watering can. What it shares is the delivery
+    *contract*: it returns a :class:`DeliveryResult`, so the Zone settles its
+    deficit exactly as it does for a valve, unaware the "backend" was a person.
+
+    It leans on things that already exist rather than inventing them: the alert is
+    a notification (any ``on_alert`` sink — a persistent notification, a mobile
+    push, the notifier seam), and **Mark irrigated** is the existing
+    ``reset_deficit`` action, reused here as the delivery *confirmation*.
+
+    The asynchronous, human-paced nature is already modelled by
+    :class:`DeliveryResult`: :meth:`request_irrigation` returns a ``delayed``
+    pending result, :meth:`mark_irrigated` the final ``declared`` one — a human is
+    the extreme case of "a backend that measures late".
+
+    Pairing note: a house plant is watered manually (this actuator) *and* its
+    demand is not weather-driven, so it pairs with a VWC / indoor water-balance
+    model, not ``ETModel``. Actuation and model are orthogonal axes: a house plant
+    picks the manual "how" and the indoor "how much".
+    """
+
+    role = "manual"
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        on_alert: Callable[[str, float, float | None], None] | None = None,
+        on_clear: Callable[[str], None] | None = None,
+    ) -> None:
+        """Configure a manual actuator; ``on_alert``/``on_clear`` raise/clear the user alert."""
+        self._name = name
+        self._on_alert = on_alert
+        self._on_clear = on_clear
+        self._pending_liters: float = 0.0
+        self._pending: bool = False
+
+    @property
+    def name(self) -> str:
+        """Human-facing name for the alert."""
+        return self._name
+
+    @property
+    def is_pending(self) -> bool:
+        """``True`` while an alert is open awaiting the user's confirmation."""
+        return self._pending
+
+    @property
+    def pending_liters(self) -> float:
+        """The recommended liters the open alert asks the user to pour."""
+        return self._pending_liters
+
+    def request_irrigation(self, liters: float, *, deficit_mm: float | None = None) -> DeliveryResult:
+        """Raise the "water this plant" alert; return a pending :class:`DeliveryResult`.
+
+        Nothing is actuated: the result is ``delayed`` with zero delivered so far,
+        settled only when the user confirms via :meth:`mark_irrigated`. A repeated
+        request while one is pending just refreshes the recommended amount.
+        """
+        self._pending_liters = liters
+        self._pending = True
+        if self._on_alert is not None:
+            self._on_alert(self._name, liters, deficit_mm)
+        return DeliveryResult(0.0, DeliveryQuality.DELAYED, 0.0, liters, detail="awaiting_manual")
+
+    def mark_irrigated(self, liters: float | None = None) -> DeliveryResult:
+        """Confirm the plant was hand-watered; return the ``declared`` result and clear the alert.
+
+        With no explicit ``liters`` the recommended amount is assumed (the user
+        followed the advice); an explicit figure lets a careful user declare how
+        much they actually poured. Either way the amount is *declared*, not
+        measured. The Zone settles its deficit with this result.
+        """
+        requested = self._pending_liters
+        delivered = requested if liters is None else max(0.0, liters)
+        self._pending = False
+        self._pending_liters = 0.0
+        if self._on_clear is not None:
+            self._on_clear(self._name)
+        return DeliveryResult(delivered, DeliveryQuality.DECLARED, 0.0, requested, detail="user_marked")

--- a/custom_components/never_dry/actuator.py
+++ b/custom_components/never_dry/actuator.py
@@ -1,0 +1,1312 @@
+"""Actuator abstraction — the single home for driving one irrigation actuator.
+
+This module materializes the domain model's ``Driver`` (see
+``docs/design_domain_object_model.md``) as a concrete, Home-Assistant-aware
+base class — the *attuatore* — together with its two specializations:
+
+* :class:`ZoneActuator` (the model's ``ZoneDriver``) — drives one zone's
+  valve/switch, translating a **liters** request into actuation and returning a
+  truthful :class:`DeliveryResult`.
+* :class:`MasterActuator` (the model's ``MasterDriver``) — drives shared
+  hydraulics (a master valve or pump), *following* aggregate zone activity with
+  an off-delay linger. It has no notion of liters.
+
+The abstract base :class:`Actuator` owns everything the two share, as the domain
+model prescribes: the entity adapter (``switch.*`` vs ``valve.*``), confirmed
+on/off commands over a pure :class:`~.valve_fsm.ValveFsm`, adaptive
+latency/timeout, the safety layers (absolute watchdog, hardware max-duration
+timer, ``CLOSE_LEAK`` recovery, stuck-open escalation), an active liveness
+probe, and the user-facing notifier seam.
+
+Design intent — this module is deliberately **self-contained**: it consolidates
+behaviour today scattered across ``valve_operator.py`` (the FSM host + safety),
+the controller ``_deliver_*`` loops (the three delivery strategies) and the
+still-missing master-pump logic (GH #95), so a later phase can *replace* those
+call sites with this one class hierarchy. It reuses the existing pure/host
+building blocks (``valve_fsm``, ``valve_latency``, ``valve_notifier``,
+``flow_utils``) by import rather than duplicating them.
+
+References: GH #74 (actuator abstraction), GH #94 (``valve.*`` support),
+GH #95 (master valve/pump), ``docs/design/actuator-abstraction.md``,
+``docs/design/valve-state-machine.md``, ``docs/design_domain_model_anomalies.md``
+(closes the *Driver ``<<abstract>>`` never declared* anomaly §C1 and gives
+``volume_preset`` a home behind the uniform ``deliver()`` seam, §A2/§D1).
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import timedelta
+from enum import StrEnum
+from time import monotonic
+from typing import ClassVar
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    async_track_time_interval,
+)
+
+from . import flow_utils
+from .const import (
+    DEFAULT_DELIVERY_TIMEOUT_S,
+    DELIVERY_MODE_ESTIMATED_FLOW,
+    DELIVERY_MODE_FLOW_METER,
+    DELIVERY_MODE_VOLUME_PRESET,
+    FLOW_METER_POLL_INTERVAL_S,
+)
+from .valve_fsm import (
+    CancelAllTimers,
+    CancelTimer,
+    EnterMaintenance,
+    FailureKind,
+    FsmAction,
+    FsmConfig,
+    NotifyFailure,
+    SendSwitchOff,
+    SendSwitchOn,
+    StartTimer,
+    TimerName,
+    TransitionResult,
+    ValveEvent,
+    ValveFsm,
+    ValveState,
+)
+from .valve_latency import MIN_SAMPLES, ValveLatencyTracker
+from .valve_notifier import NotificationKind, Severity, ValveNotifier
+
+_LOGGER = logging.getLogger(__name__)
+
+# ``volume_preset``: how long to wait for a smart valve to auto-open on a
+# ``number.set_value`` dose before we send an explicit open (idempotent).
+AUTO_OPEN_GRACE_S: float = 3.0
+# Default period of the active liveness probe (a Zigbee valve that drops off the
+# mesh often keeps showing a stale ``off``; passive state is not enough).
+DEFAULT_LIVENESS_INTERVAL_MIN: float = 30.0
+# Default linger before a master valve/pump follows the zones back to OFF.
+DEFAULT_MASTER_OFF_DELAY_S: float = 10.0
+
+
+# ── Entity adapter: switch.* vs valve.* (the shared floor, GH #94) ─────────
+
+
+class EntityDomain(StrEnum):
+    """The two actuator entity domains NeverDry can drive today."""
+
+    SWITCH = "switch"
+    VALVE = "valve"
+
+
+@dataclass(frozen=True)
+class ValveCommandAdapter:
+    """Map an ``entity_id`` to its command services and normalize its state.
+
+    This is the *floor* of the actuator abstraction (``actuator-abstraction.md``
+    §2): the one place that knows a ``switch.*`` opens with ``switch.turn_on``
+    and reports ``on``/``off``, while a ``valve.*`` opens with
+    ``valve.open_valve`` and reports ``open``/``closed``/``opening``/``closing``.
+    The domain is derived from the ``entity_id`` prefix at runtime — additive,
+    zero config migration, existing ``switch.*`` setups keep working unchanged.
+
+    Note: a **pump** is not a distinct HA domain — HA has no ``pump.*`` entity or
+    ``pump`` device_class. A pump is just a ``switch.*`` entity to HA (a relay
+    that turns it on/off), so it falls through the ``switch`` branch here with no
+    dedicated handling.
+    """
+
+    entity_id: str
+
+    @property
+    def domain(self) -> EntityDomain:
+        """Return the actuator domain, defaulting to ``switch`` for anything else."""
+        prefix = self.entity_id.split(".", 1)[0] if "." in self.entity_id else ""
+        return EntityDomain.VALVE if prefix == EntityDomain.VALVE.value else EntityDomain.SWITCH
+
+    def command(self, *, on: bool) -> tuple[str, str]:
+        """Return the ``(domain, service)`` pair that opens (``on``) or closes."""
+        if self.domain == EntityDomain.VALVE:
+            return ("valve", "open_valve" if on else "close_valve")
+        return ("switch", "turn_on" if on else "turn_off")
+
+    @staticmethod
+    def interpret_state(raw: str | None) -> str:
+        """Collapse a raw HA state to ``on`` / ``off`` / ``transitional`` / ``unavailable``.
+
+        ``opening``/``closing`` are *transitional*: the valve is moving and no
+        FSM observation should be emitted until it settles.
+        """
+        if raw is None or raw in ("unavailable", "unknown"):
+            return "unavailable" if raw != "unknown" else "unknown"
+        if raw in ("on", "open"):
+            return "on"
+        if raw in ("off", "closed"):
+            return "off"
+        if raw in ("opening", "closing"):
+            return "transitional"
+        return "unknown"
+
+
+# ── Delivery contract: DeliveryResult + qualifiers (domain model) ──────────
+
+
+class DeliveryQuality(StrEnum):
+    """How truthful the delivered-liters figure is (GH #74 review, fpytloun)."""
+
+    MEASURED = "measured"
+    ESTIMATED = "estimated"
+    PARTIAL = "partial"
+    DELAYED = "delayed"
+    LOW_CONFIDENCE = "low_confidence"
+
+
+class DeliveryMode(StrEnum):
+    """The three delivery strategies, mirroring the ``const`` string values.
+
+    Materializing the mode as an enum turns the controller's ``if mode == ...``
+    string dispatch (anomaly §D1) into real polymorphism at the ``deliver()``
+    seam.
+    """
+
+    ESTIMATED_FLOW = DELIVERY_MODE_ESTIMATED_FLOW
+    FLOW_METER = DELIVERY_MODE_FLOW_METER
+    VOLUME_PRESET = DELIVERY_MODE_VOLUME_PRESET
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    """The round-trip return of :meth:`ZoneActuator.deliver`.
+
+    Not a bare float: it carries how much water was delivered *and how truthful*
+    that figure is, so the Zone can settle its deficit and diagnostics can show
+    the user *how* the number was obtained. A backend that measures late can
+    :meth:`revise` an ``estimated``/``delayed`` result once the real figure lands.
+    """
+
+    liters_delivered: float
+    quality: DeliveryQuality
+    elapsed_s: float
+    requested_liters: float
+    detail: str | None = None
+
+    def revise(self, measured_liters: float, quality: DeliveryQuality = DeliveryQuality.MEASURED) -> DeliveryResult:
+        """Return a copy corrected with a later measured figure (see the model's ``revise``)."""
+        return replace(self, liters_delivered=measured_liters, quality=quality)
+
+
+# ── Command outcome types (carried over from valve_operator) ───────────────
+
+
+class OperationStatus(StrEnum):
+    """Outcome category for :meth:`Actuator.async_turn_on` / :meth:`async_turn_off`."""
+
+    OK = "ok"
+    FAILED = "failed"
+    MAINTENANCE = "maintenance"
+    PRECHECK_FAILED = "precheck_failed"
+
+
+@dataclass(frozen=True)
+class OperationResult:
+    """Typed return of a confirmed on/off cycle.
+
+    ``error_detail`` carries the :class:`~.valve_fsm.FailureKind` name on FAILED,
+    the precheck reason on PRECHECK_FAILED, or ``"in_maintenance"`` when locked.
+    """
+
+    status: OperationStatus
+    error_detail: str | None = None
+    retries_used: int = 0
+    duration_ms: float = 0.0
+
+
+# ── Internal mappings (carried over from valve_operator) ───────────────────
+
+
+_TIMEOUT_EVENT_FOR_TIMER: dict[TimerName, ValveEvent] = {
+    TimerName.OPEN: ValveEvent.TIMEOUT_OPEN,
+    TimerName.CLOSE: ValveEvent.TIMEOUT_CLOSE,
+    TimerName.FLOW: ValveEvent.TIMEOUT_FLOW,
+    TimerName.LEAK: ValveEvent.TIMEOUT_LEAK,
+}
+
+_TRANSIENT_FAILURES: frozenset[FailureKind] = frozenset(
+    {FailureKind.OPEN_FAILED, FailureKind.CLOSE_VERIFICATION_FAILED}
+)
+
+_OPEN_STATES: frozenset[ValveState] = frozenset({ValveState.OPEN, ValveState.OPEN_VERIFIED})
+
+_OPERATION_FOR_FAILURE: dict[FailureKind, str] = {
+    FailureKind.OPEN_FAILED: "open",
+    FailureKind.ACTUATION_FAILED: "open",
+    FailureKind.CLOSE_VERIFICATION_FAILED: "close",
+    FailureKind.CLOSE_LEAK: "close",
+}
+
+
+# ── The abstract actuator (the model's ``Driver``) ─────────────────────────
+
+
+class Actuator(abc.ABC):
+    """HA-aware driver for a single actuator, sitting on a pure :class:`ValveFsm`.
+
+    Owns the entity adapter, confirmed on/off commands with retry on transient
+    (comms) failures, the adaptive latency timeout, the absolute watchdog, the
+    optional hardware max-duration timer, ``CLOSE_LEAK`` recovery + stuck-open
+    escalation, and an active liveness probe. Subclasses add *what* to do with a
+    live actuator: :class:`ZoneActuator` delivers liters; :class:`MasterActuator`
+    follows aggregate activity.
+    """
+
+    DEFAULT_BACKOFF_S: ClassVar[tuple[float, ...]] = (1.0, 2.0, 4.0, 8.0, 16.0)
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        *,
+        flow_sensor_entity_id: str | None = None,
+        name: str = "",
+        fsm_config: FsmConfig | None = None,
+        max_retries: int = 5,
+        backoff_s: tuple[float, ...] | None = None,
+        flow_zero_threshold: float = 0.05,
+        notifier: ValveNotifier | None = None,
+        max_open_duration_s: float | Callable[[], float] = 3600.0,
+        hw_max_duration_entity: str | None = None,
+        hw_max_duration_multiplier: float = 1.0,
+        hw_max_duration_topic: str | None = None,
+        hw_max_duration_payload_template: str = "{value}",
+        availability_entity: str | None = None,
+    ) -> None:
+        """Wire the actuator to HA, subscribe to state changes and build the FSM."""
+        self._hass = hass
+        self._entity_id = entity_id
+        self._adapter = ValveCommandAdapter(entity_id)
+        self._flow_sensor_entity_id = flow_sensor_entity_id
+        self._name = name or entity_id
+        # One command owns 1 + max_retries attempts, so the retry budget can
+        # never trip MAINTENANCE mid-command — a fully-failed command reaches
+        # it exactly at its definitive failure.
+        self._fsm_config = fsm_config or FsmConfig(
+            has_flow_meter=flow_sensor_entity_id is not None,
+            max_consecutive_failures=max_retries + 1,
+        )
+        self._fsm = ValveFsm(self._fsm_config)
+        self._max_retries = max_retries
+        self._backoff_s = backoff_s if backoff_s is not None else self.DEFAULT_BACKOFF_S
+        self._flow_zero_threshold = flow_zero_threshold
+        self._notifier = notifier
+        # Static float or zero-arg callable re-evaluated at every open, so the
+        # watchdog and hardware timer track the current deficit, not a snapshot.
+        self._max_open_duration_s = max_open_duration_s
+        self._hw_max_duration_entity = hw_max_duration_entity
+        self._hw_max_duration_multiplier = hw_max_duration_multiplier
+        self._hw_max_duration_topic = hw_max_duration_topic
+        self._hw_max_duration_payload_template = hw_max_duration_payload_template
+        self._availability_entity = availability_entity
+
+        self._lock = asyncio.Lock()
+        self._timers: dict[TimerName, asyncio.Task] = {}
+        self._completion: asyncio.Future[OperationResult] | None = None
+        self._expected_terminal: tuple[ValveState, ...] = ()
+        self._leak_recovery_attempted: bool = False
+        self._retries_left: int = 0
+        self._watchdog_task: asyncio.Task | None = None
+        self._hw_duration_set: bool = False
+
+        self._latency = ValveLatencyTracker(hass, entity_id)
+        self._cmd_start_time: float | None = None
+        hass.async_create_task(self._latency.async_load())
+
+        self._unsub_switch = async_track_state_change_event(hass, [entity_id], self._on_switch_state)
+        self._unsub_flow = None
+        if flow_sensor_entity_id:
+            self._unsub_flow = async_track_state_change_event(hass, [flow_sensor_entity_id], self._on_flow_state)
+        self._unsub_liveness = None
+
+    # ── Identity ────────────────────────────────────────────────────────
+
+    @property
+    @abc.abstractmethod
+    def role(self) -> str:
+        """Return the actuator role (``"zone"`` / ``"master"``) — makes the base abstract."""
+
+    @property
+    def name(self) -> str:
+        """Human-facing name for logs and notifications."""
+        return self._name
+
+    @property
+    def entity_id(self) -> str:
+        """The driven actuator entity id."""
+        return self._entity_id
+
+    # ── State properties ─────────────────────────────────────────────────
+
+    @property
+    def state(self) -> ValveState:
+        """Return the underlying FSM state."""
+        return self._fsm.state
+
+    @property
+    def is_open(self) -> bool:
+        """``True`` while the FSM believes the actuator is open."""
+        return self._fsm.state in _OPEN_STATES
+
+    @property
+    def is_in_maintenance(self) -> bool:
+        """``True`` when the actuator is locked in MAINTENANCE."""
+        return self._fsm.state == ValveState.MAINTENANCE
+
+    @property
+    def failure_count(self) -> int:
+        """Return the FSM's consecutive-failure counter."""
+        return self._fsm.failure_count
+
+    @property
+    def latency_diagnostics(self) -> dict:
+        """Return latency statistics for this actuator (open and close windows)."""
+        return self._latency.as_dict()
+
+    def _current_max_open_duration(self) -> float:
+        """Resolve the max-open duration, evaluating the provider if callable."""
+        if callable(self._max_open_duration_s):
+            return float(self._max_open_duration_s())
+        return float(self._max_open_duration_s)
+
+    # ── Public command API ───────────────────────────────────────────────
+
+    async def async_turn_on(self) -> OperationResult:
+        """Open the actuator, awaiting verification.
+
+        Returns once the FSM reaches ``OPEN_VERIFIED`` (with flow meter) or
+        ``OPEN`` (without). Retries transient failures with exponential backoff
+        up to ``max_retries``; physical failures return immediately.
+        """
+        terminals: tuple[ValveState, ...] = (
+            (ValveState.OPEN_VERIFIED,) if self._fsm_config.has_flow_meter else (ValveState.OPEN,)
+        )
+        return await self._run_command(cmd=ValveEvent.CMD_OPEN, terminals=terminals)
+
+    async def async_turn_off(self) -> OperationResult:
+        """Close the actuator, awaiting verification, with ``CLOSE_LEAK`` recovery.
+
+        On ``CLOSE_LEAK`` (switch off but flow still positive) the last-resort
+        recovery runs *before* declaring the close failed:
+
+        1. Re-issue the close directly (bypassing the FSM, in case the first
+           command was lost on the wire).
+        2. Wait ``leak_timeout_s`` for the flow to drop.
+        3. If the flow dropped → report ``OK`` with ``error_detail="leak_recovered"``.
+        4. If the flow is still positive → call the integration-wide emergency
+           stop, emit a CRITICAL ``STUCK_OPEN`` and return the ``FAILED`` result.
+
+        Recovery is attempted at most **once** per call.
+        """
+        self._leak_recovery_attempted = False
+        result = await self._run_command(cmd=ValveEvent.CMD_CLOSE, terminals=(ValveState.IDLE,))
+        if (
+            result.status == OperationStatus.FAILED
+            and result.error_detail == FailureKind.CLOSE_LEAK.value
+            and not self._leak_recovery_attempted
+        ):
+            self._leak_recovery_attempted = True
+            if await self._attempt_leak_recovery():
+                return OperationResult(
+                    status=OperationStatus.OK,
+                    error_detail="leak_recovered",
+                    retries_used=result.retries_used,
+                    duration_ms=result.duration_ms,
+                )
+            await self._escalate_stuck_open()
+        return result
+
+    async def async_reset_maintenance(self) -> None:
+        """Clear ``MAINTENANCE`` and reset the failure counter."""
+        await self._dispatch(ValveEvent.CMD_RESET)
+
+    def async_unload(self) -> None:
+        """Detach state listeners, stop the liveness probe and cancel every timer."""
+        if self._unsub_switch:
+            self._unsub_switch()
+        if self._unsub_flow:
+            self._unsub_flow()
+        if self._unsub_liveness:
+            self._unsub_liveness()
+            self._unsub_liveness = None
+        self._cancel_all_timers()
+        self._cancel_watchdog()
+
+    # ── Active liveness probe (Driver.ping in the model) ─────────────────
+
+    def start_liveness_probe(self, interval_min: float = DEFAULT_LIVENESS_INTERVAL_MIN) -> None:
+        """Begin polling the actuator's reachability every ``interval_min`` minutes.
+
+        Passive HA state is not enough: a sleepy Zigbee valve that drops off the
+        mesh can keep showing a stale ``off`` for hours. The probe drives the
+        FSM ``UNREACHABLE`` state and an ``UNREACHABLE_PASSIVE`` notification so
+        the user learns about a dead valve *before* the next scheduled run.
+        """
+        if self._unsub_liveness is not None:
+            return
+        self._unsub_liveness = async_track_time_interval(
+            self._hass, self._on_liveness_tick, timedelta(minutes=interval_min)
+        )
+
+    @callback
+    def _on_liveness_tick(self, _now) -> None:
+        """Time-interval callback: schedule the async reachability probe."""
+        self._hass.async_create_task(self.async_ping())
+
+    async def async_ping(self) -> bool:
+        """Probe reachability once; return ``True`` when the actuator is live.
+
+        Uses the cheapest backend-appropriate signal: a dedicated availability
+        entity when configured (e.g. a Z2M availability sensor), otherwise the
+        actuator entity's own state. A failed probe feeds the *existing*
+        machinery — the FSM ``OBS_UNAVAILABLE`` event and an
+        ``UNREACHABLE_PASSIVE`` notification — rather than inventing a new one.
+        """
+        source = self._availability_entity or self._entity_id
+        state = self._hass.states.get(source)
+        raw = state.state if state is not None else None
+        reachable = (
+            raw not in (None, "unavailable", "unknown", "off")
+            if self._availability_entity
+            else (state is not None and state.state not in ("unavailable", "unknown"))
+        )
+        if not reachable:
+            if self._fsm.state != ValveState.UNREACHABLE:
+                await self._dispatch(ValveEvent.OBS_UNAVAILABLE)
+            if self._notifier is not None:
+                await self._notifier.notify(
+                    self._name,
+                    NotificationKind.UNREACHABLE_PASSIVE,
+                    Severity.WARNING,
+                    context={"duration": "detected by liveness probe"},
+                )
+            return False
+        if self._fsm.state == ValveState.UNREACHABLE:
+            await self._dispatch(ValveEvent.OBS_AVAILABLE)
+        if self._notifier is not None and self._notifier.is_active(self._name, NotificationKind.UNREACHABLE_PASSIVE):
+            await self._notifier.clear(self._name, NotificationKind.UNREACHABLE_PASSIVE)
+        return True
+
+    # ── Command driver ───────────────────────────────────────────────────
+
+    async def _run_command(self, cmd: ValveEvent, terminals: tuple[ValveState, ...]) -> OperationResult:
+        """Run an open or close cycle with retry on transient failures."""
+        start = monotonic()
+        precheck = self._precheck()
+        if precheck is not None:
+            return OperationResult(
+                status=precheck[0],
+                error_detail=precheck[1],
+                retries_used=0,
+                duration_ms=self._elapsed_ms(start),
+            )
+        async with self._lock:
+            retries = 0
+            while True:
+                self._retries_left = self._max_retries - retries
+                outcome = await self._run_cycle(cmd, terminals)
+                if outcome.status == OperationStatus.OK:
+                    return self._finalise(outcome, retries, start)
+                if not self._is_retryable(outcome) or retries >= self._max_retries:
+                    return self._finalise(outcome, retries, start)
+                retries += 1
+                await asyncio.sleep(self._backoff_for(retries - 1))
+
+    def _precheck(self) -> tuple[OperationStatus, str] | None:
+        """Return a failure tuple if HA state forbids dispatching, else ``None``."""
+        if self._fsm.state == ValveState.MAINTENANCE:
+            return (OperationStatus.MAINTENANCE, "in_maintenance")
+        state = self._hass.states.get(self._entity_id)
+        if state is None:
+            return (OperationStatus.PRECHECK_FAILED, "switch_entity_not_found")
+        if state.state in ("unavailable", "unknown"):
+            return (OperationStatus.PRECHECK_FAILED, "switch_unavailable")
+        return None
+
+    async def _run_cycle(self, cmd: ValveEvent, terminals: tuple[ValveState, ...]) -> OperationResult:
+        """Dispatch ``cmd`` and await the resulting cycle completion."""
+        loop = asyncio.get_event_loop()
+        self._completion = loop.create_future()
+        self._expected_terminal = terminals
+        self._cmd_start_time = monotonic()
+        await self._dispatch(cmd)
+        return await self._completion
+
+    def _is_retryable(self, outcome: OperationResult) -> bool:
+        """``True`` if ``outcome`` describes a transient (comms) failure."""
+        if outcome.status != OperationStatus.FAILED or outcome.error_detail is None:
+            return False
+        try:
+            kind = FailureKind(outcome.error_detail)
+        except ValueError:
+            return False
+        return kind in _TRANSIENT_FAILURES
+
+    def _backoff_for(self, retry_index: int) -> float:
+        """Return the sleep duration before retry number ``retry_index``."""
+        if not self._backoff_s:
+            return 0.0
+        idx = min(retry_index, len(self._backoff_s) - 1)
+        return self._backoff_s[idx]
+
+    def _finalise(self, outcome: OperationResult, retries: int, start: float) -> OperationResult:
+        """Stamp timing and retry count on an :class:`OperationResult`."""
+        return OperationResult(
+            status=outcome.status,
+            error_detail=outcome.error_detail,
+            retries_used=retries,
+            duration_ms=self._elapsed_ms(start),
+        )
+
+    @staticmethod
+    def _elapsed_ms(start: float) -> float:
+        """Return milliseconds elapsed since ``start`` (``monotonic()`` based)."""
+        return (monotonic() - start) * 1000.0
+
+    # ── FSM bridging ─────────────────────────────────────────────────────
+
+    async def _dispatch(self, event: ValveEvent) -> None:
+        """Push ``event`` into the FSM, execute its actions, settle the future."""
+        result = self._fsm.dispatch(event)
+        await self._execute_actions(result.actions)
+        self._check_terminal(result)
+        self._manage_watchdog()
+
+    async def _execute_actions(self, actions: tuple[FsmAction, ...]) -> None:
+        """Run every action returned by the FSM, in order."""
+        for action in actions:
+            await self._execute_action(action)
+
+    async def _execute_action(self, action: FsmAction) -> None:
+        """Execute a single FSM action against Home Assistant."""
+        if isinstance(action, SendSwitchOn):
+            await self._call_actuator(on=True)
+        elif isinstance(action, SendSwitchOff):
+            await self._call_actuator(on=False)
+        elif isinstance(action, StartTimer):
+            self._start_timer(action.name, action.seconds)
+        elif isinstance(action, CancelTimer):
+            self._cancel_timer(action.name)
+        elif isinstance(action, CancelAllTimers):
+            self._cancel_all_timers()
+        elif isinstance(action, NotifyFailure):
+            await self._notify_failure(action.kind)
+        elif isinstance(action, EnterMaintenance):
+            await self._notify_maintenance()
+
+    def _check_terminal(self, result: TransitionResult) -> None:
+        """If ``result`` terminates the current cycle, resolve the awaiting future."""
+        if self._completion is None or self._completion.done():
+            return
+        if result.to_state == ValveState.MAINTENANCE:
+            detail = result.failure.value if result.failure else "in_maintenance"
+            self._completion.set_result(OperationResult(OperationStatus.MAINTENANCE, detail))
+            return
+        if result.failure is not None:
+            self._completion.set_result(OperationResult(OperationStatus.FAILED, result.failure.value))
+            return
+        if result.to_state in self._expected_terminal:
+            self._completion.set_result(OperationResult(OperationStatus.OK))
+
+    # ── Notifier bridging ────────────────────────────────────────────────
+
+    async def _notify_failure(self, kind: FailureKind) -> None:
+        """Surface a FailureKind via the notifier (or log if none configured).
+
+        ``CLOSE_LEAK`` is intentionally suppressed here: :meth:`async_turn_off`
+        attempts recovery first, and :meth:`_escalate_stuck_open` sends CRITICAL
+        only if recovery fails. Transient failures are also suppressed while
+        retry attempts remain: on a flaky Zigbee mesh a late confirmation is
+        routine, and alerting on every attempt produced spurious CRITICALs.
+        """
+        if kind in _TRANSIENT_FAILURES and self._retries_left > 0:
+            _LOGGER.warning(
+                "Actuator '%s' transient failure %s — retrying (%d attempt(s) left)",
+                self._name,
+                kind.name,
+                self._retries_left,
+            )
+            return
+        _LOGGER.error("Actuator '%s' failure: %s", self._name, kind.name)
+        if self._notifier is None:
+            return
+        if kind == FailureKind.CLOSE_LEAK:
+            return
+        severity = Severity.CRITICAL if kind == FailureKind.CLOSE_VERIFICATION_FAILED else Severity.WARNING
+        await self._notifier.notify(
+            self._name,
+            NotificationKind.COMMAND_FAILED,
+            severity,
+            context={"operation": _OPERATION_FOR_FAILURE[kind], "error_detail": kind.value},
+        )
+
+    async def _attempt_leak_recovery(self) -> bool:
+        """Last-resort recovery from ``CLOSE_LEAK``: re-issue close, re-check flow."""
+        _LOGGER.warning(
+            "Actuator '%s' CLOSE_LEAK detected — attempting recovery (direct close + recheck)",
+            self._name,
+        )
+        await self._call_actuator(on=False)
+        await asyncio.sleep(self._fsm_config.leak_timeout_s)
+
+        if self._flow_sensor_entity_id is None:
+            return False
+        state = self._hass.states.get(self._flow_sensor_entity_id)
+        if state is None:
+            return False
+        try:
+            flow = float(state.state)
+        except (ValueError, TypeError):
+            return False
+        recovered = flow <= self._flow_zero_threshold
+        if recovered:
+            _LOGGER.info("Actuator '%s' leak recovery succeeded (flow=%.3f)", self._name, flow)
+        else:
+            _LOGGER.error("Actuator '%s' leak recovery failed (flow=%.3f)", self._name, flow)
+        return recovered
+
+    async def _escalate_stuck_open(self) -> None:
+        """Trigger integration-wide emergency stop + CRITICAL notification."""
+        _LOGGER.error(
+            "Actuator '%s' stuck-open confirmed after recovery; calling never_dry.stop and escalating",
+            self._name,
+        )
+        try:
+            await self._hass.services.async_call("never_dry", "stop", {}, blocking=False)
+        except Exception as exc:
+            _LOGGER.error("Failed to trigger emergency stop for stuck-open '%s': %s", self._name, exc)
+        if self._notifier is None:
+            return
+        await self._notifier.notify(
+            self._name,
+            NotificationKind.STUCK_OPEN,
+            Severity.CRITICAL,
+            context={"flow": "still positive after recovery attempt"},
+        )
+
+    async def _notify_maintenance(self) -> None:
+        """Notify that the actuator just entered MAINTENANCE."""
+        _LOGGER.error(
+            "Actuator '%s' entered MAINTENANCE (consecutive failures = %d)",
+            self._name,
+            self._fsm.failure_count,
+        )
+        if self._notifier is None:
+            return
+        await self._notifier.notify(
+            self._name,
+            NotificationKind.ZONE_DISABLED,
+            Severity.CRITICAL,
+            context={"failures": self._fsm.failure_count},
+        )
+
+    # ── HA service helper (adapter-routed: switch.* or valve.*) ──────────
+
+    async def _call_actuator(self, *, on: bool) -> None:
+        """Invoke the open/close service on the configured entity, logging errors."""
+        domain, service = self._adapter.command(on=on)
+        try:
+            await self._hass.services.async_call(
+                domain,
+                service,
+                {"entity_id": self._entity_id},
+                blocking=False,
+            )
+        except Exception as exc:
+            _LOGGER.error("Actuator '%s' %s.%s call raised: %s", self._name, domain, service, exc)
+
+    def _read_normalized_state(self) -> str:
+        """Return the actuator's normalized state via the adapter."""
+        state = self._hass.states.get(self._entity_id)
+        return self._adapter.interpret_state(state.state if state is not None else None)
+
+    def _actuator_is_off(self) -> bool:
+        """``True`` when the actuator entity currently reads closed/off."""
+        return self._read_normalized_state() == "off"
+
+    # ── Watchdog + hardware max-duration timer ───────────────────────────
+
+    def _manage_watchdog(self) -> None:
+        """Start the absolute watchdog while open; cancel it otherwise.
+
+        On the first transition into an open state also schedules the hardware
+        max-duration write (if configured), so the on-device timer is set even
+        if HA later loses communication.
+        """
+        if self._fsm.state in _OPEN_STATES:
+            if self._watchdog_task is None or self._watchdog_task.done():
+                self._watchdog_task = self._hass.async_create_task(self._watchdog())
+                self._hass.async_create_task(self._set_hw_max_duration())
+        else:
+            self._cancel_watchdog()
+
+    def _cancel_watchdog(self) -> None:
+        """Cancel the watchdog task and reset the hw-duration sentinel."""
+        if self._watchdog_task and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+        self._watchdog_task = None
+        self._hw_duration_set = False
+
+    async def _set_hw_max_duration(self) -> None:
+        """Write max_open_duration to the actuator's on-device hardware timer.
+
+        Called once per open cycle (idempotent via ``_hw_duration_set``). Prefers
+        a HA ``number`` entity (``hw_max_duration_entity``); falls back to raw
+        ``mqtt.publish`` (``hw_max_duration_topic``) with a configurable payload
+        template rendered with ``{value}``. Failures are logged, never raised.
+        """
+        if self._hw_duration_set:
+            return
+        has_entity = self._hw_max_duration_entity is not None
+        has_topic = self._hw_max_duration_topic is not None
+        if not has_entity and not has_topic:
+            return
+        self._hw_duration_set = True
+        value = round(self._current_max_open_duration() * self._hw_max_duration_multiplier, 1)
+
+        if has_entity:
+            try:
+                await self._hass.services.async_call(
+                    "number",
+                    "set_value",
+                    {"entity_id": self._hw_max_duration_entity, "value": value},
+                    blocking=False,
+                )
+                _LOGGER.debug(
+                    "Actuator '%s' hardware max_duration set to %.1f via entity %s",
+                    self._name,
+                    value,
+                    self._hw_max_duration_entity,
+                )
+                return
+            except Exception as exc:
+                _LOGGER.warning(
+                    "Actuator '%s' failed to set hardware max_duration via entity %s: %s; trying MQTT",
+                    self._name,
+                    self._hw_max_duration_entity,
+                    exc,
+                )
+
+        if has_topic:
+            try:
+                payload = self._hw_max_duration_payload_template.format(value=value)
+                await self._hass.services.async_call(
+                    "mqtt",
+                    "publish",
+                    {"topic": self._hw_max_duration_topic, "payload": payload},
+                    blocking=False,
+                )
+                _LOGGER.debug(
+                    "Actuator '%s' hardware max_duration set to %.1f via MQTT topic %s",
+                    self._name,
+                    value,
+                    self._hw_max_duration_topic,
+                )
+            except Exception as exc:
+                _LOGGER.warning(
+                    "Actuator '%s' failed to set hardware max_duration via MQTT topic %s: %s",
+                    self._name,
+                    self._hw_max_duration_topic,
+                    exc,
+                )
+
+    async def _watchdog(self) -> None:
+        """Absolute safety timer: force-close the actuator if it stays open too long."""
+        max_open_s = self._current_max_open_duration()
+        try:
+            await asyncio.sleep(max_open_s)
+        except asyncio.CancelledError:
+            return
+        _LOGGER.error(
+            "Actuator '%s' watchdog triggered after %.0f s open — forcing close",
+            self._name,
+            max_open_s,
+        )
+        await self._call_actuator(on=False)
+        if self._notifier is not None:
+            await self._notifier.notify(
+                self._name,
+                NotificationKind.WATCHDOG_TRIGGERED,
+                Severity.CRITICAL,
+                context={"duration_min": int(max_open_s / 60)},
+            )
+
+    # ── Timer plumbing ───────────────────────────────────────────────────
+
+    def _start_timer(self, name: TimerName, seconds: float) -> None:
+        """Start (or restart) a named timer that dispatches the matching TIMEOUT."""
+        self._cancel_timer(name)
+        if name == TimerName.OPEN and len(self._latency.open._samples) >= MIN_SAMPLES:
+            seconds = self._latency.open_timeout_s()
+        elif name == TimerName.CLOSE and len(self._latency.close._samples) >= MIN_SAMPLES:
+            seconds = self._latency.close_timeout_s()
+        self._timers[name] = self._hass.async_create_task(self._timer(name, seconds))
+
+    def _cancel_timer(self, name: TimerName) -> None:
+        """Cancel ``name`` if it is running; safe to call when absent."""
+        task = self._timers.pop(name, None)
+        if task and not task.done():
+            task.cancel()
+
+    def _cancel_all_timers(self) -> None:
+        """Cancel every active timer for this actuator."""
+        for name in list(self._timers):
+            self._cancel_timer(name)
+
+    async def _timer(self, name: TimerName, seconds: float) -> None:
+        """Background task: sleep, then dispatch the matching ``TIMEOUT_*`` event."""
+        try:
+            await asyncio.sleep(seconds)
+            await self._dispatch(_TIMEOUT_EVENT_FOR_TIMER[name])
+        except asyncio.CancelledError:
+            pass
+
+    # ── HA state listeners ───────────────────────────────────────────────
+
+    @callback
+    def _on_switch_state(self, event) -> None:
+        """HA callback: schedule the async actuator-state handler."""
+        self._hass.async_create_task(self._handle_switch_state(event))
+
+    @callback
+    def _on_flow_state(self, event) -> None:
+        """HA callback: schedule the async flow-state handler."""
+        self._hass.async_create_task(self._handle_flow_state(event))
+
+    async def _handle_switch_state(self, event) -> None:
+        """Map an actuator state change to the matching FSM observation."""
+        new_state = event.data.get("new_state")
+        if new_state is None:
+            return
+        value = self._adapter.interpret_state(new_state.state)
+        if value in ("unavailable", "unknown"):
+            await self._dispatch(ValveEvent.OBS_UNAVAILABLE)
+            return
+        if value == "transitional":
+            # Valve is moving (opening/closing); wait for it to settle.
+            return
+        if self._fsm.state == ValveState.UNREACHABLE:
+            await self._dispatch(ValveEvent.OBS_AVAILABLE)
+        if value == "on":
+            self._record_latency(self._latency.open, ValveState.REQ_OPEN, self._latency.open_timeout_s)
+            await self._dispatch(ValveEvent.OBS_SWITCH_ON)
+        elif value == "off":
+            self._record_latency(self._latency.close, ValveState.REQ_CLOSE, self._latency.close_timeout_s)
+            await self._dispatch(ValveEvent.OBS_SWITCH_OFF)
+
+    def _record_latency(self, window, awaited_state: ValveState, timeout_getter: Callable[[], float]) -> None:
+        """Record the command→confirmation latency if we were awaiting ``awaited_state``."""
+        if self._fsm.state != awaited_state or self._cmd_start_time is None:
+            return
+        latency_ms = (monotonic() - self._cmd_start_time) * 1000.0
+        self._cmd_start_time = None
+        window.record(latency_ms)
+        self._hass.async_create_task(self._latency.async_save())
+        _LOGGER.debug(
+            "Actuator '%s' confirmation latency %.1f ms → adaptive timeout %.2f s",
+            self._name,
+            latency_ms,
+            timeout_getter(),
+        )
+
+    async def _handle_flow_state(self, event) -> None:
+        """Map a flow-sensor state change to OBS_FLOW_POSITIVE/OBS_FLOW_ZERO."""
+        new_state = event.data.get("new_state")
+        if new_state is None:
+            return
+        try:
+            flow = float(new_state.state)
+        except (ValueError, TypeError):
+            return
+        if flow > self._flow_zero_threshold:
+            await self._dispatch(ValveEvent.OBS_FLOW_POSITIVE)
+        else:
+            await self._dispatch(ValveEvent.OBS_FLOW_ZERO)
+
+
+# ── Zone actuator (the model's ``ZoneDriver``) ─────────────────────────────
+
+
+class ZoneActuator(Actuator):
+    """Drive one zone's actuator, translating a **liters** request into water.
+
+    ``deliver(liters)`` is the contract with the Zone: the zone always asks for
+    liters and only the driver knows whether to deliver them by native volume,
+    by measured flow, or by time x flow rate. It returns a :class:`DeliveryResult`
+    stating the delivered liters *as truthfully as the backend allows*.
+
+    All three strategies live behind this one seam — including ``volume_preset``,
+    whose smart-valve self-close is a *strategy detail* here rather than a bypass
+    of the whole abstraction (closes anomalies §A2/§D1).
+    """
+
+    role = "zone"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        *,
+        delivery_mode: str | DeliveryMode = DeliveryMode.ESTIMATED_FLOW,
+        flow_rate_lpm: float = 0.0,
+        volume_entity: str | None = None,
+        flow_meter_sensor: str | None = None,
+        delivery_timeout_s: float = DEFAULT_DELIVERY_TIMEOUT_S,
+        auto_open_grace_s: float = AUTO_OPEN_GRACE_S,
+        **base_kwargs,
+    ) -> None:
+        """Configure a zone actuator; ``base_kwargs`` flow to :class:`Actuator`."""
+        super().__init__(hass, entity_id, flow_sensor_entity_id=flow_meter_sensor, **base_kwargs)
+        self._delivery_mode = DeliveryMode(delivery_mode)
+        self._flow_rate_lpm = flow_rate_lpm
+        self._volume_entity = volume_entity
+        self._flow_meter_sensor = flow_meter_sensor
+        self._delivery_timeout_s = delivery_timeout_s
+        self._auto_open_grace_s = auto_open_grace_s
+
+    @property
+    def delivery_mode(self) -> DeliveryMode:
+        """The configured delivery strategy."""
+        return self._delivery_mode
+
+    # ── The liters → actuation contract ──────────────────────────────────
+
+    async def deliver(
+        self,
+        liters: float,
+        *,
+        should_abort: Callable[[], bool] | None = None,
+        on_progress: Callable[[float], None] | None = None,
+    ) -> DeliveryResult:
+        """Deliver ``liters`` of water and return a truthful :class:`DeliveryResult`.
+
+        ``should_abort`` lets the caller stop delivery early (global/zone stop);
+        ``on_progress`` receives the running delivered-liters figure so the caller
+        can update a live deficit. Polymorphic dispatch over :class:`DeliveryMode`
+        replaces the controller's ``if mode == ...`` chain.
+        """
+        if liters <= 0:
+            return DeliveryResult(0.0, DeliveryQuality.MEASURED, 0.0, liters)
+        if self._delivery_mode == DeliveryMode.ESTIMATED_FLOW:
+            return await self._deliver_estimated_flow(liters, should_abort)
+        if self._delivery_mode == DeliveryMode.FLOW_METER:
+            return await self._deliver_flow_meter(liters, should_abort, on_progress)
+        if self._delivery_mode == DeliveryMode.VOLUME_PRESET:
+            return await self._deliver_volume_preset(liters, should_abort)
+        _LOGGER.error("Unknown delivery mode '%s' for zone '%s'", self._delivery_mode, self._name)
+        return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail="unknown_delivery_mode")
+
+    # ── Strategy 1: estimated flow (open, wait, close) ───────────────────
+
+    async def _deliver_estimated_flow(self, liters: float, should_abort: Callable[[], bool] | None) -> DeliveryResult:
+        """Open, wait the duration implied by the nominal flow rate, close.
+
+        No measurement: the delivered figure is time-based, so it is ``estimated``
+        (``partial`` when interrupted or auto-closed early).
+        """
+        if self._flow_rate_lpm <= 0:
+            _LOGGER.warning("Zone '%s' has no flow_rate configured; cannot estimate duration", self._name)
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail="no_flow_rate")
+        duration = liters / self._flow_rate_lpm * 60.0
+        if duration <= 0:
+            return DeliveryResult(0.0, DeliveryQuality.MEASURED, 0.0, liters)
+
+        if (result := await self.async_turn_on()).status != OperationStatus.OK:
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail=result.error_detail)
+
+        elapsed = await self._wait_with_abort(duration, should_abort)
+        await self.async_turn_off()
+        delivered = liters * min(elapsed, duration) / duration
+        quality = DeliveryQuality.ESTIMATED if elapsed >= duration else DeliveryQuality.PARTIAL
+        return DeliveryResult(delivered, quality, elapsed, liters)
+
+    # ── Strategy 2: flow meter (cumulative volume or integrated rate) ────
+
+    async def _deliver_flow_meter(
+        self,
+        liters: float,
+        should_abort: Callable[[], bool] | None,
+        on_progress: Callable[[float], None] | None,
+    ) -> DeliveryResult:
+        """Open, monitor the flow sensor, close when the target volume is reached."""
+        meter = self._flow_meter_sensor
+        if not meter:
+            _LOGGER.error("Zone '%s' has no flow_meter_sensor configured", self._name)
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail="no_flow_meter")
+        if flow_utils.is_flow_rate_sensor(self._hass, meter):
+            return await self._deliver_by_rate(liters, meter, should_abort, on_progress)
+        return await self._deliver_by_volume(liters, meter, should_abort, on_progress)
+
+    async def _deliver_by_volume(
+        self,
+        liters: float,
+        meter: str,
+        should_abort: Callable[[], bool] | None,
+        on_progress: Callable[[float], None] | None,
+    ) -> DeliveryResult:
+        """Cumulative-volume meter: deliver by the delta between start and current reading."""
+        initial = flow_utils.read_volume_liters(self._hass, meter)
+        if initial is None:
+            _LOGGER.error("Flow meter '%s' unavailable for zone '%s'", meter, self._name)
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail="meter_unavailable")
+
+        if (result := await self.async_turn_on()).status != OperationStatus.OK:
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail=result.error_detail)
+
+        delivered = 0.0
+        elapsed = 0.0
+        timeout = self._delivery_timeout_s
+        reached_target = False
+        while elapsed < timeout:
+            if should_abort and should_abort():
+                break
+            await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+            elapsed += FLOW_METER_POLL_INTERVAL_S
+            if self._actuator_is_off():
+                break  # hardware auto-close — stop polling a dead meter
+            current = flow_utils.read_volume_liters(self._hass, meter)
+            if current is None:
+                continue
+            delivered = current - initial
+            if delivered < 0:
+                initial = 0.0
+                delivered = current
+            if on_progress:
+                on_progress(delivered)
+            if delivered >= liters:
+                reached_target = True
+                break
+
+        await self.async_turn_off()
+        return self._settle(liters, delivered, elapsed, reached_target)
+
+    async def _deliver_by_rate(
+        self,
+        liters: float,
+        meter: str,
+        should_abort: Callable[[], bool] | None,
+        on_progress: Callable[[float], None] | None,
+    ) -> DeliveryResult:
+        """Flow-rate meter: integrate the rate (normalized to L/min) over time."""
+        if (result := await self.async_turn_on()).status != OperationStatus.OK:
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail=result.error_detail)
+
+        delivered = 0.0
+        elapsed = 0.0
+        timeout = self._delivery_timeout_s
+        reached_target = False
+        while elapsed < timeout:
+            if should_abort and should_abort():
+                break
+            await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+            elapsed += FLOW_METER_POLL_INTERVAL_S
+            if self._actuator_is_off():
+                break
+            rate = flow_utils.read_flow_meter(self._hass, meter)
+            if rate is None or rate < 0:
+                continue
+            unit = flow_utils.get_flow_meter_unit(self._hass, meter)
+            delivered += flow_utils.rate_to_lpm(rate, unit) / 60.0 * FLOW_METER_POLL_INTERVAL_S
+            if on_progress:
+                on_progress(delivered)
+            if delivered >= liters:
+                reached_target = True
+                break
+
+        await self.async_turn_off()
+        return self._settle(liters, delivered, elapsed, reached_target)
+
+    def _settle(self, liters: float, delivered: float, elapsed: float, reached_target: bool) -> DeliveryResult:
+        """Build the flow-meter :class:`DeliveryResult`, falling back when nothing measured.
+
+        A session that ran with the valve open but measured zero flow is far more
+        likely a dead/stale sensor than a dry pipe: credit the nominal flow rate
+        so the deficit still settles (the field bug behind the zero-measured-flow
+        retry loop), labeled ``estimated``.
+        """
+        if delivered > 0:
+            quality = DeliveryQuality.MEASURED if reached_target else DeliveryQuality.PARTIAL
+            return DeliveryResult(delivered, quality, elapsed, liters)
+        if elapsed > 0 and self._flow_rate_lpm > 0:
+            estimate = self._flow_rate_lpm * elapsed / 60.0
+            _LOGGER.warning(
+                "Zone '%s': flow sensor measured 0 L after %.0fs open — crediting estimated %.1fL",
+                self._name,
+                elapsed,
+                estimate,
+            )
+            return DeliveryResult(estimate, DeliveryQuality.ESTIMATED, elapsed, liters, detail="fallback_estimate")
+        _LOGGER.warning(
+            "Zone '%s': flow sensor measured 0 L and no flow_rate to estimate from; deficit unsettled",
+            self._name,
+        )
+        return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, elapsed, liters, detail="no_measurement")
+
+    # ── Strategy 3: volume preset (smart self-piloting valve) ────────────
+
+    async def _deliver_volume_preset(self, liters: float, should_abort: Callable[[], bool] | None) -> DeliveryResult:
+        """Arm the smart-valve dose, ensure it opens, wait for its self-close.
+
+        Smart valves accept a dose on a ``number`` entity and close themselves;
+        they drive their own state and do not fit the FSM's "I command, you obey"
+        semantics, so this strategy talks to the actuator directly. It still lives
+        behind the uniform ``deliver()`` seam and reuses the base precheck.
+        """
+        if not self._volume_entity:
+            _LOGGER.error("Zone '%s' has no volume_entity configured", self._name)
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail="no_volume_entity")
+        precheck = self._precheck()
+        if precheck is not None:
+            if self._notifier is not None:
+                await self._notifier.notify(
+                    self._name,
+                    NotificationKind.UNREACHABLE_AT_IRRIGATION,
+                    Severity.WARNING,
+                    context={"reason": precheck[1]},
+                )
+            return DeliveryResult(0.0, DeliveryQuality.LOW_CONFIDENCE, 0.0, liters, detail=precheck[1])
+
+        # 1) Arm the dose.
+        await self._hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": self._volume_entity, "value": round(liters, 1)},
+            blocking=False,
+        )
+
+        # 2-3) Grace window for auto-open; explicit open as fallback.
+        if not await self._wait_for_auto_open(self._auto_open_grace_s):
+            _LOGGER.info(
+                "Zone '%s': smart valve did not auto-open within %.1fs, sending open",
+                self._name,
+                self._auto_open_grace_s,
+            )
+            await self._call_actuator(on=True)
+
+        # 4) Wait for the smart valve to finish (self-close), stop or timeout.
+        elapsed = 0.0
+        timeout = self._delivery_timeout_s
+        while elapsed < timeout:
+            if should_abort and should_abort():
+                await self._call_actuator(on=False)
+                estimate = self._flow_rate_lpm * elapsed / 60.0 if self._flow_rate_lpm > 0 else 0.0
+                return DeliveryResult(min(liters, estimate), DeliveryQuality.PARTIAL, elapsed, liters, detail="aborted")
+            await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
+            elapsed += FLOW_METER_POLL_INTERVAL_S
+            if self._actuator_is_off():
+                return DeliveryResult(liters, DeliveryQuality.MEASURED, elapsed, liters)
+
+        _LOGGER.warning("Zone '%s' volume_preset timeout (%.0fs). Forcing close.", self._name, timeout)
+        await self._call_actuator(on=False)
+        return DeliveryResult(liters, DeliveryQuality.LOW_CONFIDENCE, elapsed, liters, detail="timeout")
+
+    async def _wait_for_auto_open(self, grace_s: float) -> bool:
+        """Poll the actuator state up to ``grace_s`` for a smart-valve auto-open."""
+        elapsed = 0.0
+        step = min(0.5, grace_s)
+        while elapsed < grace_s:
+            if self._read_normalized_state() == "on":
+                return True
+            await asyncio.sleep(step)
+            elapsed += step
+        return self._read_normalized_state() == "on"
+
+    # ── Shared wait helper ───────────────────────────────────────────────
+
+    async def _wait_with_abort(self, duration_s: float, should_abort: Callable[[], bool] | None) -> float:
+        """Sleep up to ``duration_s``, breaking early on abort or external close."""
+        elapsed = 0.0
+        while elapsed < duration_s:
+            if should_abort and should_abort():
+                break
+            step = min(FLOW_METER_POLL_INTERVAL_S, duration_s - elapsed)
+            await asyncio.sleep(step)
+            elapsed += step
+            if self._actuator_is_off():
+                break
+        return elapsed
+
+
+# ── Master actuator (the model's ``MasterDriver``) ─────────────────────────
+
+
+class MasterActuator(Actuator):
+    """Drive shared hydraulics (a master valve or pump) by following zone activity.
+
+    It takes no irrigation decisions and has no notion of liters: it is ON while
+    any zone actuator is active and OFF once none are, after a configurable
+    off-delay linger that avoids pump cycling during sequential zone runs (GH #95).
+    Modeling it as an :class:`Actuator` means the safety layers — never leave the
+    pump running on error/stop/restart — are inherited from the base, not
+    duplicated.
+
+    Note: "pump" is a *role*, not a HA device type — HA has no ``pump.*`` domain
+    or ``pump`` device_class. A pump is driven as a ``switch.*`` entity (a relay),
+    which the :class:`ValveCommandAdapter` handles transparently; ``MasterActuator``
+    adds only the pump-specific behaviour (``off_delay_s`` linger). This is why the
+    domain model folds pump and master valve into the single ``MasterDriver``.
+    """
+
+    role = "master"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        *,
+        off_delay_s: float = DEFAULT_MASTER_OFF_DELAY_S,
+        **base_kwargs,
+    ) -> None:
+        """Configure a master actuator; ``base_kwargs`` flow to :class:`Actuator`."""
+        super().__init__(hass, entity_id, **base_kwargs)
+        self._off_delay_s = off_delay_s
+        self._linger_task: asyncio.Task | None = None
+
+    @property
+    def off_delay_s(self) -> float:
+        """The linger before following the zones back to OFF."""
+        return self._off_delay_s
+
+    async def follow(self, any_zone_active: bool) -> None:
+        """React to aggregate zone activity: ON when any is active, OFF (delayed) when none.
+
+        Called by the orchestrator on every change in aggregate activity. Turning
+        ON cancels a pending off-linger; turning inactive schedules the off after
+        ``off_delay_s`` so a brief gap between two sequential zones does not cycle
+        the pump.
+        """
+        if any_zone_active:
+            self._cancel_linger()
+            if not self.is_open:
+                await self.async_turn_on()
+            return
+        if self._linger_task is None or self._linger_task.done():
+            self._linger_task = self._hass.async_create_task(self._linger_off())
+
+    async def _linger_off(self) -> None:
+        """Wait the off-delay, then close the master actuator."""
+        try:
+            await asyncio.sleep(self._off_delay_s)
+        except asyncio.CancelledError:
+            return
+        await self.async_turn_off()
+
+    def _cancel_linger(self) -> None:
+        """Cancel a pending off-linger (a new zone became active)."""
+        if self._linger_task and not self._linger_task.done():
+            self._linger_task.cancel()
+        self._linger_task = None
+
+    def async_unload(self) -> None:
+        """Cancel the off-linger, then unload the base actuator."""
+        self._cancel_linger()
+        super().async_unload()

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -639,7 +639,7 @@ class IrrigationController:
                 # mid-cycle (a network glitch in the flow sensor used to
                 # lose every mm we had already delivered).
                 deficit_at_start = zone._zone_deficit
-                zone._deficit_at_irrigation_start = deficit_at_start
+                zone.begin_cycle()
                 ts_start = datetime.now()
                 delivered = await self._deliver_water(zone)
                 ts_end = datetime.now()
@@ -715,8 +715,9 @@ class IrrigationController:
             else:
                 # Partial irrigation — authoritative recompute from snapshot
                 all_complete = False
-                delivered_mm = delivered * zone._efficiency / zone._area if zone._area > 0 else 0.0
-                zone._zone_deficit = max(0.0, deficit_at_start - delivered_mm)
+                # The zone credits it against its own cycle snapshot, which is
+                # the same value as ``deficit_at_start`` (see _irrigate_zones).
+                zone.credit_delivery(delivered)
                 zone._last_volume_delivered = round(delivered, 1)
                 zone._session_water_delivered = round(delivered, 1)
                 zone._total_water_delivered += delivered
@@ -1165,8 +1166,7 @@ class IrrigationController:
         snapshot = zone._deficit_at_irrigation_start
         if snapshot is None or zone._area <= 0:
             return
-        delivered_mm = delivered_liters * zone._efficiency / zone._area
-        zone._zone_deficit = max(0.0, snapshot - delivered_mm)
+        zone.credit_delivery(delivered_liters)
         # Session water must rise live during a flow-metered cycle, not only at
         # completion — otherwise the card shows Volume/Duration counting down
         # while Session water stays 0 (field report, flow_meter zone).
@@ -1433,8 +1433,9 @@ class IrrigationController:
             )
 
         if delivered_liters > 0 and zone._area > 0:
-            delivered_mm = delivered_liters * zone._efficiency / zone._area
-            zone._zone_deficit = max(0.0, zone._zone_deficit - delivered_mm)
+            # No cycle was opened on this path, so the zone credits against its
+            # current deficit — which is what this site did explicitly before.
+            zone.credit_delivery(delivered_liters)
             zone._last_irrigation_source = "manual"
             zone._last_irrigated = ts_end
             zone._last_volume_delivered = round(delivered_liters, 1)

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -911,6 +911,11 @@ class Driver(abc.ABC):
             await asyncio.sleep(seconds)
             await self._dispatch(_TIMEOUT_EVENT_FOR_TIMER[name])
         except asyncio.CancelledError:
+            # Expected, and the normal way a timer ends: `_cancel_timer` cancels
+            # this task whenever the event it guards arrives first — a valve that
+            # confirms before its timeout, a session that stops early. Swallowing
+            # it here keeps cancellation from surfacing as a spurious error; a
+            # real timeout still dispatches its event on the line above.
             pass
 
     # ── HA state listeners ───────────────────────────────────────────────

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -1,17 +1,17 @@
-"""Actuator abstraction — the single home for driving one irrigation actuator.
+"""Driver abstraction — the single home for driving one irrigation actuator.
 
 This module materializes the domain model's ``Driver`` (see
 ``docs/design_domain_object_model.md``) as a concrete, Home-Assistant-aware
 base class — the *attuatore* — together with its two specializations:
 
-* :class:`ZoneActuator` (the model's ``ZoneDriver``) — drives one zone's
+* :class:`ZoneDriver` (the model's ``ZoneDriver``) — drives one zone's
   valve/switch, translating a **liters** request into actuation and returning a
   truthful :class:`DeliveryResult`.
-* :class:`MasterActuator` (the model's ``MasterDriver``) — drives shared
+* :class:`MasterDriver` (the model's ``MasterDriver``) — drives shared
   hydraulics (a master valve or pump), *following* aggregate zone activity with
   an off-delay linger. It has no notion of liters.
 
-The abstract base :class:`Actuator` owns everything the two share, as the domain
+The abstract base :class:`Driver` owns everything the two share, as the domain
 model prescribes: the entity adapter (``switch.*`` vs ``valve.*``), confirmed
 on/off commands over a pure :class:`~.valve_fsm.ValveFsm`, adaptive
 latency/timeout, the safety layers (absolute watchdog, hardware max-duration
@@ -182,7 +182,7 @@ class DeliveryMode(StrEnum):
 
 @dataclass(frozen=True)
 class DeliveryResult:
-    """The round-trip return of :meth:`ZoneActuator.deliver`.
+    """The round-trip return of :meth:`ZoneDriver.deliver`.
 
     Not a bare float: it carries how much water was delivered *and how truthful*
     that figure is, so the Zone can settle its deficit and diagnostics can show
@@ -205,7 +205,7 @@ class DeliveryResult:
 
 
 class OperationStatus(StrEnum):
-    """Outcome category for :meth:`Actuator.async_turn_on` / :meth:`async_turn_off`."""
+    """Outcome category for :meth:`Driver.async_turn_on` / :meth:`async_turn_off`."""
 
     OK = "ok"
     FAILED = "failed"
@@ -259,17 +259,17 @@ _CONFIRM_FOR_CMD: dict[ValveEvent, tuple[str, ValveEvent]] = {
 }
 
 
-# ── The abstract actuator (the model's ``Driver``) ─────────────────────────
+# ── The abstract driver (the model's ``Driver``) ───────────────────────────
 
 
-class Actuator(abc.ABC):
+class Driver(abc.ABC):
     """HA-aware driver for a single actuator, sitting on a pure :class:`ValveFsm`.
 
     Owns the entity adapter, confirmed on/off commands with retry on transient
     (comms) failures, the adaptive latency timeout, the absolute watchdog, the
     optional hardware max-duration timer, ``CLOSE_LEAK`` recovery + stuck-open
     escalation, and an active liveness probe. Subclasses add *what* to do with a
-    live actuator: :class:`ZoneActuator` delivers liters; :class:`MasterActuator`
+    live actuator: :class:`ZoneDriver` delivers liters; :class:`MasterDriver`
     follows aggregate activity.
     """
 
@@ -673,13 +673,13 @@ class Actuator(abc.ABC):
         """
         if kind in _TRANSIENT_FAILURES and self._retries_left > 0:
             _LOGGER.warning(
-                "Actuator '%s' transient failure %s — retrying (%d attempt(s) left)",
+                "Driver '%s' transient failure %s — retrying (%d attempt(s) left)",
                 self._name,
                 kind.name,
                 self._retries_left,
             )
             return
-        _LOGGER.error("Actuator '%s' failure: %s", self._name, kind.name)
+        _LOGGER.error("Driver '%s' failure: %s", self._name, kind.name)
         if self._notifier is None:
             return
         if kind == FailureKind.CLOSE_LEAK:
@@ -695,7 +695,7 @@ class Actuator(abc.ABC):
     async def _attempt_leak_recovery(self) -> bool:
         """Last-resort recovery from ``CLOSE_LEAK``: re-issue close, re-check flow."""
         _LOGGER.warning(
-            "Actuator '%s' CLOSE_LEAK detected — attempting recovery (direct close + recheck)",
+            "Driver '%s' CLOSE_LEAK detected — attempting recovery (direct close + recheck)",
             self._name,
         )
         await self._call_actuator(on=False)
@@ -712,15 +712,15 @@ class Actuator(abc.ABC):
             return False
         recovered = flow <= self._flow_zero_threshold
         if recovered:
-            _LOGGER.info("Actuator '%s' leak recovery succeeded (flow=%.3f)", self._name, flow)
+            _LOGGER.info("Driver '%s' leak recovery succeeded (flow=%.3f)", self._name, flow)
         else:
-            _LOGGER.error("Actuator '%s' leak recovery failed (flow=%.3f)", self._name, flow)
+            _LOGGER.error("Driver '%s' leak recovery failed (flow=%.3f)", self._name, flow)
         return recovered
 
     async def _escalate_stuck_open(self) -> None:
         """Trigger integration-wide emergency stop + CRITICAL notification."""
         _LOGGER.error(
-            "Actuator '%s' stuck-open confirmed after recovery; calling never_dry.stop and escalating",
+            "Driver '%s' stuck-open confirmed after recovery; calling never_dry.stop and escalating",
             self._name,
         )
         try:
@@ -739,7 +739,7 @@ class Actuator(abc.ABC):
     async def _notify_maintenance(self) -> None:
         """Notify that the actuator just entered MAINTENANCE."""
         _LOGGER.error(
-            "Actuator '%s' entered MAINTENANCE (consecutive failures = %d)",
+            "Driver '%s' entered MAINTENANCE (consecutive failures = %d)",
             self._name,
             self._fsm.failure_count,
         )
@@ -765,14 +765,14 @@ class Actuator(abc.ABC):
                 blocking=False,
             )
         except Exception as exc:
-            _LOGGER.error("Actuator '%s' %s.%s call raised: %s", self._name, domain, service, exc)
+            _LOGGER.error("Driver '%s' %s.%s call raised: %s", self._name, domain, service, exc)
 
     def _read_normalized_state(self) -> str:
         """Return the actuator's normalized state via the adapter."""
         state = self._hass.states.get(self._entity_id)
         return self._adapter.interpret_state(state.state if state is not None else None)
 
-    def _actuator_is_off(self) -> bool:
+    def _driver_is_off(self) -> bool:
         """``True`` when the actuator entity currently reads closed/off."""
         return self._read_normalized_state() == "off"
 
@@ -825,7 +825,7 @@ class Actuator(abc.ABC):
                     blocking=False,
                 )
                 _LOGGER.debug(
-                    "Actuator '%s' hardware max_duration set to %.1f via entity %s",
+                    "Driver '%s' hardware max_duration set to %.1f via entity %s",
                     self._name,
                     value,
                     self._hw_max_duration_entity,
@@ -833,7 +833,7 @@ class Actuator(abc.ABC):
                 return
             except Exception as exc:
                 _LOGGER.warning(
-                    "Actuator '%s' failed to set hardware max_duration via entity %s: %s; trying MQTT",
+                    "Driver '%s' failed to set hardware max_duration via entity %s: %s; trying MQTT",
                     self._name,
                     self._hw_max_duration_entity,
                     exc,
@@ -849,14 +849,14 @@ class Actuator(abc.ABC):
                     blocking=False,
                 )
                 _LOGGER.debug(
-                    "Actuator '%s' hardware max_duration set to %.1f via MQTT topic %s",
+                    "Driver '%s' hardware max_duration set to %.1f via MQTT topic %s",
                     self._name,
                     value,
                     self._hw_max_duration_topic,
                 )
             except Exception as exc:
                 _LOGGER.warning(
-                    "Actuator '%s' failed to set hardware max_duration via MQTT topic %s: %s",
+                    "Driver '%s' failed to set hardware max_duration via MQTT topic %s: %s",
                     self._name,
                     self._hw_max_duration_topic,
                     exc,
@@ -870,7 +870,7 @@ class Actuator(abc.ABC):
         except asyncio.CancelledError:
             return
         _LOGGER.error(
-            "Actuator '%s' watchdog triggered after %.0f s open — forcing close",
+            "Driver '%s' watchdog triggered after %.0f s open — forcing close",
             self._name,
             max_open_s,
         )
@@ -955,7 +955,7 @@ class Actuator(abc.ABC):
         window.record(latency_ms)
         self._hass.async_create_task(self._latency.async_save())
         _LOGGER.debug(
-            "Actuator '%s' confirmation latency %.1f ms → adaptive timeout %.2f s",
+            "Driver '%s' confirmation latency %.1f ms → adaptive timeout %.2f s",
             self._name,
             latency_ms,
             timeout_getter(),
@@ -979,7 +979,7 @@ class Actuator(abc.ABC):
 # ── Zone actuator (the model's ``ZoneDriver``) ─────────────────────────────
 
 
-class ZoneActuator(Actuator):
+class ZoneDriver(Driver):
     """Drive one zone's actuator, translating a **liters** request into water.
 
     ``deliver(liters)`` is the contract with the Zone: the zone always asks for
@@ -1007,7 +1007,7 @@ class ZoneActuator(Actuator):
         auto_open_grace_s: float = AUTO_OPEN_GRACE_S,
         **base_kwargs,
     ) -> None:
-        """Configure a zone actuator; ``base_kwargs`` flow to :class:`Actuator`."""
+        """Configure a zone actuator; ``base_kwargs`` flow to :class:`Driver`."""
         super().__init__(hass, entity_id, flow_sensor_entity_id=flow_meter_sensor, **base_kwargs)
         self._delivery_mode = DeliveryMode(delivery_mode)
         self._flow_rate_lpm = flow_rate_lpm
@@ -1114,7 +1114,7 @@ class ZoneActuator(Actuator):
                 break
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
-            if self._actuator_is_off():
+            if self._driver_is_off():
                 break  # hardware auto-close — stop polling a dead meter
             current = flow_utils.read_volume_liters(self._hass, meter)
             if current is None:
@@ -1152,7 +1152,7 @@ class ZoneActuator(Actuator):
                 break
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
-            if self._actuator_is_off():
+            if self._driver_is_off():
                 break
             rate = flow_utils.read_flow_meter(self._hass, meter)
             if rate is None or rate < 0:
@@ -1245,7 +1245,7 @@ class ZoneActuator(Actuator):
                 return DeliveryResult(min(liters, estimate), DeliveryQuality.PARTIAL, elapsed, liters, detail="aborted")
             await asyncio.sleep(FLOW_METER_POLL_INTERVAL_S)
             elapsed += FLOW_METER_POLL_INTERVAL_S
-            if self._actuator_is_off():
+            if self._driver_is_off():
                 return DeliveryResult(liters, DeliveryQuality.MEASURED, elapsed, liters)
 
         _LOGGER.warning("Zone '%s' volume_preset timeout (%.0fs). Forcing close.", self._name, timeout)
@@ -1274,7 +1274,7 @@ class ZoneActuator(Actuator):
             step = min(FLOW_METER_POLL_INTERVAL_S, duration_s - elapsed)
             await asyncio.sleep(step)
             elapsed += step
-            if self._actuator_is_off():
+            if self._driver_is_off():
                 break
         return elapsed
 
@@ -1282,19 +1282,19 @@ class ZoneActuator(Actuator):
 # ── Master actuator (the model's ``MasterDriver``) ─────────────────────────
 
 
-class MasterActuator(Actuator):
+class MasterDriver(Driver):
     """Drive shared hydraulics (a master valve or pump) by following zone activity.
 
     It takes no irrigation decisions and has no notion of liters: it is ON while
     any zone actuator is active and OFF once none are, after a configurable
     off-delay linger that avoids pump cycling during sequential zone runs (GH #95).
-    Modeling it as an :class:`Actuator` means the safety layers — never leave the
+    Modeling it as an :class:`Driver` means the safety layers — never leave the
     pump running on error/stop/restart — are inherited from the base, not
     duplicated.
 
     Note: "pump" is a *role*, not a HA device type — HA has no ``pump.*`` domain
     or ``pump`` device_class. A pump is driven as a ``switch.*`` entity (a relay),
-    which the :class:`ValveCommandAdapter` handles transparently; ``MasterActuator``
+    which the :class:`ValveCommandAdapter` handles transparently; ``MasterDriver``
     adds only the pump-specific behaviour (``off_delay_s`` linger). This is why the
     domain model folds pump and master valve into the single ``MasterDriver``.
     """
@@ -1309,7 +1309,7 @@ class MasterActuator(Actuator):
         off_delay_s: float = DEFAULT_MASTER_OFF_DELAY_S,
         **base_kwargs,
     ) -> None:
-        """Configure a master actuator; ``base_kwargs`` flow to :class:`Actuator`."""
+        """Configure a master actuator; ``base_kwargs`` flow to :class:`Driver`."""
         super().__init__(hass, entity_id, **base_kwargs)
         self._off_delay_s = off_delay_s
         self._linger_task: asyncio.Task | None = None
@@ -1364,7 +1364,7 @@ class ManualActuator:
     The third materialization of the domain's "how": there is no hardware to
     drive. Instead of opening a valve it raises an **alert** when a zone's deficit
     says water is due, and the delivery completes when the user presses **Mark
-    irrigated**. It deliberately does *not* extend :class:`Actuator` — that base
+    irrigated**. It deliberately does *not* extend :class:`Driver` — that base
     is all valve machinery (FSM, switch commands, watchdog, liveness), none of
     which applies to a human with a watering can. What it shares is the delivery
     *contract*: it returns a :class:`DeliveryResult`, so the Zone settles its

--- a/custom_components/never_dry/environment.py
+++ b/custom_components/never_dry/environment.py
@@ -1,0 +1,219 @@
+"""The site — what the installation *has*, and what it can therefore compute.
+
+This module materializes the object the RFC in ``docs/design_domain_object_model.md``
+calls :class:`Environment`: the user's declared answer to "which sensors do you
+have?", plus the shared quantities that belong to the sky rather than to any one
+zone.
+
+It replaces the object previously called **System**, which was a catch-all
+bundling three unrelated responsibilities. The RFC dissolves it rather than
+renaming it, redistributing what it held:
+
+===========================  ==================================================
+System attribute (before)    Now lives in
+===========================  ==================================================
+temperature + rain sensors   :class:`Environment` — environmental feeds
+alpha (ET sensitivity)       ``ETModel`` — used *only* by the simple ET tier
+D_max (deficit clamp)        ``Zone`` — the value is the zone's soil reservoir;
+                             only the clamping *mechanism* is shared
+master valve / pump          ``MasterActuator`` — a hydraulics concern
+===========================  ==================================================
+
+**Capability matching** is the reason this object earns its place. Each
+water-balance model declares the sensors it requires; a zone may offer only the
+models whose requirements this site satisfies::
+
+    Environment.declared_sensors  >=  model.required_sensors   =>  model offered
+
+So a user with a thermometer gets the simple ET tier; add humidity, wind and net
+radiation and Penman-Monteith unlocks; add a soil probe and VWC becomes
+available — with no model selectable by hand that the hardware cannot feed.
+
+Design intent — this module is deliberately **pure**: no Home Assistant import,
+no I/O. It holds *bindings* (entity ids as opaque strings) and the rules about
+them, never the readings; resolving a binding to a value is the integration's
+job. Same choice as ``water_balance_model.py``, for the same reason: the rules
+are trivially testable when nothing has to be mocked.
+
+**Phase 1 — inert scaffold.** Nothing imports this module yet. Wiring
+``DrynessIndexSensor`` onto it is a deliberate later phase, and is gated on the
+`Zone` class (``zone.py``) landing too: the two are the halves of the same seam.
+
+References: ``docs/design_domain_object_model.md`` (RFC: dissolve ``System``),
+``docs/design_water_balance_reference_model.md`` (D3, yearly rain as a shared
+quantity), GH #146 (site exposure, the per-zone counterpart to this object).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+
+# Defaults mirror ``const.py`` so an Environment built with no overrides behaves
+# exactly like today's system sensor. Kept as module constants (not a HA import)
+# to keep the module pure; the integration passes the user-configured values in.
+DEFAULT_LATITUDE: float = 45.0
+DEFAULT_BACKFILL_DAYS: int = 90
+DEFAULT_RAIN_DELAY_THRESHOLD: float = 0.60
+DEFAULT_RAIN_DELAY_HOURS: float = 12.0
+
+
+class SensorKind(StrEnum):
+    """A kind of environmental input a water-balance model may require.
+
+    Deliberately about the *quantity*, not the entity: two thermometers are one
+    ``TEMPERATURE`` capability. This is the vocabulary both sides of the
+    capability match are written in.
+    """
+
+    TEMPERATURE = "temperature"
+    RAIN = "rain"
+    HUMIDITY = "humidity"
+    WIND_SPEED = "wind_speed"
+    NET_RADIATION = "net_radiation"
+    TEMP_MAX = "temp_max"
+    TEMP_MIN = "temp_min"
+    SOIL_MOISTURE = "soil_moisture"
+    RAIN_PROBABILITY = "rain_probability"
+
+
+#: Which :class:`Environment` attribute carries the binding for each sensor kind.
+#: Module-level rather than a dataclass field: it describes the class, not an
+#: installation, and is identical for every instance.
+BINDING_BY_KIND: dict[SensorKind, str] = {
+    SensorKind.TEMPERATURE: "temperature_sensor",
+    SensorKind.RAIN: "rain_sensor",
+    SensorKind.HUMIDITY: "humidity_sensor",
+    SensorKind.WIND_SPEED: "wind_speed_sensor",
+    SensorKind.NET_RADIATION: "net_radiation_sensor",
+    SensorKind.TEMP_MAX: "temp_max_sensor",
+    SensorKind.TEMP_MIN: "temp_min_sensor",
+    SensorKind.SOIL_MOISTURE: "soil_moisture_sensor",
+    SensorKind.RAIN_PROBABILITY: "rain_probability_sensor",
+}
+
+
+class RainSensorType(StrEnum):
+    """How the rain binding reports, which decides how a delta is derived.
+
+    Mirrors ``const.py``. Carried here because it is a property of the *feed*,
+    not of any zone: it says how to read the sensor, not what to do with it.
+    """
+
+    CUMULATIVE = "cumulative"
+    ROLLING = "rolling"
+    EVENT = "event"
+
+
+@dataclass(frozen=True)
+class RainDelayPolicy:
+    """Forecast-driven delay: *the signal*, not the decision.
+
+    The environment supplies "rain is likely"; it never skips a watering itself.
+    Whether a given zone honours the delay is the zone's business — an indoor or
+    patio zone is unaffected, which is why the gate lives on ``Zone.placement``
+    (see the RFC). Keeping the threshold here and the gate there is what stops
+    forecast rain and measured rain from ever disagreeing about a zone.
+    """
+
+    enabled: bool = False
+    probability_threshold: float = DEFAULT_RAIN_DELAY_THRESHOLD
+    delay_hours: float = DEFAULT_RAIN_DELAY_HOURS
+
+    def triggers_at(self, probability: float | None) -> bool:
+        """``True`` when a forecast probability is high enough to delay watering."""
+        if not self.enabled or probability is None:
+            return False
+        return probability >= self.probability_threshold
+
+
+@dataclass
+class Environment:
+    """The declared sensor inventory of one installation, plus the shared sky.
+
+    Holds *bindings* — opaque entity-id strings — never readings. A binding that
+    is ``None`` means "the user does not have this sensor", which is exactly the
+    input the capability match needs.
+    """
+
+    # ── Feeds: what the user declared at install ────────────────────────────
+    temperature_sensor: str | None = None
+    rain_sensor: str | None = None
+    humidity_sensor: str | None = None
+    wind_speed_sensor: str | None = None
+    net_radiation_sensor: str | None = None
+    temp_max_sensor: str | None = None
+    temp_min_sensor: str | None = None
+    soil_moisture_sensor: str | None = None
+    rain_probability_sensor: str | None = None
+
+    # ── How to read them ────────────────────────────────────────────────────
+    rain_sensor_type: RainSensorType = RainSensorType.EVENT
+    backfill_days: int = DEFAULT_BACKFILL_DAYS
+
+    # ── Site constants ──────────────────────────────────────────────────────
+    # Latitude is a property of the place, not of a sensor: Hargreaves needs it
+    # for the astronomical radiation term, and the seasonal Kc curve needs it to
+    # flip for the southern hemisphere.
+    latitude: float = DEFAULT_LATITUDE
+
+    # ── Policy the site offers, that zones consume ──────────────────────────
+    rain_delay: RainDelayPolicy = field(default_factory=RainDelayPolicy)
+
+    # ── Shared quantity: one sky over the whole garden ──────────────────────
+    # Rain that fell this calendar year [mm]. A site quantity by nature, so every
+    # zone mirrors the same figure instead of keeping its own drifting counter
+    # (reference model D3). Note the asymmetry with the deficit, which is
+    # emphatically *not* shared: rain falls on the garden, deficit belongs to a
+    # patch of soil.
+    yearly_rain_mm: float = 0.0
+    yearly_rain_year: int | None = None
+
+    # ── Capability matching ─────────────────────────────────────────────────
+
+    @property
+    def declared_sensors(self) -> frozenset[SensorKind]:
+        """Every :class:`SensorKind` the user actually bound to an entity."""
+        return frozenset(kind for kind, attr in BINDING_BY_KIND.items() if getattr(self, attr) is not None)
+
+    def binding_for(self, kind: SensorKind) -> str | None:
+        """The entity id bound to ``kind``, or ``None`` when undeclared."""
+        return getattr(self, BINDING_BY_KIND[kind], None)
+
+    def satisfies(self, required: frozenset[SensorKind] | set[SensorKind]) -> bool:
+        """``True`` when this site declares everything ``required`` asks for.
+
+        The whole capability rule, in one line: ``declared >= required``.
+        """
+        return self.declared_sensors >= frozenset(required)
+
+    def missing_for(self, required: frozenset[SensorKind] | set[SensorKind]) -> frozenset[SensorKind]:
+        """What ``required`` asks for and this site does not have.
+
+        The complement of :meth:`satisfies`, kept separate because the UI needs
+        to say *which* sensor unlocks a model, not merely that one is missing.
+        """
+        return frozenset(required) - self.declared_sensors
+
+    # ── Shared-rain bookkeeping ─────────────────────────────────────────────
+
+    def accrue_yearly_rain(self, rain_mm: float, *, year: int) -> Environment:
+        """Return a copy with ``rain_mm`` added to the yearly total.
+
+        Rolls over when ``year`` differs from the stored one. Credits only
+        positive increments: a decreasing reading is never rain (GH #123), and
+        that rule belongs with the feed rather than with each consumer.
+        """
+        if rain_mm <= 0 and self.yearly_rain_year == year:
+            return self
+        if self.yearly_rain_year != year:
+            return replace(self, yearly_rain_mm=max(0.0, rain_mm), yearly_rain_year=year)
+        return replace(self, yearly_rain_mm=self.yearly_rain_mm + rain_mm)
+
+    def reset_yearly_rain(self, *, year: int) -> Environment:
+        """Return a copy with the yearly rain total cleared (user-invoked reset)."""
+        return replace(self, yearly_rain_mm=0.0, yearly_rain_year=year)
+
+    def yearly_rain_liters(self, area_m2: float) -> float:
+        """Project the yearly rain onto an area: 1 mm over 1 m² is 1 litre."""
+        return self.yearly_rain_mm * area_m2

--- a/custom_components/never_dry/environment.py
+++ b/custom_components/never_dry/environment.py
@@ -16,7 +16,7 @@ temperature + rain sensors   :class:`Environment` — environmental feeds
 alpha (ET sensitivity)       ``ETModel`` — used *only* by the simple ET tier
 D_max (deficit clamp)        ``Zone`` — the value is the zone's soil reservoir;
                              only the clamping *mechanism* is shared
-master valve / pump          ``MasterActuator`` — a hydraulics concern
+master valve / pump          ``MasterDriver`` — a hydraulics concern
 ===========================  ==================================================
 
 **Capability matching** is the reason this object earns its place. Each

--- a/custom_components/never_dry/scheduler.py
+++ b/custom_components/never_dry/scheduler.py
@@ -1,0 +1,156 @@
+"""The *when* — which zone waters, and whether it may start right now.
+
+The fifth object of the model, and the last to get a module. It was left out
+of the first round on the grounds that scheduling is deferred, which conflated
+two different things:
+
+* **What is deferred** (DA-3, and the GH #74 answer): the queue, time windows,
+  calendars, parallel zone runs, and interleaving another zone during a soak
+  pause. Those open only on a concrete demand for parallel zones. Nothing here
+  builds them.
+* **What already runs**: two decision rules, a serial concurrency policy and a
+  rate limit — real scheduling behaviour, merely written inline inside two
+  Home Assistant callbacks in ``controller.py`` where it cannot be read as a
+  policy or tested without a controller.
+
+This module materializes the second. The seam is decision versus execution:
+**the scheduler decides, the controller acts**. Registering time listeners,
+spawning tasks and driving valves stay on the HA side; what belongs here is the
+answer to "may this zone water now, and why not".
+
+Design intent — **pure**: no Home Assistant import, no I/O, no clock. Whether
+something is already running and whether a call is rate-limited are passed *in*
+as facts, because a decision function that reads the world cannot be tested
+against the cases that matter.
+
+**Phase 1 — inert scaffold.** Nothing imports this module yet.
+
+References: ``docs/design_domain_object_model.md`` (the Scheduler object, and
+"serial vs parallel is a Scheduler policy"), GH #74 (why the queue is deferred),
+AI-183 (why scheduled mode ignores the threshold).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .zone import Zone
+
+#: Minimum gap between two service calls with the same key. Mirrors ``const.py``.
+DEFAULT_MIN_SERVICE_INTERVAL_S: int = 5
+
+
+class Trigger(StrEnum):
+    """What asked for this irrigation. Becomes the zone's ``last_source``."""
+
+    SCHEDULED = "scheduled"
+    REACTIVE = "reactive"
+    MANUAL = "manual"
+    SERVICE = "service"
+
+
+class SkipReason(StrEnum):
+    """Why a zone that was considered is not going to water.
+
+    Named rather than boolean on purpose: every one of these is a line the user
+    may read in the log, and two of them (``ALREADY_RUNNING``, ``THROTTLED``)
+    are the ones that make a watering look mysteriously missing.
+    """
+
+    NOTHING_TO_REFILL = "nothing_to_refill"
+    BELOW_THRESHOLD = "below_threshold"
+    ALREADY_RUNNING = "already_running"
+    THROTTLED = "throttled"
+
+
+class ConcurrencyPolicy(StrEnum):
+    """Whether zones may run at the same time.
+
+    ``SERIAL`` is what the code does today, though nowhere does it say so: the
+    two handlers each check "is something already running" and bail. Naming the
+    policy is the point — it turns an emergent behaviour into a stated one, and
+    gives ``PARALLEL`` somewhere to be added if the demand ever arrives.
+    """
+
+    SERIAL = "serial"
+    PARALLEL = "parallel"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """The scheduler's answer about one zone: water, or skip with a reason."""
+
+    should_irrigate: bool
+    trigger: Trigger | None = None
+    reason: SkipReason | None = None
+
+    @classmethod
+    def go(cls, trigger: Trigger) -> Decision:
+        """Water this zone now, attributed to ``trigger``."""
+        return cls(True, trigger=trigger)
+
+    @classmethod
+    def skip(cls, reason: SkipReason) -> Decision:
+        """Do not water, and say why."""
+        return cls(False, reason=reason)
+
+
+@dataclass
+class Scheduler:
+    """Decides *when* a zone waters. Holds no state about the world.
+
+    Every method takes the world's facts as arguments — ``is_running``,
+    ``is_throttled`` — instead of reaching for them. That is what makes the
+    rules testable in isolation, which is the whole reason they are worth
+    extracting from the callbacks they live in today.
+    """
+
+    concurrency: ConcurrencyPolicy = ConcurrencyPolicy.SERIAL
+    min_service_interval_s: int = DEFAULT_MIN_SERVICE_INTERVAL_S
+
+    @property
+    def allows_overlap(self) -> bool:
+        """``True`` when a zone may start while another is already watering."""
+        return self.concurrency is ConcurrencyPolicy.PARALLEL
+
+    def evaluate_scheduled(self, zone: Zone, *, is_running: bool) -> Decision:
+        """The daily top-up: water at the scheduled hour, threshold or not.
+
+        The threshold is deliberately **not** consulted. A schedule means "top
+        this zone back up at this hour", and gating it on the reactive threshold
+        would silently turn every scheduled run into a reactive one (AI-183).
+        The only zone with nothing to do is one that is already full.
+        """
+        if zone.deficit.value_mm <= 0:
+            return Decision.skip(SkipReason.NOTHING_TO_REFILL)
+        if is_running and not self.allows_overlap:
+            return Decision.skip(SkipReason.ALREADY_RUNNING)
+        return Decision.go(Trigger.SCHEDULED)
+
+    def evaluate_reactive(self, zone: Zone, *, is_running: bool, is_throttled: bool = False) -> Decision:
+        """Mode A: water as soon as the deficit crosses the zone's threshold."""
+        if not zone.needs_water:
+            return Decision.skip(SkipReason.BELOW_THRESHOLD)
+        if is_running and not self.allows_overlap:
+            return Decision.skip(SkipReason.ALREADY_RUNNING)
+        if is_throttled:
+            return Decision.skip(SkipReason.THROTTLED)
+        return Decision.go(Trigger.REACTIVE)
+
+    def next_eligible(self, zones: list[Zone], *, is_running: bool) -> Zone | None:
+        """The zone to water next under the current policy, or ``None``.
+
+        Today this is only ever asked with one candidate, because the two
+        handlers each act on their own zone. It exists so that the ordering
+        question has a home the day more than one zone is eligible at once —
+        and it deliberately does **not** implement a queue: a queue has memory
+        of what is waiting, which is exactly the deferred design (DA-3, GH #74).
+        Driest first is the ordering that needs no memory.
+        """
+        if is_running and not self.allows_overlap:
+            return None
+        eligible = [z for z in zones if z.needs_water]
+        if not eligible:
+            return None
+        return max(eligible, key=lambda z: z.deficit.value_mm)

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -15,6 +15,7 @@ import logging
 import math
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import (
@@ -104,8 +105,23 @@ from .const import (
 from .controller import IrrigationController
 from .services import async_setup_services
 from .unit_convert import LPM_TO_GPH, LPM_TO_LPH
+from .zone import Zone as DomainZone
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _LitersDelivered:
+    """A bare delivered figure, shaped to satisfy ``zone.Delivery``.
+
+    The entity layer still receives plain floats from the controller. Rather
+    than widen the Zone's contract to accept them, this wraps one at the seam —
+    so the day the controller returns a real ``DeliveryResult`` the wrapper
+    simply disappears.
+    """
+
+    liters_delivered: float
+    elapsed_s: float = 0.0
 
 
 # ══════════════════════════════════════════════════════════
@@ -1071,7 +1087,6 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._dryness = dryness_sensor
         self._zone_name = zone_config[CONF_ZONE_NAME]
         self._valve = zone_config.get(CONF_ZONE_VALVE)
-        self._area = zone_config.get(CONF_ZONE_AREA, 0.0)
         self._system_type = zone_config.get(CONF_ZONE_SYSTEM_TYPE)
         self._flow_rate = zone_config.get(CONF_ZONE_FLOW_RATE, 0.0)
         if self._flow_rate > UNUSUAL_FLOW_MAX_LPM:
@@ -1097,22 +1112,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._irrigating = False
         self._no_guard_flow_warned = False
         self._session_listeners: list[Callable] = []
-        self._last_irrigated: datetime | None = None
-        self._last_volume_delivered: float = 0.0
-        self._last_irrigation_source: str | None = None
-        self._last_session_duration_s: int = 0
         self._operator = None  # set by _setup_controller after operator creation
-        # Snapshot of zone_deficit captured by the controller at the start
-        # of an irrigation cycle. Used by flow-metered delivery modes for
-        # real-time deficit updates: every update is computed as
-        # ``max(0, snapshot - delivered_mm)`` so intermediate writes are
-        # idempotent and the end-of-cycle settle never double-counts.
-        # ``None`` outside an active cycle.
-        self._deficit_at_irrigation_start: float | None = None
-        self._total_water_delivered: float = 0.0
-        self._yearly_water_delivered: float = 0.0
-        self._yearly_water_year: int = datetime.now().year
-        self._session_water_delivered: float = 0.0
 
         # Kc: manual override > plant family seasonal profile > 1.0,
         # scaled by the site-exposure microclimate factor (kmc).
@@ -1152,17 +1152,35 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                 configured_factor,
             )
 
-        # Per-zone deficit
-        self._zone_deficit = 0.0
         self._d_max = dryness_sensor._d_max
 
         # Efficiency: explicit value > system_type default > global default
         if CONF_ZONE_EFFICIENCY in zone_config:
-            self._efficiency = zone_config[CONF_ZONE_EFFICIENCY]
+            efficiency = zone_config[CONF_ZONE_EFFICIENCY]
         elif self._system_type and self._system_type in SYSTEM_TYPES:
-            self._efficiency = SYSTEM_TYPES[self._system_type]["default_efficiency"]
+            efficiency = SYSTEM_TYPES[self._system_type]["default_efficiency"]
         else:
-            self._efficiency = DEFAULT_EFFICIENCY
+            efficiency = DEFAULT_EFFICIENCY
+
+        # The domain object behind this entity (A1). It owns the deficit, the
+        # water counters and the crediting arithmetic; the entity keeps only
+        # what Home Assistant needs — unique_id, device info, published state.
+        # The private attributes below survive as properties onto this object so
+        # that every existing reader, including the test suite, is unaffected.
+        self._zone = DomainZone(
+            name=self._zone_name,
+            area_m2=zone_config.get(CONF_ZONE_AREA, 0.0),
+            efficiency=efficiency,
+            plant_family=self._plant_family,
+            manual_kc=self._manual_kc,
+            exposure=self._exposure,
+            microclimate_factor=self._microclimate_factor,
+            d_max=self._d_max,
+            threshold_mm=self._threshold,
+        )
+        # The counters default to "no year recorded"; today's entity starts on
+        # the current one, and the published attribute must not become null.
+        self._zone.counters.yearly_water_year = datetime.now().year
 
         slug = self._zone_name.lower().replace(" ", "_")
         self._attr_name = "Volume"
@@ -1172,6 +1190,130 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
 
         # Register as listener on the dryness sensor
         dryness_sensor.register_zone_listener(self._on_et_update)
+
+    # ── Delegation to the domain Zone (anomaly A1) ──────────────────────────
+    #
+    # These were plain attributes; they are now views onto ``self._zone``, which
+    # is the single storage. Read *and* write are preserved verbatim — in
+    # particular the deficit setter does **not** clamp, because the attribute it
+    # replaces did not: callers clamp explicitly and the tests rely on assigning
+    # arbitrary values. Behaviour is identical by construction; what changes is
+    # that there is now one owner of this state instead of thirteen loose fields.
+
+    @property
+    def _area(self) -> float:
+        return self._zone.area_m2
+
+    @_area.setter
+    def _area(self, value: float) -> None:
+        self._zone.area_m2 = value
+
+    @property
+    def _efficiency(self) -> float:
+        return self._zone.efficiency
+
+    @_efficiency.setter
+    def _efficiency(self, value: float) -> None:
+        self._zone.efficiency = value
+
+    @property
+    def _zone_deficit(self) -> float:
+        return self._zone.deficit.value_mm
+
+    @_zone_deficit.setter
+    def _zone_deficit(self, value: float) -> None:
+        self._zone.deficit = self._zone.deficit.with_value(value)
+
+    @property
+    def _deficit_at_irrigation_start(self) -> float | None:
+        return self._zone.cycle_baseline_mm
+
+    @_deficit_at_irrigation_start.setter
+    def _deficit_at_irrigation_start(self, value: float | None) -> None:
+        self._zone.cycle_baseline_mm = value
+
+    @property
+    def _last_irrigated(self) -> datetime | None:
+        return self._zone.last_irrigated
+
+    @_last_irrigated.setter
+    def _last_irrigated(self, value: datetime | None) -> None:
+        self._zone.last_irrigated = value
+
+    @property
+    def _last_irrigation_source(self) -> str | None:
+        return self._zone.last_source
+
+    @_last_irrigation_source.setter
+    def _last_irrigation_source(self, value: str | None) -> None:
+        self._zone.last_source = value
+
+    @property
+    def _last_session_duration_s(self) -> int:
+        return self._zone.last_duration_s
+
+    @_last_session_duration_s.setter
+    def _last_session_duration_s(self, value: int) -> None:
+        self._zone.last_duration_s = value
+
+    @property
+    def _last_volume_delivered(self) -> float:
+        return self._zone.counters.last_volume_l
+
+    @_last_volume_delivered.setter
+    def _last_volume_delivered(self, value: float) -> None:
+        self._zone.counters.last_volume_l = value
+
+    @property
+    def _session_water_delivered(self) -> float:
+        return self._zone.counters.session_water_l
+
+    @_session_water_delivered.setter
+    def _session_water_delivered(self, value: float) -> None:
+        self._zone.counters.session_water_l = value
+
+    @property
+    def _total_water_delivered(self) -> float:
+        return self._zone.counters.total_water_l
+
+    @_total_water_delivered.setter
+    def _total_water_delivered(self, value: float) -> None:
+        self._zone.counters.total_water_l = value
+
+    @property
+    def _yearly_water_delivered(self) -> float:
+        return self._zone.counters.yearly_water_l
+
+    @_yearly_water_delivered.setter
+    def _yearly_water_delivered(self, value: float) -> None:
+        self._zone.counters.yearly_water_l = value
+
+    @property
+    def _yearly_water_year(self) -> int:
+        return self._zone.counters.yearly_water_year
+
+    @_yearly_water_year.setter
+    def _yearly_water_year(self, value: int) -> None:
+        self._zone.counters.yearly_water_year = value
+
+    # ── The irrigation cycle, delegated ─────────────────────────────────────
+
+    def begin_cycle(self) -> None:
+        """Open an irrigation cycle, snapshotting the deficit it starts from."""
+        self._zone.begin_cycle()
+
+    def credit_delivery(self, liters: float) -> float:
+        """Credit delivered liters against the deficit; return the new deficit.
+
+        The single home of ``max(0, baseline - delivered*efficiency/area)``,
+        which used to be written out at four call sites.
+        """
+        return self._zone.credit_delivery(_LitersDelivered(liters)).value_mm
+
+    def settle_cycle(self, liters: float, *, source: str, at: datetime, duration_s: int = 0) -> float:
+        """Close a cycle: credit the final figure, stamp it, drop the snapshot."""
+        deficit = self._zone.settle(_LitersDelivered(liters, duration_s), source=source, at=at)
+        return deficit.value_mm
 
     async def async_added_to_hass(self) -> None:
         """Restore zone deficit from previous state.

--- a/custom_components/never_dry/water_balance_model.py
+++ b/custom_components/never_dry/water_balance_model.py
@@ -44,6 +44,7 @@ GH #123 (the deficit reference-frame bug this model makes impossible).
 from __future__ import annotations
 
 import abc
+import math
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import ClassVar
@@ -57,6 +58,15 @@ DEFAULT_D_MAX: float = 100.0
 DEFAULT_FIELD_CAPACITY: float = 0.30
 DEFAULT_ROOT_DEPTH: float = 0.30
 DEFAULT_KC: float = 1.0
+
+# Standard sea-level atmospheric pressure [kPa], for the FAO-56 Penman-Monteith
+# psychrometric constant. A site can override it (it varies with altitude).
+DEFAULT_PRESSURE_KPA: float = 101.3
+
+# Solar constant [MJ/m²/min], for the Hargreaves extraterrestrial radiation Ra.
+_SOLAR_CONSTANT_MJ_MIN: float = 0.0820
+# MJ/m²/day of radiation → equivalent mm/day of evaporation (FAO-56 eq. 20).
+_MJ_TO_MM_EVAP: float = 0.408
 
 # Metres → millimetres. A VWC fraction over a root depth in metres yields metres
 # of water; x1000 expresses the deficit in the model's canonical millimetres.
@@ -163,6 +173,51 @@ class ETStep:
 
 
 @dataclass(frozen=True)
+class PenmanStep:
+    """One integration step for :class:`PenmanMonteithModel` — a richer weather reading.
+
+    Superset of :class:`ETStep`: it carries the same ``dt_h`` / ``temp_c`` /
+    ``rain_mm`` the integrator needs, plus the extra inputs the FAO-56
+    Penman-Monteith reference equation requires and *not every user has* — which
+    is exactly why Penman-Monteith is a higher tier than the temperature-only
+    :class:`ETModel`:
+
+    * ``rh_pct`` — relative humidity [%], for the vapour-pressure deficit
+    * ``wind_m_s`` — wind speed at 2 m [m/s] (``u2``)
+    * ``net_radiation_mj`` — net radiation [MJ/m²/day] (``Rn``); soil heat flux
+      ``G`` is taken as 0 for daily steps
+    """
+
+    dt_h: float
+    temp_c: float
+    rh_pct: float
+    wind_m_s: float
+    net_radiation_mj: float
+    rain_mm: float = 0.0
+
+
+@dataclass(frozen=True)
+class HargreavesStep:
+    """One integration step for :class:`HargreavesModel` — a temperature-range reading.
+
+    The middle tier: it needs only the daily temperature **range** (``tmax_c`` /
+    ``tmin_c``) plus the calendar ``day_of_year``, because its radiation term is
+    the *extraterrestrial* radiation computed from latitude and date (FAO-56
+    eq. 21) — no humidity, wind or radiation **sensor** required. Latitude is a
+    site constant held on the model, not on the step.
+
+    * ``tmax_c`` / ``tmin_c`` — daily max/min temperature [°C]
+    * ``day_of_year`` — 1..365/366, for the astronomical radiation
+    """
+
+    dt_h: float
+    tmax_c: float
+    tmin_c: float
+    day_of_year: int
+    rain_mm: float = 0.0
+
+
+@dataclass(frozen=True)
 class VWCReading:
     """One reading for a VWC model: the current volumetric water content.
 
@@ -174,7 +229,7 @@ class VWCReading:
 
 
 # Union of everything a model's :meth:`WaterBalanceModel.step` may accept.
-ModelInput = ETStep | VWCReading
+ModelInput = ETStep | HargreavesStep | PenmanStep | VWCReading
 
 
 # ── The abstract water-balance model (the "how much" seam) ──────────────────
@@ -236,36 +291,34 @@ class WaterBalanceModel(abc.ABC):
         return self.deficit
 
 
-# ── Strategy 1: ET water balance (temperature + rain, stateful) ─────────────
+# ── ET frame: shared forward-Euler integration, pluggable ET method ─────────
 
 
-class ETModel(WaterBalanceModel):
-    """Forward-Euler ET water balance: ``D += ET_h · Kc · Δt - rain``, clamped.
+class ETBalanceModel(WaterBalanceModel):
+    """Abstract ET-frame model: owns the integration, subclasses supply the ET rate.
 
-    The evapotranspiration demand is the same simplified linear estimate the
-    integration uses today (:func:`et_hourly`). ``Kc`` (the crop coefficient) is
-    a **Zone** attribute in the domain model, not a property of the physics: a
-    per-zone model instance is built with that zone's ``kc``, while the *system
-    reference* model uses ``kc = 1.0``. Each zone owns its own instance because
-    irrigation resets are per-zone and independent — a shared reference cannot be
-    scaled proportionally after the fact (reference model D1/D4).
+    All ET methods share the same water balance — forward-Euler
+    ``D += ET_h · Kc · Δt - rain``, clamped — and the same reference frame (the
+    deficit is relative to the shared weather feeds, so it is comparable across
+    zones). They differ **only** in how the hourly ET rate is computed, which is
+    the single abstract hook :meth:`et_rate`. This is the "ET tier" seam: a
+    temperature-only estimate (:class:`ETModel`) and the fuller FAO-56
+    Penman-Monteith (:class:`PenmanMonteithModel`) are two rates behind one
+    integrator, not two integrators.
+
+    ``Kc`` (the crop coefficient) is a **Zone** attribute in the domain model,
+    not a property of the physics: a per-zone instance is built with that zone's
+    ``kc``, while the *system reference* uses ``kc = 1.0``. Each zone owns its own
+    instance because irrigation resets are per-zone and independent — a shared
+    reference cannot be scaled proportionally after the fact (reference model
+    D1/D4).
     """
 
     is_stateful: ClassVar[bool] = True
 
-    def __init__(
-        self,
-        *,
-        alpha: float = DEFAULT_ALPHA,
-        t_base: float = DEFAULT_T_BASE,
-        kc: float = DEFAULT_KC,
-        d_max: float = DEFAULT_D_MAX,
-        initial_mm: float = 0.0,
-    ) -> None:
-        """Configure ET sensitivity ``alpha``, base temperature ``t_base`` and ``kc``."""
+    def __init__(self, *, kc: float = DEFAULT_KC, d_max: float = DEFAULT_D_MAX, initial_mm: float = 0.0) -> None:
+        """Configure the crop coefficient ``kc`` and the deficit clamp ``d_max``."""
         super().__init__(d_max=d_max, initial_mm=initial_mm)
-        self._alpha = alpha
-        self._t_base = t_base
         self._kc = kc
 
     @property
@@ -278,26 +331,201 @@ class ETModel(WaterBalanceModel):
         """The crop coefficient this instance integrates with (1.0 for the reference)."""
         return self._kc
 
-    @staticmethod
-    def et_hourly(temp_c: float, *, alpha: float = DEFAULT_ALPHA, t_base: float = DEFAULT_T_BASE) -> float:
-        """Instantaneous ET estimate [mm/h] — ``max(0, alpha · (T - T_base) / 24)``.
-
-        The single source of the ET formula today written twice (``ETSensor`` and
-        ``DrynessIndexSensor``); the abstraction unifies it here.
-        """
-        return max(0.0, alpha * (temp_c - t_base) / 24.0)
+    @abc.abstractmethod
+    def et_rate(self, inputs: ModelInput) -> float:
+        """Return the ET rate [mm/h] for this step (the only thing ET methods vary)."""
 
     def step(self, inputs: ModelInput) -> Deficit:
-        """Integrate one ``ETStep``: add ``ET_h · Kc · Δt``, subtract rain, clamp."""
-        if not isinstance(inputs, ETStep):
-            raise TypeError(f"ETModel.step expects ETStep, got {type(inputs).__name__}")
-        et_h = self.et_hourly(inputs.temp_c, alpha=self._alpha, t_base=self._t_base)
+        """Integrate one step: add ``ET_h · Kc · Δt``, subtract rain, clamp.
+
+        The concrete :meth:`et_rate` type-guards its own input DTO, so ``dt_h`` and
+        ``rain_mm`` are only read once the input is known to be the right shape.
+        """
+        et_h = self.et_rate(inputs)
         self._value_mm = _clamp(
             self._value_mm + et_h * self._kc * inputs.dt_h - inputs.rain_mm,
             0.0,
             self._d_max,
         )
         return self.deficit
+
+
+# ── Strategy 1a: simplified temperature-only ET (today's model) ─────────────
+
+
+class ETModel(ETBalanceModel):
+    """Simplified temperature-only ET — the linear estimate NeverDry uses today.
+
+    Needs a single input, temperature, which makes it the baseline tier: any user
+    with a weather/temperature sensor can run it. The demand is
+    :func:`et_hourly`, the same formula written twice today (``ETSensor`` and
+    ``DrynessIndexSensor``) that the abstraction unifies here.
+    """
+
+    def __init__(
+        self,
+        *,
+        alpha: float = DEFAULT_ALPHA,
+        t_base: float = DEFAULT_T_BASE,
+        kc: float = DEFAULT_KC,
+        d_max: float = DEFAULT_D_MAX,
+        initial_mm: float = 0.0,
+    ) -> None:
+        """Configure ET sensitivity ``alpha``, base temperature ``t_base`` and ``kc``."""
+        super().__init__(kc=kc, d_max=d_max, initial_mm=initial_mm)
+        self._alpha = alpha
+        self._t_base = t_base
+
+    @staticmethod
+    def et_hourly(temp_c: float, *, alpha: float = DEFAULT_ALPHA, t_base: float = DEFAULT_T_BASE) -> float:
+        """Instantaneous ET estimate [mm/h] — ``max(0, alpha · (T - T_base) / 24)``."""
+        return max(0.0, alpha * (temp_c - t_base) / 24.0)
+
+    def et_rate(self, inputs: ModelInput) -> float:
+        """The temperature-only ET rate [mm/h] from an :class:`ETStep`."""
+        if not isinstance(inputs, ETStep):
+            raise TypeError(f"ETModel.step expects ETStep, got {type(inputs).__name__}")
+        return self.et_hourly(inputs.temp_c, alpha=self._alpha, t_base=self._t_base)
+
+
+# ── Strategy 1b: FAO-56 Penman-Monteith ET (higher tier, more inputs) ───────
+
+
+class PenmanMonteithModel(ETBalanceModel):
+    """FAO-56 Penman-Monteith reference ET — the physically-grounded higher tier.
+
+    Same ET frame and same integrator as :class:`ETModel`; it only computes a
+    better ET rate, at the cost of inputs not every user has: relative humidity,
+    wind speed and net radiation (see :class:`PenmanStep`). This is the concrete
+    payoff of abstracting at the *output*: a setup can move from ``ETModel`` to
+    ``PenmanMonteithModel`` — or fall back — and the Zone still just reads a
+    :class:`Deficit`, unaware of which tier produced it.
+
+    The reference equation (FAO-56 eq. 6) yields ET₀ in mm/day; the integrator
+    works in mm/h, so the rate is ET₀/24. Soil heat flux ``G`` is taken as 0
+    (daily assumption).
+    """
+
+    def __init__(
+        self,
+        *,
+        kc: float = DEFAULT_KC,
+        pressure_kpa: float = DEFAULT_PRESSURE_KPA,
+        d_max: float = DEFAULT_D_MAX,
+        initial_mm: float = 0.0,
+    ) -> None:
+        """Configure ``kc`` and site atmospheric ``pressure_kpa`` (altitude-dependent)."""
+        super().__init__(kc=kc, d_max=d_max, initial_mm=initial_mm)
+        self._pressure_kpa = pressure_kpa
+
+    @staticmethod
+    def _saturation_vapour_pressure(temp_c: float) -> float:
+        """Saturation vapour pressure e°(T) [kPa] — FAO-56 eq. 11."""
+        return 0.6108 * math.exp(17.27 * temp_c / (temp_c + 237.3))
+
+    @classmethod
+    def et0_daily(
+        cls,
+        *,
+        temp_c: float,
+        rh_pct: float,
+        wind_m_s: float,
+        net_radiation_mj: float,
+        pressure_kpa: float = DEFAULT_PRESSURE_KPA,
+    ) -> float:
+        """FAO-56 Penman-Monteith reference ET₀ [mm/day] (eq. 6, ``G = 0``)."""
+        es = cls._saturation_vapour_pressure(temp_c)
+        ea = es * max(0.0, min(rh_pct, 100.0)) / 100.0
+        vpd = es - ea
+        # Slope of the saturation vapour-pressure curve Δ [kPa/°C] — FAO-56 eq. 13.
+        delta = 4098.0 * es / (temp_c + 237.3) ** 2
+        # Psychrometric constant gamma [kPa/°C] — FAO-56 eq. 8.
+        gamma = 0.000665 * pressure_kpa
+        numerator = 0.408 * delta * net_radiation_mj + gamma * (900.0 / (temp_c + 273.0)) * wind_m_s * vpd
+        denominator = delta + gamma * (1.0 + 0.34 * wind_m_s)
+        return max(0.0, numerator / denominator)
+
+    def et_rate(self, inputs: ModelInput) -> float:
+        """The Penman-Monteith ET rate [mm/h] from a :class:`PenmanStep` (ET₀/24)."""
+        if not isinstance(inputs, PenmanStep):
+            raise TypeError(f"PenmanMonteithModel.step expects PenmanStep, got {type(inputs).__name__}")
+        et0 = self.et0_daily(
+            temp_c=inputs.temp_c,
+            rh_pct=inputs.rh_pct,
+            wind_m_s=inputs.wind_m_s,
+            net_radiation_mj=inputs.net_radiation_mj,
+            pressure_kpa=self._pressure_kpa,
+        )
+        return et0 / 24.0
+
+
+# ── Strategy 1c: Hargreaves-Samani ET (middle tier, computed radiation) ─────
+
+
+class HargreavesModel(ETBalanceModel):
+    """FAO-56 Hargreaves-Samani ET — the middle tier between temperature-only and Penman.
+
+    Physically better than :class:`ETModel` (it captures the diurnal temperature
+    range and the seasonal/latitude radiation cycle) yet needs **no extra
+    sensor**: its radiation term is the *extraterrestrial* radiation ``Ra``,
+    computed purely from latitude and day-of-year (FAO-56 eq. 21). So the only
+    inputs are daily max/min temperature and the date — the sweet spot for users
+    who have a temperature sensor but no humidity/wind/radiation gear.
+
+    ``ET0 = 0.0023 · (Tmean + 17.8) · sqrt(Tmax - Tmin) · Ra_mm`` [mm/day], with
+    ``Tmean = (Tmax + Tmin) / 2`` and ``Ra_mm`` the extraterrestrial radiation
+    expressed in mm/day. Latitude is a site constant on the model; the date rides
+    on each :class:`HargreavesStep`. The rate is ET0/24 for the hourly integrator.
+    """
+
+    def __init__(
+        self,
+        *,
+        latitude_deg: float,
+        kc: float = DEFAULT_KC,
+        d_max: float = DEFAULT_D_MAX,
+        initial_mm: float = 0.0,
+    ) -> None:
+        """Configure the site ``latitude_deg`` (drives the astronomical radiation) and ``kc``."""
+        super().__init__(kc=kc, d_max=d_max, initial_mm=initial_mm)
+        self._latitude_deg = latitude_deg
+
+    @staticmethod
+    def extraterrestrial_radiation(day_of_year: int, latitude_deg: float) -> float:
+        """Extraterrestrial radiation Ra [MJ/m²/day] — FAO-56 eq. 21 (no sensor needed)."""
+        phi = math.radians(latitude_deg)
+        # Inverse relative Earth-Sun distance (eq. 23) and solar declination (eq. 24).
+        dr = 1.0 + 0.033 * math.cos(2.0 * math.pi / 365.0 * day_of_year)
+        decl = 0.409 * math.sin(2.0 * math.pi / 365.0 * day_of_year - 1.39)
+        # Sunset hour angle (eq. 25), guarded for polar day/night.
+        cos_ws = -math.tan(phi) * math.tan(decl)
+        ws = math.acos(max(-1.0, min(1.0, cos_ws)))
+        return (
+            (24.0 * 60.0 / math.pi)
+            * _SOLAR_CONSTANT_MJ_MIN
+            * dr
+            * (ws * math.sin(phi) * math.sin(decl) + math.cos(phi) * math.cos(decl) * math.sin(ws))
+        )
+
+    @classmethod
+    def et0_daily(cls, *, tmax_c: float, tmin_c: float, day_of_year: int, latitude_deg: float) -> float:
+        """FAO-56 Hargreaves-Samani reference ET₀ [mm/day]."""
+        tmean = (tmax_c + tmin_c) / 2.0
+        trange = max(0.0, tmax_c - tmin_c)
+        ra_mm = _MJ_TO_MM_EVAP * cls.extraterrestrial_radiation(day_of_year, latitude_deg)
+        return max(0.0, 0.0023 * (tmean + 17.8) * math.sqrt(trange) * ra_mm)
+
+    def et_rate(self, inputs: ModelInput) -> float:
+        """The Hargreaves ET rate [mm/h] from a :class:`HargreavesStep` (ET₀/24)."""
+        if not isinstance(inputs, HargreavesStep):
+            raise TypeError(f"HargreavesModel.step expects HargreavesStep, got {type(inputs).__name__}")
+        et0 = self.et0_daily(
+            tmax_c=inputs.tmax_c,
+            tmin_c=inputs.tmin_c,
+            day_of_year=inputs.day_of_year,
+            latitude_deg=self._latitude_deg,
+        )
+        return et0 / 24.0
 
 
 # ── Strategy 2: VWC from a system probe (stateless measurement) ─────────────

--- a/custom_components/never_dry/water_balance_model.py
+++ b/custom_components/never_dry/water_balance_model.py
@@ -20,7 +20,7 @@ per-zone deficit loop):
 Design intent — this module is deliberately **pure**: no Home Assistant import,
 no I/O, only arithmetic on floats. The "how much water" math has no reason to
 touch HA, which makes it trivially testable and reusable. This mirrors, on the
-*sensing* side, what ``actuator.py`` did on the *actuation* side: extract the
+*sensing* side, what ``driver.py`` did on the *actuation* side: extract the
 implicit domain object into a self-contained module now, wire the existing call
 sites onto it in a later phase.
 

--- a/custom_components/never_dry/water_balance_model.py
+++ b/custom_components/never_dry/water_balance_model.py
@@ -1,0 +1,383 @@
+"""Water-balance model abstraction — the single home for computing *how much*
+water a patch of soil needs, independent of *how* it is measured.
+
+This module materializes two domain-model concepts that today live implicitly,
+scattered inside ``sensor.py`` (``DrynessIndexSensor`` / ``ETSensor`` and the
+per-zone deficit loop):
+
+* :class:`WaterBalanceModel` (abstract) — the *scientific model*: "give me the
+  deficit, no matter which inputs I compute it from". Its three concrete
+  strategies mirror the reference frames of
+  ``docs/design_water_balance_reference_model.md``:
+  :class:`ETModel` (temperature + rain), :class:`VWCSystemModel` (one system
+  soil-moisture probe), :class:`VWCPerZoneModel` (a per-zone probe, target
+  AI-174).
+* :class:`Deficit` (value object) — the *quantity*: millimetres **plus the
+  reference frame they are defined against**. The load-bearing rule of the
+  reference model is that *two deficits are comparable only if they share a
+  frame*, so a bare ``float`` is not enough — the frame travels with the value.
+
+Design intent — this module is deliberately **pure**: no Home Assistant import,
+no I/O, only arithmetic on floats. The "how much water" math has no reason to
+touch HA, which makes it trivially testable and reusable. This mirrors, on the
+*sensing* side, what ``actuator.py`` did on the *actuation* side: extract the
+implicit domain object into a self-contained module now, wire the existing call
+sites onto it in a later phase.
+
+The seam is the **output**, not the input: the three models share no inputs
+(ET needs weather, VWC needs a probe), but every model produces a
+:class:`Deficit` in mm. This is exactly why the abstraction sits at the output —
+each model copes with whatever sensors it has and exposes the same quantity.
+
+Translation chain (see ``docs/design_domain_object_model.md``)::
+
+    WaterBalanceModel  ──produces──▶  Deficit (mm)  ──Zone──▶  Actuator (liters)
+
+References: ``docs/design_water_balance_reference_model.md`` (D1-D5, reference
+frames), ``docs/design_domain_object_model.md`` (the domain classes),
+GH #123 (the deficit reference-frame bug this model makes impossible).
+
+**Phase 1 — inert scaffold.** Nothing imports this module yet; wiring
+``DrynessIndexSensor`` / the per-zone loop onto it is a deliberate later phase.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import ClassVar
+
+# Defaults mirror ``const.py`` so a model built with no overrides behaves exactly
+# like today's sensors. Kept as module constants (not a HA import) to keep the
+# module pure; the integration passes the user-configured values in.
+DEFAULT_ALPHA: float = 0.22
+DEFAULT_T_BASE: float = 9.0
+DEFAULT_D_MAX: float = 100.0
+DEFAULT_FIELD_CAPACITY: float = 0.30
+DEFAULT_ROOT_DEPTH: float = 0.30
+DEFAULT_KC: float = 1.0
+
+# Metres → millimetres. A VWC fraction over a root depth in metres yields metres
+# of water; x1000 expresses the deficit in the model's canonical millimetres.
+_M_TO_MM: float = 1000.0
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    """Clamp ``value`` into ``[lower, upper]`` (the FAO-56 ``[0, D_max]`` box)."""
+    return max(lower, min(value, upper))
+
+
+# ── Reference frame: what a deficit is measured *relative to* ───────────────
+
+
+class ReferenceFrame(StrEnum):
+    """The measurement frame a :class:`Deficit` is defined against.
+
+    Comparability follows the reference model: ``ET`` and ``VWC_SYSTEM`` are
+    **shared** across zones (all zones read the same feeds/probe, differing only
+    by Kc), so their deficits are comparable. ``VWC_PER_ZONE`` is **not** shared:
+    each zone measures a different patch of soil, so two per-zone deficits are
+    comparable only when they come from the *same* probe.
+    """
+
+    ET = "et"
+    VWC_SYSTEM = "vwc_system"
+    VWC_PER_ZONE = "vwc_per_zone"
+
+    @property
+    def is_shared(self) -> bool:
+        """``True`` when every zone shares this frame (ET feeds or one system probe)."""
+        return self is not ReferenceFrame.VWC_PER_ZONE
+
+
+# ── The quantity: a deficit in mm, carrying its reference frame ─────────────
+
+
+@dataclass(frozen=True)
+class Deficit:
+    """A soil water deficit in millimetres, tagged with its :class:`ReferenceFrame`.
+
+    Immutable value object. It is the common currency every
+    :class:`WaterBalanceModel` returns and the Zone consumes to decide watering.
+    The ``frame`` (and, for per-zone probes, ``source``) travel with the number
+    so the "two deficits are comparable only within one frame" rule of the
+    reference model is enforceable in code rather than left to convention.
+    """
+
+    value_mm: float
+    frame: ReferenceFrame
+    d_max: float = DEFAULT_D_MAX
+    # Identity of the frame for per-zone deficits (e.g. the probe/zone id). For
+    # shared frames (ET, system VWC) it is ``None`` — the frame alone identifies
+    # comparability. See :meth:`is_comparable_to`.
+    source: str | None = None
+
+    @classmethod
+    def zero(cls, frame: ReferenceFrame, d_max: float = DEFAULT_D_MAX, source: str | None = None) -> Deficit:
+        """Return a fresh zero deficit — a new zone starts here (reference model D4)."""
+        return cls(0.0, frame, d_max, source)
+
+    def clamped(self) -> Deficit:
+        """Return a copy with ``value_mm`` clamped into the FAO-56 ``[0, d_max]`` box."""
+        return replace(self, value_mm=_clamp(self.value_mm, 0.0, self.d_max))
+
+    def with_value(self, value_mm: float) -> Deficit:
+        """Return a copy at ``value_mm`` (unclamped); pair with :meth:`clamped`."""
+        return replace(self, value_mm=value_mm)
+
+    def is_comparable_to(self, other: Deficit) -> bool:
+        """``True`` when ``self`` and ``other`` live in the same reference frame.
+
+        Shared frames (ET, system VWC) are comparable whenever the frame matches.
+        Per-zone frames additionally require the same ``source`` — two zones each
+        on their own probe are *not* comparable even though both are
+        ``VWC_PER_ZONE`` (reference model, "Reference frames").
+        """
+        if self.frame is not other.frame:
+            return False
+        if self.frame.is_shared:
+            return True
+        return self.source is not None and self.source == other.source
+
+    def as_liters(self, area_m2: float) -> float:
+        """Project this deficit onto a zone area: 1 mm over 1 m² is 1 litre."""
+        return self.value_mm * area_m2
+
+
+# ── Model inputs: each strategy consumes its own reading ────────────────────
+
+
+@dataclass(frozen=True)
+class ETStep:
+    """One integration step for :class:`ETModel`: a time delta plus its weather.
+
+    ``dt_h`` is the hours elapsed since the previous step (forward-Euler variable
+    step, as today's event-driven integrator); ``temp_c`` the current temperature
+    in °C; ``rain_mm`` the rain credited over this step in mm.
+    """
+
+    dt_h: float
+    temp_c: float
+    rain_mm: float = 0.0
+
+
+@dataclass(frozen=True)
+class VWCReading:
+    """One reading for a VWC model: the current volumetric water content.
+
+    ``vwc`` is a volumetric fraction in ``[0, 1]`` (e.g. ``0.22`` = 22 %),
+    directly comparable to ``field_capacity``.
+    """
+
+    vwc: float
+
+
+# Union of everything a model's :meth:`WaterBalanceModel.step` may accept.
+ModelInput = ETStep | VWCReading
+
+
+# ── The abstract water-balance model (the "how much" seam) ──────────────────
+
+
+class WaterBalanceModel(abc.ABC):
+    """A strategy that turns sensor inputs into a per-frame :class:`Deficit` in mm.
+
+    Concrete models differ in *what they read* (weather vs a moisture probe) and
+    in whether they are **stateful** (ET integrates over time) or **stateless**
+    (VWC recomputes each reading), but they all expose the same contract:
+    :meth:`step` advances the model and returns the current deficit,
+    :meth:`apply_irrigation` registers delivered water, :meth:`reset` returns to
+    zero. The Zone talks to this interface and never to a specific model.
+    """
+
+    #: Whether the model accumulates state across steps (ET) or recomputes each
+    #: reading from scratch (VWC). Subclasses set it as a class attribute.
+    is_stateful: ClassVar[bool]
+
+    def __init__(self, *, d_max: float = DEFAULT_D_MAX, initial_mm: float = 0.0, source: str | None = None) -> None:
+        """Initialise the model at ``initial_mm`` (default 0 — reference model D4)."""
+        self._d_max = d_max
+        self._source = source
+        self._value_mm = _clamp(initial_mm, 0.0, d_max)
+
+    @property
+    @abc.abstractmethod
+    def reference_frame(self) -> ReferenceFrame:
+        """The frame every :class:`Deficit` from this model is defined against."""
+
+    @property
+    def d_max(self) -> float:
+        """The FAO-56 upper clamp on the deficit [mm]."""
+        return self._d_max
+
+    @property
+    def deficit(self) -> Deficit:
+        """The current deficit as a frame-tagged value object."""
+        source = self._source if self.reference_frame is ReferenceFrame.VWC_PER_ZONE else None
+        return Deficit(round(self._value_mm, 4), self.reference_frame, self._d_max, source)
+
+    @abc.abstractmethod
+    def step(self, inputs: ModelInput) -> Deficit:
+        """Advance the model with one reading and return the updated deficit."""
+
+    def apply_irrigation(self, delivered_mm: float) -> Deficit:
+        """Register ``delivered_mm`` of water just applied and return the new deficit.
+
+        Stateful models subtract it (and clamp at 0); stateless models override
+        to a no-op because their next reading already reflects the wetter soil.
+        """
+        self._value_mm = _clamp(self._value_mm - delivered_mm, 0.0, self._d_max)
+        return self.deficit
+
+    def reset(self) -> Deficit:
+        """Reset the deficit to zero (a zone was fully irrigated) and return it."""
+        self._value_mm = 0.0
+        return self.deficit
+
+
+# ── Strategy 1: ET water balance (temperature + rain, stateful) ─────────────
+
+
+class ETModel(WaterBalanceModel):
+    """Forward-Euler ET water balance: ``D += ET_h · Kc · Δt - rain``, clamped.
+
+    The evapotranspiration demand is the same simplified linear estimate the
+    integration uses today (:func:`et_hourly`). ``Kc`` (the crop coefficient) is
+    a **Zone** attribute in the domain model, not a property of the physics: a
+    per-zone model instance is built with that zone's ``kc``, while the *system
+    reference* model uses ``kc = 1.0``. Each zone owns its own instance because
+    irrigation resets are per-zone and independent — a shared reference cannot be
+    scaled proportionally after the fact (reference model D1/D4).
+    """
+
+    is_stateful: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        *,
+        alpha: float = DEFAULT_ALPHA,
+        t_base: float = DEFAULT_T_BASE,
+        kc: float = DEFAULT_KC,
+        d_max: float = DEFAULT_D_MAX,
+        initial_mm: float = 0.0,
+    ) -> None:
+        """Configure ET sensitivity ``alpha``, base temperature ``t_base`` and ``kc``."""
+        super().__init__(d_max=d_max, initial_mm=initial_mm)
+        self._alpha = alpha
+        self._t_base = t_base
+        self._kc = kc
+
+    @property
+    def reference_frame(self) -> ReferenceFrame:
+        """ET deficits are shared across zones (same temperature + rain feeds)."""
+        return ReferenceFrame.ET
+
+    @property
+    def kc(self) -> float:
+        """The crop coefficient this instance integrates with (1.0 for the reference)."""
+        return self._kc
+
+    @staticmethod
+    def et_hourly(temp_c: float, *, alpha: float = DEFAULT_ALPHA, t_base: float = DEFAULT_T_BASE) -> float:
+        """Instantaneous ET estimate [mm/h] — ``max(0, alpha · (T - T_base) / 24)``.
+
+        The single source of the ET formula today written twice (``ETSensor`` and
+        ``DrynessIndexSensor``); the abstraction unifies it here.
+        """
+        return max(0.0, alpha * (temp_c - t_base) / 24.0)
+
+    def step(self, inputs: ModelInput) -> Deficit:
+        """Integrate one ``ETStep``: add ``ET_h · Kc · Δt``, subtract rain, clamp."""
+        if not isinstance(inputs, ETStep):
+            raise TypeError(f"ETModel.step expects ETStep, got {type(inputs).__name__}")
+        et_h = self.et_hourly(inputs.temp_c, alpha=self._alpha, t_base=self._t_base)
+        self._value_mm = _clamp(
+            self._value_mm + et_h * self._kc * inputs.dt_h - inputs.rain_mm,
+            0.0,
+            self._d_max,
+        )
+        return self.deficit
+
+
+# ── Strategy 2: VWC from a system probe (stateless measurement) ─────────────
+
+
+class VWCSystemModel(WaterBalanceModel):
+    """Deficit read directly from one system soil-moisture probe (stateless).
+
+    ``D = (field_capacity - vwc) · root_depth · 1000``, clamped to ``[0, d_max]``.
+    Stateless: every reading recomputes the deficit from the current measurement,
+    so there is no drift and no seeding — which is why the interim system-level
+    VWC deficit is benign (reference model D5). All zones scale the same current
+    reading by their Kc downstream; the frame is shared.
+    """
+
+    is_stateful: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        *,
+        field_capacity: float = DEFAULT_FIELD_CAPACITY,
+        root_depth: float = DEFAULT_ROOT_DEPTH,
+        d_max: float = DEFAULT_D_MAX,
+    ) -> None:
+        """Configure ``field_capacity`` (fraction) and ``root_depth`` (metres)."""
+        super().__init__(d_max=d_max)
+        self._field_capacity = field_capacity
+        self._root_depth = root_depth
+
+    @property
+    def reference_frame(self) -> ReferenceFrame:
+        """A single system probe is a shared frame across zones."""
+        return ReferenceFrame.VWC_SYSTEM
+
+    def step(self, inputs: ModelInput) -> Deficit:
+        """Recompute the deficit from a ``VWCReading`` — no accumulated state."""
+        if not isinstance(inputs, VWCReading):
+            raise TypeError(f"{type(self).__name__}.step expects VWCReading, got {type(inputs).__name__}")
+        self._value_mm = _clamp(
+            (self._field_capacity - inputs.vwc) * self._root_depth * _M_TO_MM,
+            0.0,
+            self._d_max,
+        )
+        return self.deficit
+
+    def apply_irrigation(self, delivered_mm: float) -> Deficit:
+        """No-op: a stateless probe reflects the wetter soil on its next reading."""
+        return self.deficit
+
+    def reset(self) -> Deficit:
+        """No-op: there is no accumulated state to clear (the probe is the truth)."""
+        return self.deficit
+
+
+# ── Strategy 3: VWC from a per-zone probe (target, AI-174) ──────────────────
+
+
+class VWCPerZoneModel(VWCSystemModel):
+    """Deficit from a zone's *own* soil-moisture probe (the AI-174 target).
+
+    Same stateless measurement as :class:`VWCSystemModel`, but the frame is
+    **per-zone**: each zone measures a different patch of soil, so its deficit is
+    not comparable with a sibling's (the ``source`` identity — the probe/zone id
+    — guards this in :meth:`Deficit.is_comparable_to`). When this lands, the
+    system-level VWC deficit disappears entirely (reference model D5).
+    """
+
+    def __init__(
+        self,
+        *,
+        source: str,
+        field_capacity: float = DEFAULT_FIELD_CAPACITY,
+        root_depth: float = DEFAULT_ROOT_DEPTH,
+        d_max: float = DEFAULT_D_MAX,
+    ) -> None:
+        """Configure a per-zone VWC model; ``source`` identifies the zone/probe frame."""
+        super().__init__(field_capacity=field_capacity, root_depth=root_depth, d_max=d_max)
+        self._source = source
+
+    @property
+    def reference_frame(self) -> ReferenceFrame:
+        """A per-zone probe is *not* shared: deficits differ patch by patch."""
+        return ReferenceFrame.VWC_PER_ZONE

--- a/custom_components/never_dry/zone.py
+++ b/custom_components/never_dry/zone.py
@@ -223,6 +223,15 @@ class Zone:
         if self.deficit is None:
             self.deficit = Deficit.zero(ReferenceFrame.ET, d_max=self.d_max, source=self.name)
 
+    @property
+    def cycle_baseline_mm(self) -> float | None:
+        """The deficit a cycle started from, or ``None`` outside one."""
+        return self._cycle_baseline_mm
+
+    @cycle_baseline_mm.setter
+    def cycle_baseline_mm(self, value: float | None) -> None:
+        self._cycle_baseline_mm = value
+
     # ── Crop coefficient ────────────────────────────────────────────────────
 
     def effective_kc(self, base_kc: float) -> float:

--- a/custom_components/never_dry/zone.py
+++ b/custom_components/never_dry/zone.py
@@ -1,0 +1,321 @@
+"""The zone — the irrigation unit that owns its deficit and turns it into water.
+
+This module writes out the class the domain model has specified since the
+beginning and the code never typed: :class:`Zone`. It has a row in the
+five-object table, a box in the class diagram, and a named owner for every
+behaviour listed in anomaly A1 — but until now no module. What exists instead is
+``IrrigationZoneSensor`` plus eighteen ``Zone*Sensor`` numeric projections of it,
+with the accounting living in ``IrrigationController``.
+
+Why that matters more than tidiness. Look at where the other two scaffolds point:
+``actuator.py`` returns a ``DeliveryResult`` — to *whom*? To the zone that settles
+it. ``water_balance_model.py`` produces a ``Deficit`` — for *whom*? For the zone
+that owns it. Both seams face this class. They are inert not because wiring is
+hard but because the object they attach to had not been written.
+
+**The one crediting formula.** Today ``max(0, baseline - delivered*efficiency/area)``
+is duplicated across four sites — ``_settle_irrigated_zones``,
+``_update_deficit_realtime`` and ``_finalize_manual_session`` in ``controller.py``,
+and ``reset_deficit`` in ``sensor.py`` — and the four are *not* identical: two
+subtract from a snapshot taken at cycle start, one subtracts from the live value.
+:meth:`Zone.credit_delivery` is the single home for that arithmetic. It resolves
+the divergence deliberately, on the snapshot when a cycle is open and on the
+current value otherwise, so an intermediate write stays idempotent and settling
+never double-counts.
+
+**Placement, not exposure, not environment.** ``Zone.placement`` says where the
+zone sits — outdoors, on a covered patio, under glass, indoors — and gates
+whether rain reaches it at all. It is deliberately *not* named ``environment``
+(that is the site-level sensor inventory, see ``environment.py``) nor
+``exposure`` (that is the sun/wind microclimate factor of GH #146). Three
+overlapping words at two levels; the collision is resolved here rather than
+after wiring.
+
+Design intent — this module is **pure**: no Home Assistant import, no I/O, only
+arithmetic and rules. It reads a delivery through the structural
+:class:`Delivery` protocol rather than importing ``actuator.DeliveryResult``,
+because ``actuator.py`` is HA-coupled and this module must not become so;
+``DeliveryResult`` satisfies the protocol without either module knowing about the
+other. That is also the first declared interface in the package, which anomaly C1
+notes is otherwise entirely absent.
+
+**Phase 1 — inert scaffold.** Nothing imports this module yet. Wiring
+``IrrigationZoneSensor`` and the controller onto it is a deliberate later phase.
+
+References: ``docs/design_domain_object_model.md`` (the domain classes, the
+translation chain, ``Zone.placement``, per-zone ``D_max``),
+``docs/design_domain_model_anomalies.md`` (A1, the anemic model this closes),
+``docs/design_water_balance_reference_model.md`` (D4, a new zone starts at 0).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+from .water_balance_model import DEFAULT_D_MAX, Deficit, ReferenceFrame
+
+# Defaults mirror ``const.py`` so a Zone built with no overrides behaves exactly
+# like today's zone sensor.
+DEFAULT_EFFICIENCY: float = 0.85
+DEFAULT_THRESHOLD_MM: float = 20.0
+DEFAULT_MICROCLIMATE_FACTOR: float = 1.0
+
+
+class Placement(StrEnum):
+    """Where the zone sits, which decides what reaches it from the sky.
+
+    Categorical rather than a boolean because of ``PATIO``: a covered terrace is
+    fully outdoors for temperature and wind yet receives no rain, so "receives
+    rain" and "is outdoors" are independent properties. With only the other three
+    values one would be tempted to collapse them into a single flag.
+    """
+
+    OUTDOOR = "outdoor"
+    PATIO = "patio"
+    GREENHOUSE = "greenhouse"
+    INDOOR = "indoor"
+
+    @property
+    def receives_rain(self) -> bool:
+        """``True`` only when the zone is open to the sky.
+
+        Gates both the measured rain credit and the forecast rain delay. Sharing
+        one gate is what stops the two from ever disagreeing about a zone.
+        """
+        return self is Placement.OUTDOOR
+
+    @property
+    def driven_by_outdoor_et(self) -> bool:
+        """``True`` when outdoor evapotranspiration describes this zone's demand.
+
+        A patio is: it feels the same heat and wind as the lawn. Indoors is not —
+        that case wants moisture-threshold logic rather than a weather-driven
+        balance. A greenhouse is a sheltered regime of its own and is excluded
+        here rather than approximated.
+        """
+        return self in (Placement.OUTDOOR, Placement.PATIO)
+
+
+class IrrigationMode(StrEnum):
+    """How this zone decides to water. Mirrors ``const.py``."""
+
+    MANUAL = "manual"
+    REACTIVE = "reactive"
+    SCHEDULED = "scheduled"
+
+
+@runtime_checkable
+class Delivery(Protocol):
+    """The structural shape :meth:`Zone.credit_delivery` needs from a delivery.
+
+    A protocol rather than an import: ``actuator.DeliveryResult`` satisfies it
+    without this pure module taking on ``actuator.py``'s Home Assistant
+    dependency. Anything reporting how much water it actually delivered can
+    settle a zone — including, later, a manual "I watered by hand" record.
+    """
+
+    liters_delivered: float
+    elapsed_s: float
+
+
+@dataclass(frozen=True)
+class CycleSoakRule:
+    """Split a run into segments with soak time between them.
+
+    A Zone rule, not a Scheduler policy: the parameters follow from soil
+    infiltration rate, slope and soil type, which are properties of this patch of
+    ground. Executing the segments is controller/actuator mechanics. Unset means
+    today's behaviour — one uninterrupted run.
+    """
+
+    max_segment_s: int | None = None
+    soak_s: int | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """``True`` when both halves are configured; either alone means nothing."""
+        return bool(self.max_segment_s and self.soak_s)
+
+
+@dataclass
+class WaterCounters:
+    """The zone's delivered-water bookkeeping, kept together rather than loose.
+
+    These are the attributes the controller reaches in and writes today; grouping
+    them makes the surface that has to move explicit.
+    """
+
+    last_volume_l: float = 0.0
+    session_water_l: float = 0.0
+    total_water_l: float = 0.0
+    yearly_water_l: float = 0.0
+    yearly_water_year: int | None = None
+
+    def credit(self, liters: float, *, year: int) -> None:
+        """Add ``liters`` to every counter, rolling the yearly total on year change."""
+        credited = round(liters, 1)
+        self.last_volume_l = credited
+        self.session_water_l = credited
+        self.total_water_l += credited
+        if self.yearly_water_year != year:
+            self.yearly_water_l = 0.0
+            self.yearly_water_year = year
+        self.yearly_water_l += credited
+
+    def reset_yearly(self, *, year: int) -> None:
+        """Clear the yearly total, preserving the lifetime one (user-invoked reset)."""
+        self.yearly_water_l = 0.0
+        self.yearly_water_year = year
+
+
+@dataclass
+class Zone:
+    """One irrigation unit: owns its deficit, and turns it into litres.
+
+    The deficit is a :class:`Deficit` value object rather than a bare float, so
+    the reference frame travels with the number and two deficits from different
+    frames cannot be compared by accident.
+    """
+
+    name: str
+
+    # ── Geometry and hydraulics ─────────────────────────────────────────────
+    area_m2: float = 0.0
+    efficiency: float = DEFAULT_EFFICIENCY
+
+    # ── What grows here, and where here is ──────────────────────────────────
+    plant_family: str | None = None
+    manual_kc: float | None = None
+    # Site exposure (GH #146): sun and wind relative to an open site. Multiplies
+    # the seasonal curve rather than replacing it.
+    exposure: str | None = None
+    microclimate_factor: float = DEFAULT_MICROCLIMATE_FACTOR
+    placement: Placement = Placement.OUTDOOR
+
+    # ── Water balance ───────────────────────────────────────────────────────
+    # D_max is the reservoir *this* soil can hold — soil type times root depth —
+    # so it is per-zone. Only the clamping mechanism is shared across models.
+    d_max: float = DEFAULT_D_MAX
+    threshold_mm: float = DEFAULT_THRESHOLD_MM
+    deficit: Deficit = field(default=None)  # type: ignore[assignment]
+
+    # ── Scheduling ──────────────────────────────────────────────────────────
+    irrigation_mode: IrrigationMode = IrrigationMode.MANUAL
+    irrigation_time: str | None = None
+    cycle_soak: CycleSoakRule = field(default_factory=CycleSoakRule)
+
+    # ── Session state ───────────────────────────────────────────────────────
+    counters: WaterCounters = field(default_factory=WaterCounters)
+    last_irrigated: datetime | None = None
+    last_source: str | None = None
+    last_duration_s: int = 0
+    # Deficit captured when a cycle opens; ``None`` outside a cycle. Present so
+    # repeated real-time credits during a flow-metered run stay idempotent.
+    _cycle_baseline_mm: float | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        # A new zone starts at zero rather than inheriting a shared reference
+        # deficit, which drifts high under per-zone irrigation (reference model
+        # D4, GH #123).
+        if self.deficit is None:
+            self.deficit = Deficit.zero(ReferenceFrame.ET, d_max=self.d_max, source=self.name)
+
+    # ── Crop coefficient ────────────────────────────────────────────────────
+
+    def effective_kc(self, base_kc: float) -> float:
+        """Apply this zone's site exposure to a seasonal or overridden ``base_kc``.
+
+        The seasonal curve itself is intentionally *not* recomputed here: its
+        plant-family table has one home already, and copying it in would create
+        the second source of truth that anomaly E1 is about. The zone owns the
+        part that is genuinely its own — where it sits relative to sun and wind.
+        """
+        return round(base_kc * self.microclimate_factor, 4)
+
+    # ── Water balance ───────────────────────────────────────────────────────
+
+    def accumulate(self, *, dt_h: float, et_h: float, base_kc: float, rain_mm: float = 0.0) -> Deficit:
+        """Advance the deficit over ``dt_h`` hours and return it.
+
+        ``+ET*Kc*dt - rain``, clamped into ``[0, d_max]``. Rain is credited only
+        when :attr:`placement` is open to the sky: a patio or indoor zone never
+        saw that water, and crediting it would silently under-water them.
+        """
+        credited_rain = rain_mm if self.placement.receives_rain else 0.0
+        advanced = self.deficit.value_mm + et_h * self.effective_kc(base_kc) * dt_h - credited_rain
+        self.deficit = self.deficit.with_value(advanced).clamped()
+        return self.deficit
+
+    @property
+    def water_demand_l(self) -> float:
+        """Litres needed to clear the current deficit over this zone's area.
+
+        1 mm over 1 m² is 1 litre, divided by the system's application
+        efficiency — a drip line puts more of what it emits into the root zone
+        than a pop-up sprinkler does.
+        """
+        if self.efficiency <= 0:
+            return 0.0
+        return self.deficit.as_liters(self.area_m2) / self.efficiency
+
+    @property
+    def needs_water(self) -> bool:
+        """``True`` when the deficit has reached this zone's trigger threshold."""
+        return self.deficit.value_mm >= self.threshold_mm
+
+    def delivered_mm(self, liters: float) -> float:
+        """Convert delivered litres into millimetres over this zone's area."""
+        if self.area_m2 <= 0:
+            return 0.0
+        return liters * self.efficiency / self.area_m2
+
+    # ── The irrigation cycle ────────────────────────────────────────────────
+
+    def begin_cycle(self) -> None:
+        """Open a cycle, snapshotting the deficit it starts from."""
+        self._cycle_baseline_mm = self.deficit.value_mm
+
+    def credit_delivery(self, delivery: Delivery) -> Deficit:
+        """Credit delivered water against the deficit — *the* one formula.
+
+        Subtracts from the cycle snapshot when a cycle is open, and from the
+        current value otherwise. That distinction is what makes repeated credits
+        during a flow-metered run idempotent, and it is the point where the four
+        divergent copies in today's code are reconciled: the manual path used to
+        subtract from the live value even mid-cycle.
+        """
+        baseline = self._cycle_baseline_mm if self._cycle_baseline_mm is not None else self.deficit.value_mm
+        remaining = baseline - self.delivered_mm(delivery.liters_delivered)
+        self.deficit = self.deficit.with_value(remaining).clamped()
+        return self.deficit
+
+    def settle(self, delivery: Delivery, *, source: str, at: datetime) -> Deficit:
+        """Close a cycle: credit the final figure, stamp it, and drop the snapshot.
+
+        Takes the timestamp rather than reading the clock, so the module stays
+        pure and the behaviour stays testable.
+        """
+        self.credit_delivery(delivery)
+        self.counters.credit(delivery.liters_delivered, year=at.year)
+        self.last_irrigated = at
+        self.last_source = source
+        self.last_duration_s = round(delivery.elapsed_s)
+        self._cycle_baseline_mm = None
+        return self.deficit
+
+    def mark_irrigated(self, *, source: str, at: datetime) -> Deficit:
+        """Record watering that happened outside NeverDry's control.
+
+        The hose case: no delivery was measured, so the volume is inferred from
+        the deficit being cleared.
+        """
+        credited = self.water_demand_l
+        self.deficit = self.deficit.with_value(0.0).clamped()
+        self.counters.credit(credited, year=at.year)
+        self.last_irrigated = at
+        self.last_source = source
+        self._cycle_baseline_mm = None
+        return self.deficit

--- a/custom_components/never_dry/zone.py
+++ b/custom_components/never_dry/zone.py
@@ -8,7 +8,7 @@ behaviour listed in anomaly A1 — but until now no module. What exists instead 
 with the accounting living in ``IrrigationController``.
 
 Why that matters more than tidiness. Look at where the other two scaffolds point:
-``actuator.py`` returns a ``DeliveryResult`` — to *whom*? To the zone that settles
+``driver.py`` returns a ``DeliveryResult`` — to *whom*? To the zone that settles
 it. ``water_balance_model.py`` produces a ``Deficit`` — for *whom*? For the zone
 that owns it. Both seams face this class. They are inert not because wiring is
 hard but because the object they attach to had not been written.
@@ -33,8 +33,8 @@ after wiring.
 
 Design intent — this module is **pure**: no Home Assistant import, no I/O, only
 arithmetic and rules. It reads a delivery through the structural
-:class:`Delivery` protocol rather than importing ``actuator.DeliveryResult``,
-because ``actuator.py`` is HA-coupled and this module must not become so;
+:class:`Delivery` protocol rather than importing ``driver.DeliveryResult``,
+because ``driver.py`` is HA-coupled and this module must not become so;
 ``DeliveryResult`` satisfies the protocol without either module knowing about the
 other. That is also the first declared interface in the package, which anomaly C1
 notes is otherwise entirely absent.
@@ -111,8 +111,8 @@ class IrrigationMode(StrEnum):
 class Delivery(Protocol):
     """The structural shape :meth:`Zone.credit_delivery` needs from a delivery.
 
-    A protocol rather than an import: ``actuator.DeliveryResult`` satisfies it
-    without this pure module taking on ``actuator.py``'s Home Assistant
+    A protocol rather than an import: ``driver.DeliveryResult`` satisfies it
+    without this pure module taking on ``driver.py``'s Home Assistant
     dependency. Anything reporting how much water it actually delivered can
     settle a zone — including, later, a manual "I watered by hand" record.
     """

--- a/docs/assets/domain_model_uml.svg
+++ b/docs/assets/domain_model_uml.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="840" viewBox="0 0 1240 840" role="img" aria-label="UML class diagram of the NeverDry domain model">
+<style>
+  svg { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .box-body { fill: #ffffff; stroke: #c3ced1; stroke-width: 1.2; }
+  .box-head { fill: #eef2f1; }
+  .box-head.accent { fill: #dcebf3; }
+  .box-head.truth  { fill: #ddefe7; }
+  .cls-name { font-size: 13px; font-weight: 600; fill: #22292c; text-anchor: middle; }
+  .stereo { font-size: 10.5px; font-style: italic; fill: #5d6b70; text-anchor: middle; }
+  .member { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11.5px; fill: #22292c; }
+  .sep { stroke: #c3ced1; stroke-width: 1; }
+  .edge { stroke: #5d6b70; stroke-width: 1.4; fill: none; }
+  .edge.dashed { stroke-dasharray: 5 4; }
+  .edge.accent { stroke: #14719f; stroke-width: 2.1; }
+  .edge.truth { stroke: #257a5d; stroke-width: 1.5; }
+  .elabel { font-size: 11px; font-weight: 570; fill: #5d6b70; paint-order: stroke; stroke: #ffffff; stroke-width: 4px; stroke-linejoin: round; }
+  .elabel.accent { fill: #14719f; }
+  .elabel.truth { fill: #257a5d; }
+  .mult { font-family: ui-monospace, Menlo, monospace; font-size: 11px; font-weight: 600; fill: #5d6b70; paint-order: stroke; stroke: #ffffff; stroke-width: 4px; }
+  .mk-open { fill: none; stroke: #5d6b70; stroke-width: 1.4; }
+  .mk-open.accent { stroke: #14719f; stroke-width: 1.8; }
+  .mk-open.truth { stroke: #257a5d; }
+  .mk-hollow { fill: #ffffff; stroke: #5d6b70; stroke-width: 1.3; }
+</style>
+<defs>
+  <marker id="arrOpen" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="11" markerHeight="11" orient="auto-start-reverse"><path class="mk-open" d="M2,2 L10,6 L2,10"/></marker>
+  <marker id="arrOpenAccent" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto-start-reverse"><path class="mk-open accent" d="M2,2 L10,6 L2,10"/></marker>
+  <marker id="arrOpenTruth" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="11" markerHeight="11" orient="auto-start-reverse"><path class="mk-open truth" d="M2,2 L10,6 L2,10"/></marker>
+  <marker id="triHollow" viewBox="0 0 16 14" refX="15" refY="7" markerWidth="15" markerHeight="13" orient="auto-start-reverse"><path class="mk-hollow" d="M1,1 L15,7 L1,13 Z"/></marker>
+  <marker id="diamondHollow" viewBox="0 0 20 12" refX="19" refY="6" markerWidth="19" markerHeight="11" orient="auto-start-reverse"><path class="mk-hollow" d="M1,6 L10,1 L19,6 L10,11 Z"/></marker>
+</defs>
+<rect x="0" y="0" width="1240" height="840" fill="#ffffff"/>
+<path class="edge" d="M600.0,290 L600.0,191" marker-end="url(#diamondHollow)"/>
+<text class="elabel" x="610.0" y="225" text-anchor="start">owns model for</text>
+<text class="mult" x="608.0" y="207" text-anchor="start">1</text>
+<text class="mult" x="608.0" y="282" text-anchor="start">*</text>
+<path class="edge" d="M1000,560 L1000,540 Q1000,520 1020,520 L1160,520 Q1180,520 1180,500 L1180,120 Q1180,100 1160,100 L730,100" marker-end="url(#diamondHollow)"/>
+<text class="elabel" x="1172" y="300" text-anchor="end">declares</text>
+<text class="mult" x="738" y="92" text-anchor="start">1</text>
+<text class="mult" x="1150" y="512" text-anchor="end">0..1</text>
+<path class="edge" d="M360,370 L470,370" marker-end="url(#arrOpen)"/>
+<text class="elabel" x="415.0" y="360" text-anchor="middle">decides when · queues</text>
+<path class="edge accent" d="M520,498 L240,560" marker-end="url(#arrOpenAccent)"/>
+<text class="elabel accent" x="378" y="535" text-anchor="middle">requests liters</text>
+<path class="edge truth dashed" d="M360,590 L940,470" marker-end="url(#arrOpenTruth)"/>
+<text class="elabel truth" x="660" y="548" text-anchor="middle">returns</text>
+<path class="edge truth dashed" d="M730,390 L850,390" marker-end="url(#arrOpenTruth)"/>
+<text class="elabel truth" x="790.0" y="381" text-anchor="middle">settles deficit with</text>
+<path class="edge" d="M360,630 L460,630" marker-end="url(#triHollow)"/>
+<path class="edge" d="M860,615 L740,615" marker-end="url(#triHollow)"/>
+<path class="edge dashed" d="M960,654 L960,790 Q960,806 944,806 L226,806 Q210,806 210,790 L210,730" marker-end="url(#arrOpen)"/>
+<text class="elabel" x="600" y="798" text-anchor="middle">ON while any ZoneDriver is active</text>
+<rect class="box-body" x="470" y="40" width="260" height="151" rx="3"/>
+<path class="box-head" d="M470,70 v-27 a3,3 0 0 1 3,-3 h254 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="470" y="40" width="260" height="151" rx="3" fill="none"/>
+<text class="cls-name" x="600.0" y="60">System</text>
+<line class="sep" x1="470" y1="70" x2="730" y2="70"/>
+<text class="member" x="480" y="92" xml:space="preserve">+alpha : ET sensitivity</text>
+<text class="member" x="480" y="111" xml:space="preserve">+d_max : mm</text>
+<text class="member" x="480" y="130" xml:space="preserve">+temperature_sensor</text>
+<text class="member" x="480" y="149" xml:space="preserve">+rain_sensor</text>
+<line class="sep" x1="470" y1="162" x2="730" y2="162"/>
+<text class="member" x="480" y="184" xml:space="preserve">+compute_deficit() mm</text>
+<rect class="box-body" x="60" y="300" width="300" height="151" rx="3"/>
+<path class="box-head" d="M60,330 v-27 a3,3 0 0 1 3,-3 h294 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="60" y="300" width="300" height="151" rx="3" fill="none"/>
+<text class="cls-name" x="210.0" y="320">Scheduler</text>
+<line class="sep" x1="60" y1="330" x2="360" y2="330"/>
+<text class="member" x="70" y="352" xml:space="preserve">+time_windows</text>
+<text class="member" x="70" y="371" xml:space="preserve">+concurrency : serial | parallel</text>
+<text class="member" x="70" y="390" xml:space="preserve">+queue</text>
+<line class="sep" x1="60" y1="403" x2="360" y2="403"/>
+<text class="member" x="70" y="425" xml:space="preserve">+next_eligible() Zone</text>
+<text class="member" x="70" y="444" xml:space="preserve">+interleave_during_soak()</text>
+<rect class="box-body" x="470" y="290" width="260" height="208" rx="3"/>
+<path class="box-head" d="M470,320 v-27 a3,3 0 0 1 3,-3 h254 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="470" y="290" width="260" height="208" rx="3" fill="none"/>
+<text class="cls-name" x="600.0" y="310">Zone</text>
+<line class="sep" x1="470" y1="320" x2="730" y2="320"/>
+<text class="member" x="480" y="342" xml:space="preserve">+kc_or_plant_family</text>
+<text class="member" x="480" y="361" xml:space="preserve">+area_m2</text>
+<text class="member" x="480" y="380" xml:space="preserve">+sun_exposure</text>
+<text class="member" x="480" y="399" xml:space="preserve">+threshold_mm</text>
+<text class="member" x="480" y="418" xml:space="preserve">+cycle_soak_rule</text>
+<text class="member" x="480" y="437" xml:space="preserve">+deficit_mm</text>
+<line class="sep" x1="470" y1="450" x2="730" y2="450"/>
+<text class="member" x="480" y="472" xml:space="preserve">+water_demand() liters</text>
+<text class="member" x="480" y="491" xml:space="preserve">+settle(r : DeliveryResult)</text>
+<rect class="box-body" x="850" y="300" width="270" height="170" rx="3"/>
+<path class="box-head truth" d="M850,330 v-27 a3,3 0 0 1 3,-3 h264 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="850" y="300" width="270" height="170" rx="3" fill="none"/>
+<text class="cls-name" x="985.0" y="320">DeliveryResult</text>
+<line class="sep" x1="850" y1="330" x2="1120" y2="330"/>
+<text class="member" x="860" y="352" xml:space="preserve">+liters_delivered</text>
+<text class="member" x="860" y="371" xml:space="preserve">+quality : measured | estimated |</text>
+<text class="member" x="860" y="390" xml:space="preserve">          partial | delayed |</text>
+<text class="member" x="860" y="409" xml:space="preserve">          low_confidence</text>
+<text class="member" x="860" y="428" xml:space="preserve">+elapsed_s</text>
+<line class="sep" x1="850" y1="441" x2="1120" y2="441"/>
+<text class="member" x="860" y="463" xml:space="preserve">+revise(measured_liters)</text>
+<rect class="box-body" x="60" y="560" width="300" height="170" rx="3"/>
+<path class="box-head accent" d="M60,590 v-27 a3,3 0 0 1 3,-3 h294 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="60" y="560" width="300" height="170" rx="3" fill="none"/>
+<text class="cls-name" x="210.0" y="580">ZoneDriver</text>
+<line class="sep" x1="60" y1="590" x2="360" y2="590"/>
+<text class="member" x="70" y="612" xml:space="preserve">+delivery_mode : native_volume</text>
+<text class="member" x="70" y="631" xml:space="preserve">                | time × flow</text>
+<text class="member" x="70" y="650" xml:space="preserve">+flow_rate_lpm</text>
+<text class="member" x="70" y="669" xml:space="preserve">+flow_telemetry : optional</text>
+<text class="member" x="70" y="688" xml:space="preserve">+zero_flow_guard</text>
+<line class="sep" x1="60" y1="701" x2="360" y2="701"/>
+<text class="member" x="70" y="723" xml:space="preserve">+deliver(liters) DeliveryResult</text>
+<rect class="box-body" x="460" y="560" width="280" height="223" rx="3"/>
+<path class="box-head accent" d="M460,605 v-42 a3,3 0 0 1 3,-3 h274 a3,3 0 0 1 3,3 v42 z"/>
+<rect class="box-body" x="460" y="560" width="280" height="223" rx="3" fill="none"/>
+<text class="stereo" x="600.0" y="574">«abstract»</text>
+<text class="cls-name" x="600.0" y="595">Driver</text>
+<line class="sep" x1="460" y1="605" x2="740" y2="605"/>
+<text class="member" x="470" y="627" xml:space="preserve">+entity_adapter : valve.*|switch.*</text>
+<text class="member" x="470" y="646" xml:space="preserve">+adaptive_timeout</text>
+<text class="member" x="470" y="665" xml:space="preserve">+safety_layers : watchdog,</text>
+<text class="member" x="470" y="684" xml:space="preserve">   close on error/stop/restart</text>
+<text class="member" x="470" y="703" xml:space="preserve">+ping_interval_min</text>
+<line class="sep" x1="460" y1="716" x2="740" y2="716"/>
+<text class="member" x="470" y="738" xml:space="preserve">+turn_on() confirmed</text>
+<text class="member" x="470" y="757" xml:space="preserve">+turn_off() confirmed</text>
+<text class="member" x="470" y="776" xml:space="preserve">+ping() alive | unreachable</text>
+<rect class="box-body" x="860" y="560" width="280" height="94" rx="3"/>
+<path class="box-head accent" d="M860,590 v-27 a3,3 0 0 1 3,-3 h274 a3,3 0 0 1 3,3 v27 z"/>
+<rect class="box-body" x="860" y="560" width="280" height="94" rx="3" fill="none"/>
+<text class="cls-name" x="1000.0" y="580">MasterDriver</text>
+<line class="sep" x1="860" y1="590" x2="1140" y2="590"/>
+<text class="member" x="870" y="612" xml:space="preserve">+off_delay_s</text>
+<line class="sep" x1="860" y1="625" x2="1140" y2="625"/>
+<text class="member" x="870" y="647" xml:space="preserve">+follow(any_zone_driver_active)</text>
+</svg>

--- a/docs/design_domain_model_anomalies.md
+++ b/docs/design_domain_model_anomalies.md
@@ -1,0 +1,218 @@
+# Design — Domain Model Anomalies (code-verified companion)
+
+**Status:** Draft
+**Date:** 2026-07-24
+**Related:** [Domain Object Model](design_domain_object_model.md) (the target model this audits against), [Water-Balance Reference Model](design_water_balance_reference_model.md), GH #74, GH #95
+
+## Purpose
+
+This is the **audit companion** to the [Domain Object Model](design_domain_object_model.md).
+That document defines the *target* objects — System, Zone, Scheduler, Driver / ZoneDriver /
+MasterDriver, DeliveryResult — and where each responsibility belongs. This document is the
+other half of the loop: a code-verified register of the **anomalies** where the current
+implementation diverges from that model.
+
+The two documents are meant to be used together:
+
+- The **Domain Object Model** is the *yardstick* — it says who should own what.
+- This **Anomalies register** is the *measurement* — it says where the code violates that
+  ownership, with file:line evidence, and points each fix back at the responsible object.
+
+Every anomaly below names the domain object that *should* own the misplaced behaviour, so the
+correction is not "refactor for cleanliness" but "move responsibility X back to object Y as
+the model already prescribes."
+
+Verified against the code at `custom_components/never_dry/` on 2026-07-24. All line numbers
+refer to that snapshot.
+
+## Health map (as-is vs. target model)
+
+| Target object | Current carrier | Health | Root anomaly |
+|---|---|---|---|
+| **System** (feeds, not state) | `ETSensor`, `DrynessIndexSensor` | ⚠️ | Still holds a `_deficit` accumulator + duplicated FAO-56 recurrence (§E1) |
+| **Zone** (owns deficit, `settle(DeliveryResult)`) | `IrrigationZoneSensor` | 🔴 | Anemic: its accounting behaviour lives in the controller (§A1) |
+| **Scheduler** | implicit in `IrrigationController` | 🟡 | Out of scope here (deliberately deferred, GH #74) |
+| **Driver** `<<abstract>>` | — | 🔴 | Never declared; no `ABC`/`Protocol` anywhere (§C1) |
+| **ZoneDriver** (uniform seam, `deliver(liters)`) | `ValveOperator` | 🟠 | Not uniform: `volume_preset` bypasses it (§A2); mode = string dispatch (§D1) |
+| **MasterDriver** | — | ❌ | Not implemented (tracked in the Domain Object Model, out of scope here) |
+| **DeliveryResult** | bare `float` | 🟠 | No quality qualifier; deficit-crediting formula duplicated ×4 (§A1) |
+
+The reference-quality pair in the codebase is `ValveFsm` (pure, event-driven, emits `FsmAction`
+*data*) + `ValveOperator` (host that executes them). It is exactly the decoupling the target
+model prescribes for `Driver`. **It is the template for fixing everything below.**
+
+---
+
+## A. Decoupling anomalies
+
+### A1 — 🔴 Zone accounting lives in the Controller (anemic domain model)
+**Target owner:** `Zone` (`accumulate`, `water_demand()`, `settle(DeliveryResult)`).
+**As-is:** `IrrigationController` reads *and writes* 13 private attributes of the zone plus
+`zs._dryness`:
+
+```
+zone._zone_deficit  _efficiency  _area  _flow_rate  _deficit_at_irrigation_start
+_last_irrigated  _last_irrigation_source  _last_session_duration_s
+_last_volume_delivered  _session_water_delivered  _total_water_delivered
+_yearly_water_delivered  _threshold
+```
+
+The deficit-crediting formula `max(0, deficit_at_start − delivered·efficiency/area)` is
+**duplicated in 4 sites**: `_settle_irrigated_zones` (controller.py:694),
+`_update_deficit_realtime` (:1144), `_finalize_manual_session` (:1412), and
+`reset_deficit(delivered_liters=…)` (sensor.py:1227).
+
+**Gap vs. model:** the model says the Zone owns its deficit and settles it from a
+`DeliveryResult`. Today the Zone is a data-bag and the controller is its accounting engine.
+**Direction:** move behaviour into the Zone — `zone.begin_cycle()`, `zone.credit_delivery(result)`,
+`zone.settle(result)` — collapsing the 4 copies into one. Closing this also mechanically
+closes C1 and half of E1.
+
+### A2 — 🟠 `volume_preset` leaks the ZoneDriver abstraction
+**Target owner:** `ZoneDriver` (uniform seam; `deliver(liters)` for *every* mode).
+**As-is:** `estimated_flow` and `flow_meter` route through `operator.open()/close()`
+(controller.py:1196/1222), but `volume_preset` bypasses the operator entirely
+(controller.py:824–913) and re-implements its own precheck (:852–862), duplicating
+`ValveOperator._precheck` (valve_operator.py:301). The operator is deliberately *not created*
+for these zones (sensor.py:414–416).
+
+**Gap vs. model:** the safety layers the model puts in the `Driver` base (watchdog, adaptive
+timeout, latency, FSM, notifier dedup) silently do **not** apply to `volume_preset` zones.
+**Direction:** make `volume_preset` a `ZoneDriver` delivery strategy behind the same seam, so
+smart-valve self-close is a *strategy detail*, not a bypass of the whole abstraction.
+
+---
+
+## B. Injection present but unused
+
+### B1 — 🔴 `notifier` injected, used for 1 of 12 notification kinds
+**Target owner:** the notification bus (`ValveNotifier`) — single seam for user-facing conditions.
+**As-is:** `IrrigationController.__init__` receives `notifier` (controller.py:68) but calls it
+only for `UNREACHABLE_AT_IRRIGATION`. Three sites bypass it with raw
+`hass.services.async_call("persistent_notification", "create", …)`:
+
+| Site | Line | Template already in the notifier |
+|---|---|---|
+| `_on_battery_change` | controller.py:1636 | **`BATTERY_LOW`** exists (valve_notifier.py:113) |
+| `_check_deficit_anomaly` | controller.py:1674 | — (mappable to a new/`WATER_ME_NOW` kind) |
+| `_check_and_notify` (monitoring) | controller.py:1725 | **`WATER_ME_NOW`** exists (valve_notifier.py:125) |
+
+Evidence of the cost: `_on_battery_change` hand-rolls a `_battery_alerted` set
+(controller.py:117, 1632) to emulate the dedup `ValveNotifier.is_active()` already provides.
+
+**Cross-check:** only **5 of 12** `NotificationKind` values are emitted in production
+(`COMMAND_FAILED`, `STUCK_OPEN`, `WATCHDOG_TRIGGERED`, `ZONE_DISABLED`,
+`UNREACHABLE_AT_IRRIGATION`). The other 7 — `BATTERY_LOW`, `WATER_ME_NOW`, `LEAK_DETECTED`,
+`FLOW_METER_DEAD`, `IRRIGATION_INEFFECTIVE`, `MODEL_DRIFT`, `UNREACHABLE_PASSIVE` — have full
+templates but **no emitter**. `BATTERY_LOW` and `WATER_ME_NOW` are dead *precisely because*
+their natural emitters use the raw path.
+
+**Direction:** route the 3 raw sites through the injected notifier; drop the ad-hoc dedup set.
+Isolated, low-risk, unlocks already-written templates — the recommended first fix.
+
+---
+
+## C. Undeclared interfaces
+
+### C1 — 🟠 No `Protocol`/`ABC` in the whole package
+**Target owner:** `Driver <<abstract>>` in the model; and the implicit contracts Zone/System.
+**As-is:** zero abstract types. The controller's key collaborators are untyped:
+`dryness_sensor` (untyped), `zone_sensors: list` (untyped), `zone` parameters as bare names.
+Two large interfaces exist only implicitly:
+
+- **`ZoneProtocol`** (~25 members: `zone_name, valve, volume_liters, duration_s,
+  delivery_mode, delivery_timeout, flow_meter_sensor, volume_entity, battery_sensor,
+  irrigation_mode, irrigation_time, set_irrigating, reset_deficit, set_deficit_mm,
+  notify_session_listeners, extra_state_attributes, async_write_ha_state` + the 13 private
+  attributes from A1).
+- **`DrynessProtocol`** (`deficit, reset, set_deficit_mm, register_zone_listener,
+  async_write_ha_state`).
+
+**Gap vs. model:** the model draws `Driver` as `<<abstract>>` and expects declared seams; the
+code has none. **Direction:** declare `ZoneProtocol` / `DrynessProtocol` (and the abstract
+`Driver` when MasterDriver lands). A `Protocol` **cannot include `_private` members**, so
+declaring `ZoneProtocol` forces the public accessors that fix A1.
+
+*(Note: `ValveOperator._execute_action`'s 7-way `isinstance(action, …)` dispatch
+(valve_operator.py:377–390) is an undeclared "action visitor" — acceptable, it is the price of
+keeping the FSM pure. Listed for completeness, not for correction.)*
+
+---
+
+## D. Missing polymorphism
+
+### D1 — 🟠 Delivery mode = string dispatch
+**Target owner:** `ZoneDriver` delivery strategy (`native_volume` vs `time_x_flow`).
+**As-is:** `_deliver_water` (controller.py:735) branches `if mode == DELIVERY_MODE_*` over
+three constants into three methods. Worse, the rate-vs-cumulative logic of the *commanded*
+path is reimplemented in the *manual* path (`_external_session_monitor` →
+`_monitor_via_flow_meter`, controller.py:1529).
+**Direction:** a `DeliveryStrategy` (`EstimatedFlowDelivery` / `FlowMeterDelivery` /
+`VolumePresetDelivery`) shared by commanded and manual paths — this is the model's `ZoneDriver`
++ `DeliveryResult` made concrete.
+
+### D2 — 🟡 Flow-sensor type = `if is_rate` repeated ×4
+**As-is:** the rate/cumulative branch appears in `_deliver_flow_meter`, `_deliver_flow_rate`,
+`_monitor_via_flow_meter`, `_finalize_manual_session`.
+**Direction:** a polymorphic `FlowReader` (`RateReader` / `CumulativeReader`) collapses the
+four copies and the `_read_flow_meter` / `_read_volume_liters` / `_rate_to_lpm` wrappers.
+
+---
+
+## E. Usable inheritance / composition
+
+### E1 — 🟠 System and Zone duplicate the FAO-56 recurrence
+**Target owner:** a shared `WaterBalanceModel` / deficit account; the model already says
+"deficit lives in the Zone, System holds feeds not state."
+**As-is:** `DrynessIndexSensor` and `IrrigationZoneSensor` both implement the identical
+recurrence and deficit API:
+
+```python
+deficit = max(0, min(deficit + et*kc*dt − rain, d_max))   # sensor.py:705/810 and 1125
+# + reset(), set_deficit_mm() clamped to d_max, deficit property
+```
+
+**Gap vs. model:** the Water-Balance Reference Model is retiring `DrynessIndexSensor._deficit`
+as ET state (kept only for interim VWC), so this duplication is a *known transitional* gap.
+**Direction:** extract a `WaterBalanceModel` value object, held by composition (preferred) or a
+mixin — consistent with house style (`_ZoneTextSensor` already bases ~13 subclasses).
+
+### E2 — 🟢 Numeric zone projections without a shared base
+**As-is:** `ZoneDeficitSensor`, `ZoneRainSensor`, `ZoneSessionWaterSensor`,
+`ZoneYearlyWaterSensor`, `ZoneDurationSensor` inherit `SensorEntity` directly while the text
+projections share `_ZoneTextSensor`. Low impact. **Direction:** an analogous
+`_ZoneNumericSensor` base.
+
+---
+
+## Priority register
+
+| # | Anomaly | Target object | Severity | First-cut effort |
+|---|---|---|---|---|
+| B1 | Notifier injected, used 1/12; 3 raw sites; 7 dead kinds | ValveNotifier | 🔴 | S |
+| A1 | Controller writes 13 zone privates; deficit formula ×4 | Zone | 🔴 | L |
+| C1 | No Protocol; zone/dryness contract implicit | Driver / Zone / System | 🟠 | M |
+| A2 | `volume_preset` bypasses the operator + duplicate precheck | ZoneDriver | 🟠 | M |
+| D1 | Delivery mode = if/elif; command vs manual duplicated | ZoneDriver + DeliveryResult | 🟠 | L |
+| E1 | FAO-56 duplicated across System and Zone | WaterBalanceModel | 🟠 | M |
+| D2 | `if is_rate` ×4 | FlowReader | 🟡 | S |
+| E2 | Numeric zone projections without a base | (projection base) | 🟢 | XS |
+
+**Common root:** A1, C1 and E1 are the same fault seen from three angles — the domain
+(deficit, water, balance) has no home of its own and is smeared across the controller.
+A first-class `Zone` / `WaterBalance` with a declared interface resolves all three together.
+The blueprint for doing it is already in-tree: `ValveFsm` / `ValveOperator`.
+
+## How to use this with the Domain Object Model
+
+1. Pick an anomaly; open the **target object** in the Domain Object Model to confirm which
+   responsibility it should own.
+2. Verify the anomaly still holds against current code (line numbers above).
+3. Correct by moving the responsibility to the target object — not by local cleanup.
+4. When an anomaly is closed, update its row here and, if it changes the code mapping, the
+   "Mapping to current code" table in the Domain Object Model.
+
+The recommended sequence is **B1 → C1 → A1 → (A2, D1, E1)**: B1 is isolated and unlocks dead
+infrastructure; C1 declares the seams that make A1 safe; A1 then re-homes the deficit, after
+which the driver/strategy anomalies (A2, D1) and the model duplication (E1) refactor against a
+stable Zone contract.

--- a/docs/design_domain_model_anomalies.md
+++ b/docs/design_domain_model_anomalies.md
@@ -68,6 +68,24 @@ The deficit-crediting formula `max(0, deficit_at_start − delivered·efficiency
 `zone.settle(result)` — collapsing the 4 copies into one. Closing this also mechanically
 closes C1 and half of E1.
 
+**Why this is the keystone, not just the largest entry (2026-08-09).** The `Zone` is **designed and
+not yet written**: it has a row in the five-object table, a box in the class diagram with its
+attributes and methods, and an owner recorded for every behaviour listed above — but no module. A
+search across every ref finds only `IrrigationZoneSensor` and eighteen `Zone*Sensor` numeric
+projections of it. Now look at where the two existing scaffolds point: `actuator.py` returns a
+`DeliveryResult` — to *whom*? To the Zone that settles it. `water_balance_model.py` produces a
+`Deficit` — for *whom*? For the Zone that owns it. Both seams face a class that has been specified
+but never typed out.
+
+So the scaffolds are not inert because wiring them is hard; they are inert because the object they
+attach to has not been written yet. That reframes A1: it is not an anomaly to clean up eventually,
+it is the unwritten half of the object model, and it gates the wiring of everything else. It is also why the
+duplicated crediting formula matters beyond tidiness — wire a `WaterBalanceModel` in while the
+controller still writes `zone._zone_deficit` from four sites and you get **two writers on the same
+truth**, with the model authoritative on paper and the controller authoritative in fact. That failure
+has already happened once: it is the shape of the VWC overwrite defect (probe reading overwrites the
+zone deficit after irrigation), reproduced one layer up.
+
 ### A2 — 🟠 `volume_preset` leaks the ZoneDriver abstraction
 **Target owner:** `ZoneDriver` (uniform seam; `deliver(liters)` for *every* mode).
 **As-is:** `estimated_flow` and `flow_meter` route through `operator.open()/close()`

--- a/docs/design_domain_model_anomalies.md
+++ b/docs/design_domain_model_anomalies.md
@@ -72,7 +72,7 @@ closes C1 and half of E1.
 not yet written**: it has a row in the five-object table, a box in the class diagram with its
 attributes and methods, and an owner recorded for every behaviour listed above — but no module. A
 search across every ref finds only `IrrigationZoneSensor` and eighteen `Zone*Sensor` numeric
-projections of it. Now look at where the two existing scaffolds point: `actuator.py` returns a
+projections of it. Now look at where the two existing scaffolds point: `driver.py` returns a
 `DeliveryResult` — to *whom*? To the Zone that settles it. `water_balance_model.py` produces a
 `Deficit` — for *whom*? For the Zone that owns it. Both seams face a class that has been specified
 but never typed out.

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -39,10 +39,17 @@ Driver side, and modeling it explicitly buys the same thing the Driver did:
 | ↳ `ETModel`, `VWCSystemModel`, `VWCPerZoneModel` | ↳ `ZoneDriver`, `MasterDriver` |
 | **Deficit** (mm + reference frame) — the value returned | **DeliveryResult** (liters + quality) — the value returned |
 
-- **WaterBalanceModel** — a strategy that produces a `Deficit`. Its three concretes mirror the
+- **WaterBalanceModel** — a strategy that produces a `Deficit`. Its concretes mirror the
   reference frames of the [Water-Balance Reference Model](design_water_balance_reference_model.md):
-  `ETModel` (temperature + rain, stateful forward-Euler integration), `VWCSystemModel` (one
-  system moisture probe, stateless), `VWCPerZoneModel` (a per-zone probe — the AI-174 target).
+  the ET frame is an abstract `ETBalanceModel` (shared forward-Euler integration, pluggable ET
+  rate) with three **tiers** by input cost — `ETModel` (temperature-only, today's baseline; any
+  user can run it), `HargreavesModel` (FAO-56 Hargreaves-Samani; adds the diurnal temperature
+  range, its radiation term is computed from latitude + date, so still **no extra sensor**), and
+  `PenmanMonteithModel` (FAO-56 Penman-Monteith, physically grounded, needs humidity + wind + net
+  radiation — inputs not every user has); plus `VWCSystemModel` (one system moisture probe,
+  stateless) and `VWCPerZoneModel` (a per-zone probe — the AI-174 target). Adding a tier is one
+  new `et_rate`, not a new integrator: the "user picks the ET method their sensors support"
+  design falls straight out of the output seam.
 - **Deficit** — the value object every model returns: millimetres **plus the reference frame**
   they are defined against. A bare number is not enough — the reference model's load-bearing rule
   is that *two deficits are comparable only within one frame*, so the frame (and, for per-zone
@@ -158,10 +165,26 @@ classDiagram
         +reset() Deficit
     }
 
+    class ETBalanceModel {
+        <<abstract>>
+        +kc
+        +et_rate(inputs) mm/h
+        +step(inputs) Deficit
+    }
+
     class ETModel {
-        +alpha, t_base, kc
+        +alpha, t_base
         +et_hourly(temp_c) mm/h
-        +step(ETStep) Deficit
+    }
+
+    class HargreavesModel {
+        +latitude_deg
+        +et0_daily(Tmax, Tmin, doy) mm/day
+    }
+
+    class PenmanMonteithModel {
+        +pressure_kpa
+        +et0_daily(T, rh, wind, Rn) mm/day
     }
 
     class VWCSystemModel {
@@ -183,7 +206,10 @@ classDiagram
 
     Driver <|-- ZoneDriver
     Driver <|-- MasterDriver
-    WaterBalanceModel <|-- ETModel
+    WaterBalanceModel <|-- ETBalanceModel
+    ETBalanceModel <|-- ETModel
+    ETBalanceModel <|-- HargreavesModel
+    ETBalanceModel <|-- PenmanMonteithModel
     WaterBalanceModel <|-- VWCSystemModel
     VWCSystemModel <|-- VWCPerZoneModel
     System "1" o-- "*" Zone : feeds ET+rain to

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -148,9 +148,15 @@ classDiagram
         +follow(any_zone_driver_active)
     }
 
+    class ManualActuator {
+        +role : manual
+        +request_irrigation(liters) DeliveryResult
+        +mark_irrigated(liters?) DeliveryResult
+    }
+
     class DeliveryResult {
         +liters_delivered
-        +quality : measured, estimated, partial, delayed, low_confidence
+        +quality : measured, estimated, partial, delayed, low_confidence, declared
         +elapsed_s
         +revise(measured_liters)
     }
@@ -219,10 +225,17 @@ classDiagram
     Zone ..> Deficit : holds, settles
     Zone "1" --> "1" ZoneDriver : requests liters
     ZoneDriver ..> DeliveryResult : returns
+    Zone ..> ManualActuator : requests (manual how)
+    ManualActuator ..> DeliveryResult : returns (declared)
     Zone ..> DeliveryResult : settles deficit with
     Scheduler --> Zone : decides when, queues
     MasterDriver ..> ZoneDriver : ON while any is active
 ```
+
+`ManualActuator` is a third materialization of the *how* — but deliberately **not** a
+`Driver`: there is no entity, no FSM, no safety layers to inherit. It shares only the delivery
+**contract** (`→ DeliveryResult`), so the Zone settles its deficit identically whether the
+water came from a valve or a watering can.
 
 Reading keys: liters flow down the association `Zone → ZoneDriver` and truth flows back up as
 a `DeliveryResult`; the `Scheduler` never touches drivers — it only decides *which zone when*
@@ -296,6 +309,38 @@ result) is **replenished within the same session**, instead of surfacing a day l
 residual deficit. This is a direct synergy between the DeliveryResult contract and the
 cycle & soak rule — it requires truthful per-cycle accounting to work.
 
+### Manual actuation: a valve-less *how* for hand-watered plants
+
+*Idea 2026-07-26.* Not every plant has a valve. A **house plant** is watered by hand, so its
+"actuation" is a person: NeverDry raises an **alert** when the deficit says water is due, and
+the user presses **Mark irrigated** once they have watered. `ManualActuator` models this as a
+third materialization of the *how* — a materialization that proves the abstraction, because it
+has **no hardware at all**.
+
+It deliberately does not extend `Driver`/`Actuator`: there is no entity, no FSM, no watchdog,
+no liveness. It shares only the delivery **contract** (`→ DeliveryResult`), so the Zone settles
+its deficit identically whether the water came from a valve or a watering can. Two existing
+pieces are reused rather than reinvented: the alert is a **notification**, and **Mark
+irrigated** is the existing `reset_deficit` action, here doubling as the delivery confirmation.
+The human-paced, asynchronous nature is already covered by the DeliveryResult contract:
+`request_irrigation()` returns a `delayed` pending result and `mark_irrigated()` the final one,
+tagged with a new **`declared`** quality (assumed/declared by a human, not measured) — a person
+is simply the extreme case of "a backend that measures late".
+
+**Actuation and model are orthogonal.** A house plant picks the manual *how* **and** the right
+*how much*: indoors the demand is not weather-driven, so it pairs with a VWC / indoor
+water-balance model, **not** `ETModel`. The two axes (`Actuator` family × `WaterBalanceModel`
+family) compose freely — a house plant is just one corner of that grid.
+
+**To explore (open questions, not decided):**
+- A **placement attribute** on the Zone — `indoor` / `outdoor` / `greenhouse` — that could
+  select sensible defaults (which water-balance model, exposure, whether ET applies at all).
+- A **pot-based characterization** for house-plant zones: today a zone's water is `area × root
+  depth`; a potted plant is bounded instead by **pot volume**, and its evapotranspiring surface
+  is better described by **plant height / canopy diameter** than by ground area. This likely
+  wants its own "pot" water model (a sibling of the VWC/ET models) rather than stretching the
+  open-field geometry.
+
 ### Serial vs parallel irrigation: a Scheduler policy
 
 *From the GH #74 review (fpytloun, 2026-07-06) and the shared-resource discussion earlier in
@@ -339,7 +384,8 @@ about a dead valve *before* the next scheduled run, not from a failed one.
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
 | ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired |
 | MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `actuator.py` (`MasterActuator`) |
-| WaterBalanceModel | ⚠️ implicit today: the ET/VWC fork inside `DrynessIndexSensor._on_sensor_change` + the per-zone loop, with the ET formula duplicated in `ETSensor`. **Scaffold extracted**: `water_balance_model.py` (`WaterBalanceModel` + `ETModel`/`VWCSystemModel`/`VWCPerZoneModel`), pure, inert until wired |
+| ManualActuator | ❌ not implemented; **scaffold extracted**: `ManualActuator` in `actuator.py` (valve-less, `request_irrigation`/`mark_irrigated` → `DeliveryResult(declared)`), inert. For hand-watered house plants — a *how* with no hardware |
+| WaterBalanceModel | ⚠️ implicit today: the ET/VWC fork inside `DrynessIndexSensor._on_sensor_change` + the per-zone loop, with the ET formula duplicated in `ETSensor`. **Scaffold extracted**: `water_balance_model.py` (`WaterBalanceModel` + `ETBalanceModel` tiers `ETModel`/`HargreavesModel`/`PenmanMonteithModel` + `VWCSystemModel`/`VWCPerZoneModel`), pure, inert until wired |
 | Deficit | ❌ today a bare `float` (`_zone_deficit`, `DrynessIndexSensor._deficit`) with the frame left implicit. **Scaffold extracted**: `Deficit` value object in `water_balance_model.py` |
 
 The refactoring direction is symmetric on both axes: make the **Driver** base explicit when

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -127,6 +127,110 @@ a `DeliveryResult`; the `Scheduler` never touches drivers — it only decides *w
 `MasterDriver` reacts to the aggregate driver activity, it takes no decisions. The liveness
 `ping()` lives in the abstract `Driver`, so both specializations inherit it.
 
+## The classes in detail
+
+Attribute-by-attribute and method-by-method reference for each class, with the
+responsibility that justifies every member. This expands the diagram above; the
+diagram stays the source of truth for relationships.
+
+### System
+
+The global model and shared infrastructure. *Declares* the master valve/pump but never
+commands it.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `alpha` | attr | ET sensitivity of the model (mm/°C/day) |
+| `d_max` | attr | Cap on the accumulable deficit (mm) |
+| `temperature_sensor` | attr | Shared temperature sensor |
+| `rain_sensor` | attr | Shared rain sensor (event or cumulative type) |
+| `compute_deficit() → mm` | method | FAO-56 water balance: reference deficit at Kc = 1 |
+
+### Zone
+
+The irrigation unit: translates the model into water demand and settles the deficit with
+the driver's reported truth.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `kc_or_plant_family` | attr | Crop coefficient (or the plant family that determines it) |
+| `area_m2` | attr | Irrigated surface |
+| `sun_exposure` | attr | Per-zone sun exposure factor |
+| `threshold_mm` | attr | Deficit threshold that triggers irrigation |
+| `cycle_soak_rule` | attr | Cycle & soak rule (dose/pause) — a Zone rule, not a scheduler one |
+| `deficit_mm` | attr | Current zone deficit |
+| `water_demand() → liters` | method | mm → liters via area and efficiency; liters are the contract towards the driver |
+| `settle(r: DeliveryResult)` | method | Scales the deficit by the actually-delivered liters — exactly once |
+
+### Scheduler
+
+The *when* and the concurrency policy. It never touches drivers: it only decides which
+zone runs in which window.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `time_windows` | attr | Time windows and calendars |
+| `concurrency` | attr | Serial or parallel zone runs |
+| `queue` | attr | Queue of eligible zones |
+| `next_eligible() → Zone` | method | Next zone to serve, per queue and windows |
+| `interleave_during_soak()` | method | During a soak pause it may interleave another eligible zone |
+
+### Driver «abstract»
+
+The common base of the two specializations: everything about commanding a physical entity
+and not blindly trusting the answer.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `entity_adapter` | attr | Adapter over the HA entity (`valve.*` or `switch.*`) |
+| `adaptive_timeout` | attr | Verification window adapted to observed latency (rolling mean + 3σ) |
+| `safety_layers` | attr | Watchdog; close on error/stop/restart |
+| `ping_interval_min` | attr | Active liveness: periodic ping, not just passive state |
+| `turn_on() / turn_off()` | method | Command with state confirmation (and bounded retry with backoff) |
+| `ping() → alive \| unreachable` | method | Reachability check independent of commands |
+
+### ZoneDriver
+
+The *how* for a single zone: receives liters, picks the actuation strategy, returns the
+truth.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `delivery_mode` | attr | `native_volume` when the device doses in liters, otherwise `time × flow` (seconds via flow rate) |
+| `flow_rate_lpm` | attr | Nominal guard flow rate (L/min) |
+| `flow_telemetry` | attr | Flow telemetry, when available (optional) |
+| `zero_flow_guard` | attr | Guard against zero-flow sessions |
+| `deliver(liters) → DeliveryResult` | method | Actuates the request and reports delivered liters with their degree of truth |
+
+### MasterDriver
+
+Coordinates the shared hydraulics (pump / master valve). Reacts to aggregate driver
+activity, takes no decisions, has no notion of liters.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `off_delay_s` | attr | Linger delay after the last active zone |
+| `follow(any_zone_driver_active)` | method | ON while any ZoneDriver is active, OFF (after the linger) when none is |
+
+### DeliveryResult
+
+The return trip of the truth: the driver does not just execute — it states how much it
+delivered and how much that figure can be trusted.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `liters_delivered` | attr | Liters actually delivered, as far as the backend allows to know |
+| `quality` | attr | `measured` · `estimated` · `partial` · `delayed` · `low_confidence` |
+| `elapsed_s` | attr | Real session duration |
+| `revise(measured_liters)` | method | Late revision for slow-reporting backends (e.g. Hydrawise): the true measure arrives later and corrects the estimate |
+
+**Proposed addition (backlog AI-163, not yet part of the model):** a `device_reported`
+quality level between `measured` and `estimated`, fed by the device's own end-of-session
+report (duration + start/end volume — e.g. Sonoff SWV via Z2M). Some valves cannot stream
+flow in real time but do report a trustworthy session total: more truthful than a
+`flow_rate × time` estimate, less than live metering. It belongs to the driver as a
+capability and will land with the driver abstraction.
+
 ## Design decisions
 
 ### Master valve/pump: declared in System, executed by a Driver

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -229,6 +229,31 @@ machinery rather than inventing a new one: a failed probe drives the FSM `unreac
 and the `UNREACHABLE_PASSIVE` / `UNREACHABLE_AT_IRRIGATION` notifications, so the user learns
 about a dead valve *before* the next scheduled run, not from a failed one.
 
+### Naming candidate: `System` is really `Weather` / `Environment` (proposal)
+
+**Status: Proposed (note, not yet decided).** The object today called **System** does one thing:
+it owns the shared **environmental feeds** (temperature + rain → `et_h`, `rain_delta`) and
+broadcasts them to the zones. "System" is a catch-all name that describes *where it sits*, not
+*what it does*. A name that matches its responsibility — **`Weather`** or **`Environment`** — would
+sharpen the ubiquitous language: the zones consume an environment, not "the system". (Caveat: it
+also *declares* the master valve/pump — a non-environmental concern; if the rename is adopted, that
+declaration may want to move, or stay as a documented exception.)
+
+**Extension enabled by the rename** — if the object is explicitly the environment/weather source, two
+forecast-driven properties become natural, both **configurable from the config flow** as properties of
+this entity:
+- **`rain_probability`** — actual rain probability (from the weather forecast), exposed as a feed
+  alongside temperature and rain.
+- **`rain_delay_above_threshold`** — if `rain_probability` is above a configurable threshold, delay
+  irrigation by a configurable amount. This is a *decision input* the environment provides; the
+  Scheduler/Zone consumes it (keeps the "environment supplies feeds, zone/scheduler decides" split
+  intact — the environment does not itself skip watering, it just raises the probability signal).
+
+Open questions before promoting to a decision: does the delay live as an Environment property or a
+Scheduler policy (cf. cycle&soak = Zone rule, serial/parallel = Scheduler policy)? Interaction with
+the existing rain-delta/water-balance rain memory (avoid double-counting forecast vs measured rain).
+Tracked in the backlog; keep here as a naming/evolution note until decided.
+
 ## Mapping to current code (2026-07-05)
 
 | Object | Current state |

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model)
-**Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump), [Water-Balance Reference Model](design_water_balance_reference_model.md) (where the deficit lives)
+**Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump), [Water-Balance Reference Model](design_water_balance_reference_model.md) (where the deficit lives), [Domain Model Anomalies](design_domain_model_anomalies.md) (code-verified audit against this model)
 
 ## Purpose
 

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -63,7 +63,7 @@ quantity, so a setup can switch models (or fall back ET ⇄ VWC) without the Zon
 one ran. This also unifies the ET formula that today lives in two places (`ETSensor` and
 `DrynessIndexSensor`) into a single `ETModel.et_hourly`.
 
-Ownership follows the reference model unchanged: the **System** owns the shared feeds/probe, the
+Ownership follows the reference model unchanged: the **Environment** owns the shared feeds/probe, the
 **Zone** owns its `Deficit` and its `Kc`. The model is the *mechanism* the Zone uses to advance
 that deficit; `Kc` is passed into a per-zone `ETModel` instance (the system reference uses
 `Kc = 1.0`), because per-zone irrigation resets are independent and a shared reference cannot be
@@ -72,10 +72,13 @@ scaled proportionally after the fact.
 ## Translation chain
 
 ```
-System     provides the ET + rain feeds         α, D_max, temperature + rain sensors
+Environment provides the feeds + the inventory  temperature, rain, RH, wind, Rn, tmax/tmin,
+   │                                              probe, rain probability, latitude
+   │            gates which models a zone may run  declared_sensors ⊇ model.required_sensors
    │
-Zone       accumulates its own deficit (mm)      +ET·Kc·Δt − rain − irrigation; new zone starts at 0
-   │        then translates mm → liters (area)   applies cycle & soak
+Zone        accumulates its own deficit (mm)      +ET·Kc·Δt − rain − irrigation; new zone starts at 0
+   │         rain credited only if placement       is open to the sky
+   │         then translates mm → liters (area)    applies cycle & soak, own D_max
    │
 ZoneDriver translates liters → actuation        native volume if supported,
    │                                            else seconds via flow rate
@@ -96,7 +99,9 @@ backend allows (see the design decision below).
 
 *Rendered diagram (`assets/domain_model_uml.svg`) — blue is the liters contract going
 down, green is the truth flowing back. The Mermaid source below is the normative
-definition; keep the two in sync.*
+definition; keep the two in sync.* ⚠️ **The SVG predates the 2026-08-09 revision** and
+still shows `System` rather than `Environment`, without `Placement` or the `Delivery`
+protocol. Re-render it before this document is next published.*
 
 ```mermaid
 classDiagram
@@ -275,7 +280,7 @@ classDiagram
 ```
 
 `Zone` depends on `Delivery`, the structural protocol, rather than on `DeliveryResult` itself.
-That is what keeps `zone.py` free of Home Assistant while `actuator.py` — which owns the entity
+That is what keeps `zone.py` free of Home Assistant while `driver.py` — which owns the entity
 adapters — necessarily is not. `DeliveryResult` satisfies the protocol without either module
 importing the other.
 
@@ -415,9 +420,9 @@ capability and will land with the driver abstraction.
 
 ## Design decisions
 
-### The deficit lives in the Zone; the System holds feeds, not state
+### The deficit lives in the Zone; the site holds feeds, not state
 
-The System is not a global deficit. It owns the two shared **feeds** — the
+The `Environment` is not a global deficit. It owns the shared **feeds** — the
 temperature sensor (→ ET) and the rain sensor — and broadcasts them; each Zone
 accumulates **its own** deficit (`+ET·Kc·Δt − rain − irrigation`). Irrigating a
 zone resets only that zone. A new zone starts at 0 rather than inheriting a
@@ -428,7 +433,7 @@ frames, and the retire/keep table are in the
 [Water-Balance Reference Model](design_water_balance_reference_model.md)
 (decisions D1–D5).
 
-### Master valve/pump: declared in System, executed by a Driver
+### Master valve/pump: declared at site level, executed by a Driver
 
 The master valve is not scheduling logic — it takes no decisions. It reacts to the aggregate
 execution state (an OR over zone drivers), with an off-delay to avoid pump cycling during
@@ -487,7 +492,7 @@ the user presses **Mark irrigated** once they have watered. `ManualActuator` mod
 third materialization of the *how* — a materialization that proves the abstraction, because it
 has **no hardware at all**.
 
-It deliberately does not extend `Driver`/`Actuator`: there is no entity, no FSM, no watchdog,
+It deliberately does not extend `Driver`: there is no entity, no FSM, no watchdog,
 no liveness. It shares only the delivery **contract** (`→ DeliveryResult`), so the Zone settles
 its deficit identically whether the water came from a valve or a watering can. Two existing
 pieces are reused rather than reinvented: the alert is a **notification**, and **Mark
@@ -499,7 +504,7 @@ is simply the extreme case of "a backend that measures late".
 
 **Actuation and model are orthogonal.** A house plant picks the manual *how* **and** the right
 *how much*: indoors the demand is not weather-driven, so it pairs with a VWC / indoor
-water-balance model, **not** `ETModel`. The two axes (`Actuator` family × `WaterBalanceModel`
+water-balance model, **not** `ETModel`. The two axes (`Driver` family × `WaterBalanceModel`
 family) compose freely — a house plant is just one corner of that grid.
 
 **To explore (open questions, not decided):**
@@ -589,6 +594,11 @@ to an explicit `required_sensors` set on each model + a matching method on `Zone
 | `HargreavesModel` | tmax, tmin *(latitude/day-of-year derived)* |
 | `PenmanMonteithModel` | temperature, humidity, wind, net radiation |
 | `VWCSystemModel` / `VWCPerZoneModel` | soil-moisture probe |
+
+*Naming note.* `VWCSystemModel` still carries the name of the dissolved object. It is left alone
+deliberately: whether a site-level probe is a coherent category at all is the open question of the
+soil-moisture model, and renaming the class before that is settled would only have to be undone. The
+same question decides whether the two VWC classes collapse into one.
 
 *(rain is a credit feed shared by all ET tiers, defaulting to 0 — not a gating requirement.)*
 
@@ -680,14 +690,14 @@ Read the two columns as "what the model says" against "what runs today".
 | Environment | ⚠️ **scaffold written, inert**: `environment.py` (sensor inventory, `declared_sensors`/`satisfies`/`missing_for` capability matching, `RainDelayPolicy`, yearly rain). What runs today is still `DrynessIndexSensor` as **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones), holding the globals the RFC redistributes. Its `_deficit` accumulator is **retired as ET state** and survives only as the interim VWC-system value (D2/D5) |
 | Zone | ⚠️ **scaffold written, inert**: `zone.py` (`Placement`, per-zone `d_max`, `Deficit` ownership, the single `credit_delivery`, `CycleSoakRule`, `WaterCounters`). What runs today is `IrrigationZoneSensor` — a data bag whose accounting lives in `IrrigationController`, which reads and writes 13 of its privates and repeats the crediting formula in 4 places (**anomaly A1**). `_zone_deficit` is authoritative and a new zone starts at 0 (D4). Cycle & soak, placement, per-zone `d_max`: designed, not implemented |
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
-| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired. 📝 **Naming decision (2026-08-01):** the scaffold family will be renamed `Actuator`/`ZoneActuator`/`MasterActuator` → **`Driver`/`ZoneDriver`/`MasterDriver`** (file `actuator.py` → `driver.py`) to match this model's term; `ManualActuator` keeps its name — it is deliberately *not* a `Driver` (shares only the `DeliveryResult` contract) |
-| MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `actuator.py` (`MasterActuator`) |
-| ManualActuator | ❌ not implemented; **scaffold extracted**: `ManualActuator` in `actuator.py` (valve-less, `request_irrigation`/`mark_irrigated` → `DeliveryResult(declared)`), inert. For hand-watered house plants — a *how* with no hardware |
+| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `driver.py` (`Driver`/`ZoneDriver`/`MasterDriver`), inert until wired. ✅ **Renamed 2026-08-09** to match this model's term — the module was unreferenced by any production code or test, so the rename cost nothing and no longer waits on the wiring. `ManualActuator` keeps its name deliberately: it is *not* a `Driver` (it shares only the `DeliveryResult` contract). Lowercase *actuator* survives in prose where it means the physical valve the driver drives |
+| MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `driver.py` (`MasterDriver`) |
+| ManualActuator | ❌ not implemented; **scaffold extracted**: `ManualActuator` in `driver.py` (valve-less, `request_irrigation`/`mark_irrigated` → `DeliveryResult(declared)`), inert. For hand-watered house plants — a *how* with no hardware |
 | WaterBalanceModel | ⚠️ implicit today: the ET/VWC fork inside `DrynessIndexSensor._on_sensor_change` + the per-zone loop, with the ET formula duplicated in `ETSensor`. **Scaffold extracted**: `water_balance_model.py` (`WaterBalanceModel` + `ETBalanceModel` tiers `ETModel`/`HargreavesModel`/`PenmanMonteithModel` + `VWCSystemModel`/`VWCPerZoneModel`), pure, inert until wired |
 | Deficit | ❌ today a bare `float` (`_zone_deficit`, `DrynessIndexSensor._deficit`) with the frame left implicit. **Scaffold extracted**: `Deficit` value object in `water_balance_model.py` |
 
 The refactoring direction is symmetric on both axes: make the **Driver** base explicit when
-implementing GH #95 (so `MasterActuator` inherits the safety layers rather than reimplementing
+implementing GH #95 (so `MasterDriver` inherits the safety layers rather than reimplementing
 them), and make the **WaterBalanceModel** explicit so the ET/VWC switch becomes polymorphic
 dispatch over a shared `Deficit` output instead of an `if self._vwc_sensor:` fork with a
 duplicated ET formula. All four scaffolds now exist as self-contained modules; the remaining
@@ -699,7 +709,7 @@ Stated plainly, so the divergence is a decision rather than a surprise:
 
 | Divergence | Status |
 |---|---|
-| `Actuator`/`ZoneActuator`/`MasterActuator` in code vs **`Driver`/`ZoneDriver`/`MasterDriver`** in this document | Rename **decided**, not applied (`actuator.py` → `driver.py`). To be done before wiring, not after, or the wiring carries the wrong names |
+| ~~`Actuator` family in code vs `Driver` family in this document~~ | ✅ **Resolved 2026-08-09.** `actuator.py` → `driver.py`, `Actuator`/`ZoneActuator`/`MasterActuator` → `Driver`/`ZoneDriver`/`MasterDriver`. Free to do: no production module and no test referenced the scaffold, so the rename touched nothing that runs |
 | `Zone` and `Environment` written but nothing imports them | Deliberate. Phase 1 is the class, phase 2 is the wiring; conflating them is how a refactor becomes unreviewable |
 | Seasonal Kc curve lives in `sensor.compute_kc`, not on `Zone` | Deliberate: the plant-family table has one home, and copying it onto the Zone would create the duplicate source of truth anomaly E1 is about. `Zone.effective_kc` owns only the part that is genuinely the zone's — its exposure |
 | `D_max` per-zone in the model, seeded from the site in code (`self._d_max = dryness_sensor._d_max`) | Decided per-zone; the field already exists on the zone, so the work is to expose it in config and stop seeding it. Deriving it properly needs a wilting point the model does not have — see the caveat in the RFC |

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -48,6 +48,12 @@ backend allows (see the design decision below).
 
 ## Class diagram
 
+![UML class diagram of the NeverDry domain model](assets/domain_model_uml.svg)
+
+*Rendered diagram (`assets/domain_model_uml.svg`) — blue is the liters contract going
+down, green is the truth flowing back. The Mermaid source below is the normative
+definition; keep the two in sync.*
+
 ```mermaid
 classDiagram
     direction TB

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -161,11 +161,19 @@ classDiagram
     }
 
     class Scheduler {
-        +time_windows
-        +concurrency_policy : serial or parallel
-        +queue
-        +next_eligible() Zone
-        +interleave_during_soak()
+        +concurrency : ConcurrencyPolicy
+        +min_service_interval_s
+        +allows_overlap() bool
+        +evaluate_scheduled(zone, is_running) Decision
+        +evaluate_reactive(zone, is_running, is_throttled) Decision
+        +next_eligible(zones, is_running) Zone
+        ~deferred~ time_windows, queue, interleave_during_soak
+    }
+
+    class Decision {
+        +should_irrigate
+        +trigger : Trigger
+        +reason : SkipReason
     }
 
     class Driver {
@@ -275,7 +283,8 @@ classDiagram
     ManualActuator ..> DeliveryResult : returns (declared)
     DeliveryResult ..|> Delivery : satisfies structurally
     Zone ..> Delivery : settles deficit with
-    Scheduler --> Zone : decides when, queues
+    Scheduler --> Zone : decides when
+    Scheduler ..> Decision : returns
     MasterDriver ..> ZoneDriver : ON while any is active
 ```
 
@@ -354,12 +363,24 @@ reported truth.
 The *when* and the concurrency policy. It never touches drivers: it only decides which
 zone runs in which window.
 
+The seam is **decision versus execution**: the scheduler answers "may this zone water now, and
+why not"; registering time listeners, spawning tasks and driving valves stay on the Home Assistant
+side. It takes the world's facts (`is_running`, `is_throttled`) as arguments rather than reading
+them, which is what makes the rules testable without a controller.
+
 | Member | Kind | Meaning |
 |---|---|---|
-| `time_windows` | attr | Time windows and calendars |
-| `concurrency` | attr | Serial or parallel zone runs |
-| `queue` | attr | Queue of eligible zones |
-| `next_eligible() → Zone` | method | Next zone to serve, per queue and windows |
+| `concurrency` | attr | `SERIAL` (today's behaviour) or `PARALLEL`. Naming it turns an emergent property — both handlers happen to bail when something is running — into a stated policy |
+| `min_service_interval_s` | attr | Rate limit between service calls with the same key |
+| `evaluate_scheduled(zone, is_running) → Decision` | method | The daily top-up. Deliberately does **not** consult the threshold: gating a schedule on the reactive threshold turns every scheduled run into a reactive one (AI-183). Only a zone already full is skipped |
+| `evaluate_reactive(zone, is_running, is_throttled) → Decision` | method | Mode A: water once the deficit crosses the zone's threshold |
+| `next_eligible(zones, is_running) → Zone` | method | Driest first — an ordering that needs no memory. Deliberately **not** a queue: a queue remembers what is waiting, which is the deferred design |
+| `Decision` | value object | Water (with a `Trigger`) or skip (with a named `SkipReason`). The reasons are named because two of them — `ALREADY_RUNNING`, `THROTTLED` — are what make a watering look mysteriously missing |
+
+**Deliberately absent:** time windows, calendars, the queue, parallel runs and interleaving during
+soak. Those are deferred until a concrete demand for parallel zones appears (GH #74). Writing them
+now would be building a mechanism for a question nobody has asked; what the module does contain is
+behaviour that already runs, merely written where it can be read.
 | `interleave_during_soak()` | method | During a soak pause it may interleave another eligible zone |
 
 ### Driver «abstract»
@@ -689,7 +710,7 @@ Read the two columns as "what the model says" against "what runs today".
 |---|---|
 | Environment | ⚠️ **scaffold written, inert**: `environment.py` (sensor inventory, `declared_sensors`/`satisfies`/`missing_for` capability matching, `RainDelayPolicy`, yearly rain). What runs today is still `DrynessIndexSensor` as **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones), holding the globals the RFC redistributes. Its `_deficit` accumulator is **retired as ET state** and survives only as the interim VWC-system value (D2/D5) |
 | Zone | ⚠️ **scaffold written, inert**: `zone.py` (`Placement`, per-zone `d_max`, `Deficit` ownership, the single `credit_delivery`, `CycleSoakRule`, `WaterCounters`). What runs today is `IrrigationZoneSensor` — a data bag whose accounting lives in `IrrigationController`, which reads and writes 13 of its privates and repeats the crediting formula in 4 places (**anomaly A1**). `_zone_deficit` is authoritative and a new zone starts at 0 (D4). Cycle & soak, placement, per-zone `d_max`: designed, not implemented |
-| Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
+| Scheduler | ⚠️ **scaffold written, inert**: `scheduler.py` (`evaluate_scheduled`/`evaluate_reactive` → `Decision`, `ConcurrencyPolicy`, `next_eligible`). What runs today is the same two rules written inline inside two HA callbacks in `IrrigationController`, where they cannot be read as a policy or tested without a controller. Still no cron/sequences/calendars — deliberately, that is Irrigation Unlimited's territory — and the queue stays deferred |
 | ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `driver.py` (`Driver`/`ZoneDriver`/`MasterDriver`), inert until wired. ✅ **Renamed 2026-08-09** to match this model's term — the module was unreferenced by any production code or test, so the rename cost nothing and no longer waits on the wiring. `ManualActuator` keeps its name deliberately: it is *not* a `Driver` (it shares only the `DeliveryResult` contract). Lowercase *actuator* survives in prose where it means the physical valve the driver drives |
 | MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `driver.py` (`MasterDriver`) |
 | ManualActuator | ❌ not implemented; **scaffold extracted**: `ManualActuator` in `driver.py` (valve-less, `request_irrigation`/`mark_irrigated` → `DeliveryResult(declared)`), inert. For hand-watered house plants — a *how* with no hardware |
@@ -700,8 +721,8 @@ The refactoring direction is symmetric on both axes: make the **Driver** base ex
 implementing GH #95 (so `MasterDriver` inherits the safety layers rather than reimplementing
 them), and make the **WaterBalanceModel** explicit so the ET/VWC switch becomes polymorphic
 dispatch over a shared `Deficit` output instead of an `if self._vwc_sensor:` fork with a
-duplicated ET formula. All four scaffolds now exist as self-contained modules; the remaining
-phase is wiring the existing call sites onto them.
+duplicated ET formula. All five objects now exist as self-contained modules; the remaining phase
+is wiring the existing call sites onto them.
 
 ### Where model and code still disagree
 

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -543,13 +543,42 @@ configurable):
   configurable amount. A *decision input* the environment provides; the Scheduler/Zone consumes it
   (the environment supplies signals, it does not itself skip watering).
 
-**Open questions before Accepted.** Where does `rain_delay` live — an `Environment` property or a
-`Scheduler` policy (cf. cycle&soak = Zone rule, serial/parallel = Scheduler policy)? Avoid
-double-counting forecast vs measured rain against the water-balance rain memory. Where does the
-now-global **D_max** attach in config (a top-level setting vs a per-zone default)? Tracked in the
-backlog. This RFC raises the **α-ownership** finding (α modeled on `System` but usable only by
-`ETModel`) — to be logged as an anomaly in the [Domain Model Anomalies](design_domain_model_anomalies.md)
-audit when promoted.
+**Where the rain rules live — resolved 2026-08-09.** `rain_delay` is a **Zone** rule, not a
+`Scheduler` policy. The test that settles it: a Scheduler that must *know* indoor zones are unaffected
+by rain has already conceded the rule belongs to the Zone — it is asking each zone whether it is
+exposed, in order to decide on the zone's behalf. It also matches the criterion this document already
+uses elsewhere: cycle&soak is a Zone rule because it concerns that zone's soil; serial/parallel is a
+Scheduler policy because it arbitrates a **shared resource**. Rain is not shared — it falls on a zone
+or it does not.
+
+The property to model is not a bespoke `rain_delay` flag but **whether the zone is open to the sky**,
+expressed as a categorical `Zone.environment`:
+
+| `environment` | Receives rain | Driven by outdoor ET |
+|---|---|---|
+| `outdoor` (default) | yes | yes |
+| `patio` | no | yes |
+| `greenhouse` | no | sheltered — own regime |
+| `indoor` | no | no (moisture-threshold logic instead) |
+
+`patio` is what makes the categorical necessary rather than a boolean: a covered terrace is fully
+outdoors for temperature and wind, yet receives no rain. Without it one is tempted to collapse
+"receives rain" and "is outdoors" into a single flag, which the middle rows show are independent.
+
+One attribute then gates three things that must not be allowed to diverge: the **measured** rain
+credit, the **forecast** rain delay, and whether the outdoor ET model applies at all. That also
+answers the double-counting question below — forecast and measured rain pass through the same
+per-zone gate, so they cannot disagree about whether a zone sees rain.
+
+Note the consequence for today's code: `_broadcast_to_zones` credits `rain` to every registered zone
+unconditionally, and no indoor/outdoor discriminator exists yet. That is latent rather than live —
+there are no non-outdoor zones today — but it becomes a defect the moment `environment` ships, so the
+gate and the discriminator must land together.
+
+**Open questions before Accepted.** Where does the now-global **D_max** attach in config (a top-level
+setting vs a per-zone default)? Tracked in the backlog. This RFC raises the **α-ownership** finding
+(α modeled on `System` but usable only by `ETModel`) — to be logged as an anomaly in the
+[Domain Model Anomalies](design_domain_model_anomalies.md) audit when promoted.
 
 ## Mapping to current code (2026-07-05)
 

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -1,7 +1,7 @@
 # Design — Domain Object Model
 
 **Status:** Draft
-**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model; 2026-07-26 the water-balance model made a first-class object)
+**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model; 2026-07-26 the water-balance model made a first-class object; 2026-08-01 RFC to dissolve `System` into `Environment` + capability-matched models)
 **Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump), [Water-Balance Reference Model](design_water_balance_reference_model.md) (where the deficit lives), [Domain Model Anomalies](design_domain_model_anomalies.md) (code-verified audit against this model)
 
 ## Purpose
@@ -16,7 +16,7 @@ as the codebase evolves. For the current module/data-flow architecture see
 
 | Object | Responsibility | Key attributes |
 |---|---|---|
-| **System** | Shared **feeds** and global model params | α (ET sensitivity), D_max, the temperature + rain sensors it broadcasts to zones; *declares* the master valve/pump. **The deficit is not held here — it lives per-zone** (see Water-Balance Reference Model) |
+| **System** | Shared **feeds** and global model params | α (ET sensitivity), D_max, the temperature + rain sensors it broadcasts to zones; *declares* the master valve/pump. **The deficit is not held here — it lives per-zone** (see Water-Balance Reference Model). ⚠️ **Under RFC to be dissolved** — see "RFC: dissolve `System`" below; α is model-specific (→ `ETModel`), not a global param |
 | **Zone** | Irrigation unit; owns its deficit and translates it into water demand | Kc / plant family, area, sun exposure; cycle & soak rule; **its own deficit** (`+ET·Kc·Δt − rain − irrigation`, new zone starts at 0); translates mm → liters |
 | **Scheduler** | The *when* — and the concurrency policy | Time windows, sequences, calendars; serial vs parallel zone runs, interleaving during soak |
 | **ZoneDriver** | The *how* — actuation of one zone's water demand | Entity adapter (`valve.*`/`switch.*`), delivery mode (native volume in liters vs time in seconds via flow rate), flow rate, zero-flow guard; returns a **DeliveryResult** |
@@ -485,30 +485,71 @@ machinery rather than inventing a new one: a failed probe drives the FSM `unreac
 and the `UNREACHABLE_PASSIVE` / `UNREACHABLE_AT_IRRIGATION` notifications, so the user learns
 about a dead valve *before* the next scheduled run, not from a failed one.
 
-### Naming candidate: `System` is really `Weather` / `Environment` (proposal)
+### RFC: dissolve `System` into `Environment` + capability-matched models
 
-**Status: Proposed (note, not yet decided).** The object today called **System** does one thing:
-it owns the shared **environmental feeds** (temperature + rain → `et_h`, `rain_delta`) and
-broadcasts them to the zones. "System" is a catch-all name that describes *where it sits*, not
-*what it does*. A name that matches its responsibility — **`Weather`** or **`Environment`** — would
-sharpen the ubiquitous language: the zones consume an environment, not "the system". (Caveat: it
-also *declares* the master valve/pump — a non-environmental concern; if the rename is adopted, that
-declaration may want to move, or stay as a documented exception.)
+**Status: RFC (Proposed) — 2026-08-01.** Supersedes the earlier "rename System → Weather/Environment"
+note. Direction is agreed; not yet implemented (the water-balance/actuator scaffolds are still inert).
+Promote to Accepted only once wired.
 
-**Extension enabled by the rename** — if the object is explicitly the environment/weather source, two
-forecast-driven properties become natural, both **configurable from the config flow** as properties of
-this entity:
-- **`rain_probability`** — actual rain probability (from the weather forecast), exposed as a feed
-  alongside temperature and rain.
-- **`rain_delay_above_threshold`** — if `rain_probability` is above a configurable threshold, delay
-  irrigation by a configurable amount. This is a *decision input* the environment provides; the
-  Scheduler/Zone consumes it (keeps the "environment supplies feeds, zone/scheduler decides" split
-  intact — the environment does not itself skip watering, it just raises the probability signal).
+**Problem.** The object today called **System** is a catch-all that bundles three unrelated
+responsibilities, and one of its "global params" is not global at all:
 
-Open questions before promoting to a decision: does the delay live as an Environment property or a
-Scheduler policy (cf. cycle&soak = Zone rule, serial/parallel = Scheduler policy)? Interaction with
-the existing rain-delta/water-balance rain memory (avoid double-counting forecast vs measured rain).
-Tracked in the backlog; keep here as a naming/evolution note until decided.
+| System attribute (today) | Really belongs to | Why |
+|---|---|---|
+| temperature + rain sensors (feeds) | **`Environment`** | Environmental inputs the zones consume |
+| **α** (ET sensitivity) | **`ETModel`** | Used **only** by the simple temperature ET tier — verified: `ETModel.et_hourly = max(0, α·(T−T_base)/24)`. Hargreaves uses its own 0.0023 + extraterrestrial radiation; Penman-Monteith is an energy balance; VWC has no ET. α is meaningless for every other model, so it cannot be a system-global param |
+| **D_max** (deficit clamp) | global water-balance config | Genuinely shared — **every** model clamps its `Deficit` to `[0, D_max]` (ET tiers *and* VWC). Stays a global setting, not a `System` object member |
+| master valve / pump (declaration) | **`MasterDriver`** | A hydraulics/actuation concern, not an environmental one |
+
+With those redistributed, **nothing is left on `System`** — so `System` is **dissolved**, not renamed.
+
+**`Environment` — the declared sensor inventory.** `Environment` becomes the user's answer to
+"which sensors do you have?", declared at install from the config flow. It owns the bindings to
+**all** model inputs, not just the temperature+rain of the simple tier:
+
+- temperature, rain
+- relative humidity, wind speed, net radiation (Penman-Monteith)
+- daily tmax / tmin (Hargreaves), plus **latitude** (site constant → the astronomical radiation term)
+- system soil-moisture (VWC) probe
+- **`rain_probability`** — forecast feed (see the forecast extension below)
+
+**Capability matching.** Each `WaterBalanceModel` tier declares the sensors it requires; a `Zone`
+offers **only** the models whose requirements are satisfied by what `Environment` declares:
+
+```
+Environment.declared_sensors  ⊇  Model.required_sensors   ⇒   Zone offers that model
+```
+
+The requirement per tier is already encoded implicitly in the typed step input; the RFC promotes it
+to an explicit `required_sensors` set on each model + a matching method on `Zone`:
+
+| Model | `required_sensors` (from its `*Step`) |
+|---|---|
+| `ETModel` | temperature |
+| `HargreavesModel` | tmax, tmin *(latitude/day-of-year derived)* |
+| `PenmanMonteithModel` | temperature, humidity, wind, net radiation |
+| `VWCSystemModel` / `VWCPerZoneModel` | soil-moisture probe |
+
+*(rain is a credit feed shared by all ET tiers, defaulting to 0 — not a gating requirement.)*
+
+So a user with only a temperature sensor gets `ETModel`; add humidity + wind + radiation and
+Penman-Monteith unlocks; add a soil probe and VWC mode becomes available — per zone, automatically,
+with no model chosen by hand that the hardware can't feed.
+
+**Forecast extension** (unchanged from the earlier note, now as `Environment` properties, config-flow
+configurable):
+- **`rain_probability`** — forecast rain probability, exposed as a feed alongside temperature and rain.
+- **`rain_delay_above_threshold`** — above a configurable probability, delay irrigation by a
+  configurable amount. A *decision input* the environment provides; the Scheduler/Zone consumes it
+  (the environment supplies signals, it does not itself skip watering).
+
+**Open questions before Accepted.** Where does `rain_delay` live — an `Environment` property or a
+`Scheduler` policy (cf. cycle&soak = Zone rule, serial/parallel = Scheduler policy)? Avoid
+double-counting forecast vs measured rain against the water-balance rain memory. Where does the
+now-global **D_max** attach in config (a top-level setting vs a per-zone default)? Tracked in the
+backlog. This RFC raises the **α-ownership** finding (α modeled on `System` but usable only by
+`ETModel`) — to be logged as an anomaly in the [Domain Model Anomalies](design_domain_model_anomalies.md)
+audit when promoted.
 
 ## Mapping to current code (2026-07-05)
 
@@ -517,7 +558,7 @@ Tracked in the backlog; keep here as a naming/evolution note until decided.
 | System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` — now the **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones). Its `_deficit` accumulator is being **retired as ET state** and survives only as the interim VWC-system value (Water-Balance Reference Model, D2/D5) |
 | Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). `_zone_deficit` is **authoritative**; a new zone **starts at 0** (D4), not seeded from the global. Cycle & soak: not implemented |
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
-| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired |
+| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired. 📝 **Naming decision (2026-08-01):** the scaffold family will be renamed `Actuator`/`ZoneActuator`/`MasterActuator` → **`Driver`/`ZoneDriver`/`MasterDriver`** (file `actuator.py` → `driver.py`) to match this model's term; `ManualActuator` keeps its name — it is deliberately *not* a `Driver` (shares only the `DeliveryResult` contract) |
 | MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `actuator.py` (`MasterActuator`) |
 | ManualActuator | ❌ not implemented; **scaffold extracted**: `ManualActuator` in `actuator.py` (valve-less, `request_irrigation`/`mark_irrigated` → `DeliveryResult(declared)`), inert. For hand-watered house plants — a *how* with no hardware |
 | WaterBalanceModel | ⚠️ implicit today: the ET/VWC fork inside `DrynessIndexSensor._on_sensor_change` + the per-zone loop, with the ET formula duplicated in `ETSensor`. **Scaffold extracted**: `water_balance_model.py` (`WaterBalanceModel` + `ETBalanceModel` tiers `ETModel`/`HargreavesModel`/`PenmanMonteithModel` + `VWCSystemModel`/`VWCPerZoneModel`), pure, inert until wired |

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -498,7 +498,7 @@ responsibilities, and one of its "global params" is not global at all:
 |---|---|---|
 | temperature + rain sensors (feeds) | **`Environment`** | Environmental inputs the zones consume |
 | **α** (ET sensitivity) | **`ETModel`** | Used **only** by the simple temperature ET tier — verified: `ETModel.et_hourly = max(0, α·(T−T_base)/24)`. Hargreaves uses its own 0.0023 + extraterrestrial radiation; Penman-Monteith is an energy balance; VWC has no ET. α is meaningless for every other model, so it cannot be a system-global param |
-| **D_max** (deficit clamp) | global water-balance config | Genuinely shared — **every** model clamps its `Deficit` to `[0, D_max]` (ET tiers *and* VWC). Stays a global setting, not a `System` object member |
+| **D_max** (deficit clamp) | **`Zone`** (value), water-balance config (default) | The *mechanism* is shared — every model clamps its `Deficit` to `[0, D_max]`, ET tiers *and* VWC. The *value* is not: D_max is the zone's soil reservoir, set by soil type × root depth, so a sandy zone under shallow turf and a clay zone under deep shrubs do not hold the same water. Shared mechanism ≠ shared value — every zone has a Kc too, without Kc being global. See "D_max is per-zone" below |
 | master valve / pump (declaration) | **`MasterDriver`** | A hydraulics/actuation concern, not an environmental one |
 
 With those redistributed, **nothing is left on `System`** — so `System` is **dissolved**, not renamed.
@@ -552,9 +552,9 @@ Scheduler policy because it arbitrates a **shared resource**. Rain is not shared
 or it does not.
 
 The property to model is not a bespoke `rain_delay` flag but **whether the zone is open to the sky**,
-expressed as a categorical `Zone.environment`:
+expressed as a categorical `Zone.placement`:
 
-| `environment` | Receives rain | Driven by outdoor ET |
+| `placement` | Receives rain | Driven by outdoor ET |
 |---|---|---|
 | `outdoor` (default) | yes | yes |
 | `patio` | no | yes |
@@ -572,13 +572,42 @@ per-zone gate, so they cannot disagree about whether a zone sees rain.
 
 Note the consequence for today's code: `_broadcast_to_zones` credits `rain` to every registered zone
 unconditionally, and no indoor/outdoor discriminator exists yet. That is latent rather than live —
-there are no non-outdoor zones today — but it becomes a defect the moment `environment` ships, so the
+there are no non-outdoor zones today — but it becomes a defect the moment `placement` ships, so the
 gate and the discriminator must land together.
 
-**Open questions before Accepted.** Where does the now-global **D_max** attach in config (a top-level
-setting vs a per-zone default)? Tracked in the backlog. This RFC raises the **α-ownership** finding
+*Naming note.* `placement` rather than `environment`, deliberately: this RFC already uses
+`Environment` for the site-level sensor inventory, and `exposure` is taken by the microclimate factor
+(#146). Three overlapping words at two different levels is a collision worth resolving before wiring,
+not after. `placement` says literally what it holds — where the zone sits.
+
+**D_max is per-zone — resolved 2026-08-09.** The earlier reading ("genuinely shared, stays a global
+setting") conflated two things. What is shared is the **mechanism**: every model clamps its `Deficit`
+into `[0, D_max]`. The **value** is a property of the zone's soil — D_max is the reservoir that soil
+can hold, a function of soil type and root depth. A sandy zone under shallow turf and a clay zone
+under deep shrubs currently receive the same reservoir, which is simply wrong. Shared mechanism does
+not imply shared value: every zone has a Kc, without Kc being global.
+
+The scaffolds already assume this. `Deficit` carries `d_max` as its own field and exposes
+`clamped()`; `WaterBalanceModel` surfaces it as a property. And today's code already keeps a per-zone
+field — `IrrigationZoneSensor._d_max` — merely *seeded* from the system value
+(`self._d_max = dryness_sensor._d_max`, itself a reach into another object's private, cf. anomaly
+A1). So the work is to expose it in config and stop seeding it globally, not to relocate state.
+
+**Caveat — do not derive it silently.** In FAO-56 the reservoir is `TAW = (θ_FC − θ_WP) · Z_r`, and
+the model has **no wilting point**: `const.py` defines `DEFAULT_FIELD_CAPACITY = 0.30` and
+`DEFAULT_ROOT_DEPTH = 0.30` but nothing for θ_WP, while `DEFAULT_D_MAX = 100.0` is an independent
+constant, not derived from either. Deriving D_max properly means the soil-type presets of #126 must
+carry a wilting point as well — and the resulting values land materially lower than today's default
+(a loam at Z_r = 0.30 m gives roughly 45–50 mm, about half). That is a real change in irrigation
+behaviour and must be made deliberately, with a migration for existing installs, not slipped in.
+Note also the natural pairing it exposes: D_max ≈ TAW, while the zone's existing trigger threshold
+plays the role of RAW = p · TAW.
+
+**Open questions before Accepted.** None outstanding. This RFC raises the **α-ownership** finding
 (α modeled on `System` but usable only by `ETModel`) — to be logged as an anomaly in the
-[Domain Model Anomalies](design_domain_model_anomalies.md) audit when promoted.
+[Domain Model Anomalies](design_domain_model_anomalies.md) audit when promoted. Promotion to Accepted
+still waits on wiring, and on the `Zone` class the model presumes but the code does not yet have
+(anomaly A1).
 
 ## Mapping to current code (2026-07-05)
 

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -1,7 +1,7 @@
 # Design — Domain Object Model
 
 **Status:** Draft
-**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model)
+**Date:** 2026-07-05 (updated 2026-07-06 with review feedback from GH #74; 2026-07-23 aligned with the water-balance reference model; 2026-07-26 the water-balance model made a first-class object)
 **Related:** GH #74 (actuator abstraction discussion), GH #94 (`valve.*` support), GH #95 (master valve/pump), [Water-Balance Reference Model](design_water_balance_reference_model.md) (where the deficit lives), [Domain Model Anomalies](design_domain_model_anomalies.md) (code-verified audit against this model)
 
 ## Purpose
@@ -25,6 +25,42 @@ as the codebase evolves. For the current module/data-flow architecture see
 ZoneDriver and MasterDriver are two specializations of a common **Driver** base, which owns
 what they share: the entity adapter, ON/OFF command with state confirmation, adaptive
 latency/timeout, and the safety layers (watchdog, close on error/stop/restart).
+
+## The water-balance model (the *how much*)
+
+Where the **Driver** abstracts the *how* of actuation, the **WaterBalanceModel** abstracts the
+*how much*: the scientific computation of a zone's water demand. It is the object that turns
+whatever inputs a user's setup provides into a **Deficit**. It has two symmetries with the
+Driver side, and modeling it explicitly buys the same thing the Driver did:
+
+| Sensing side (*how much*) | Actuation side (*how*) |
+|---|---|
+| **WaterBalanceModel** (abstract strategy) | **Driver** (abstract) |
+| ↳ `ETModel`, `VWCSystemModel`, `VWCPerZoneModel` | ↳ `ZoneDriver`, `MasterDriver` |
+| **Deficit** (mm + reference frame) — the value returned | **DeliveryResult** (liters + quality) — the value returned |
+
+- **WaterBalanceModel** — a strategy that produces a `Deficit`. Its three concretes mirror the
+  reference frames of the [Water-Balance Reference Model](design_water_balance_reference_model.md):
+  `ETModel` (temperature + rain, stateful forward-Euler integration), `VWCSystemModel` (one
+  system moisture probe, stateless), `VWCPerZoneModel` (a per-zone probe — the AI-174 target).
+- **Deficit** — the value object every model returns: millimetres **plus the reference frame**
+  they are defined against. A bare number is not enough — the reference model's load-bearing rule
+  is that *two deficits are comparable only within one frame*, so the frame (and, for per-zone
+  probes, the source identity) travels with the value.
+
+**The seam is the output, not the input.** The three models share no inputs — ET needs weather,
+VWC needs a probe, and not every user has a soil-moisture sensor. What they share is the
+**output**: every model yields a `Deficit` in mm. This is precisely why plug-and-play works at
+the output and not the input: each model copes with the sensors it has and exposes the same
+quantity, so a setup can switch models (or fall back ET ⇄ VWC) without the Zone knowing which
+one ran. This also unifies the ET formula that today lives in two places (`ETSensor` and
+`DrynessIndexSensor`) into a single `ETModel.et_hourly`.
+
+Ownership follows the reference model unchanged: the **System** owns the shared feeds/probe, the
+**Zone** owns its `Deficit` and its `Kc`. The model is the *mechanism* the Zone uses to advance
+that deficit; `Kc` is passed into a per-zone `ETModel` instance (the system reference uses
+`Kc = 1.0`), because per-zone irrigation resets are independent and a shared reference cannot be
+scaled proportionally after the fact.
 
 ## Translation chain
 
@@ -112,10 +148,49 @@ classDiagram
         +revise(measured_liters)
     }
 
+    class WaterBalanceModel {
+        <<abstract>>
+        +reference_frame : ReferenceFrame
+        +is_stateful : bool
+        +deficit : Deficit
+        +step(inputs) Deficit
+        +apply_irrigation(mm) Deficit
+        +reset() Deficit
+    }
+
+    class ETModel {
+        +alpha, t_base, kc
+        +et_hourly(temp_c) mm/h
+        +step(ETStep) Deficit
+    }
+
+    class VWCSystemModel {
+        +field_capacity, root_depth
+        +step(VWCReading) Deficit
+    }
+
+    class VWCPerZoneModel {
+        +source : probe/zone id
+    }
+
+    class Deficit {
+        +value_mm
+        +frame : ReferenceFrame
+        +source : per-zone identity
+        +is_comparable_to(other) bool
+        +as_liters(area_m2) liters
+    }
+
     Driver <|-- ZoneDriver
     Driver <|-- MasterDriver
+    WaterBalanceModel <|-- ETModel
+    WaterBalanceModel <|-- VWCSystemModel
+    VWCSystemModel <|-- VWCPerZoneModel
     System "1" o-- "*" Zone : feeds ET+rain to
     System "1" o-- "0..1" MasterDriver : declares
+    Zone "1" --> "1" WaterBalanceModel : advances deficit via
+    WaterBalanceModel ..> Deficit : returns
+    Zone ..> Deficit : holds, settles
     Zone "1" --> "1" ZoneDriver : requests liters
     ZoneDriver ..> DeliveryResult : returns
     Zone ..> DeliveryResult : settles deficit with
@@ -236,8 +311,14 @@ about a dead valve *before* the next scheduled run, not from a failed one.
 | System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` — now the **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones). Its `_deficit` accumulator is being **retired as ET state** and survives only as the interim VWC-system value (Water-Balance Reference Model, D2/D5) |
 | Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). `_zone_deficit` is **authoritative**; a new zone **starts at 0** (D4), not seeded from the global. Cycle & soak: not implemented |
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
-| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet |
-| MasterDriver | ❌ not implemented (GH #95) |
+| ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired |
+| MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `actuator.py` (`MasterActuator`) |
+| WaterBalanceModel | ⚠️ implicit today: the ET/VWC fork inside `DrynessIndexSensor._on_sensor_change` + the per-zone loop, with the ET formula duplicated in `ETSensor`. **Scaffold extracted**: `water_balance_model.py` (`WaterBalanceModel` + `ETModel`/`VWCSystemModel`/`VWCPerZoneModel`), pure, inert until wired |
+| Deficit | ❌ today a bare `float` (`_zone_deficit`, `DrynessIndexSensor._deficit`) with the frame left implicit. **Scaffold extracted**: `Deficit` value object in `water_balance_model.py` |
 
-The refactoring direction is to make the Driver base explicit when implementing GH #95, so
-MasterDriver inherits the existing safety layers rather than reimplementing them.
+The refactoring direction is symmetric on both axes: make the **Driver** base explicit when
+implementing GH #95 (so `MasterActuator` inherits the safety layers rather than reimplementing
+them), and make the **WaterBalanceModel** explicit so the ET/VWC switch becomes polymorphic
+dispatch over a shared `Deficit` output instead of an `if self._vwc_sensor:` fork with a
+duplicated ET formula. Both scaffolds already exist as pure/self-contained modules; the
+remaining phase is wiring the existing call sites onto them.

--- a/docs/design_domain_object_model.md
+++ b/docs/design_domain_object_model.md
@@ -16,8 +16,8 @@ as the codebase evolves. For the current module/data-flow architecture see
 
 | Object | Responsibility | Key attributes |
 |---|---|---|
-| **System** | Shared **feeds** and global model params | α (ET sensitivity), D_max, the temperature + rain sensors it broadcasts to zones; *declares* the master valve/pump. **The deficit is not held here — it lives per-zone** (see Water-Balance Reference Model). ⚠️ **Under RFC to be dissolved** — see "RFC: dissolve `System`" below; α is model-specific (→ `ETModel`), not a global param |
-| **Zone** | Irrigation unit; owns its deficit and translates it into water demand | Kc / plant family, area, sun exposure; cycle & soak rule; **its own deficit** (`+ET·Kc·Δt − rain − irrigation`, new zone starts at 0); translates mm → liters |
+| **Environment** | The **site**: what this installation has, and what it can therefore compute | The declared sensor inventory (temperature, rain, humidity, wind, net radiation, tmax/tmin, soil probe, rain probability) + latitude; **capability matching** — a zone may offer only the models this inventory can feed; yearly rain, one sky over the whole garden; the forecast rain-delay threshold. Written in `environment.py`. Replaces the former **System**, which was dissolved rather than renamed (α → `ETModel`, D_max → `Zone`, master valve → `MasterDriver`) |
+| **Zone** | Irrigation unit; owns its deficit and translates it into water demand | Kc / plant family, area, efficiency, site exposure; **placement** (outdoor/patio/greenhouse/indoor — gates whether rain reaches it); **its own D_max**, the reservoir of this soil; cycle & soak rule; **its own deficit** (`+ET·Kc·Δt − rain − irrigation`, new zone starts at 0); translates mm → liters. Written in `zone.py` |
 | **Scheduler** | The *when* — and the concurrency policy | Time windows, sequences, calendars; serial vs parallel zone runs, interleaving during soak |
 | **ZoneDriver** | The *how* — actuation of one zone's water demand | Entity adapter (`valve.*`/`switch.*`), delivery mode (native volume in liters vs time in seconds via flow rate), flow rate, zero-flow guard; returns a **DeliveryResult** |
 | **MasterDriver** | Coordination of shared hydraulics (pump / master valve) | ON when any ZoneDriver is active, OFF when none; configurable off-delay; no notion of liters |
@@ -102,24 +102,57 @@ definition; keep the two in sync.*
 classDiagram
     direction TB
 
-    class System {
-        +alpha : ET sensitivity
-        +d_max : mm
+    class Environment {
         +temperature_sensor
         +rain_sensor
-        +broadcast(et_h, rain)
+        +humidity_sensor
+        +wind_speed_sensor
+        +net_radiation_sensor
+        +temp_max_sensor
+        +temp_min_sensor
+        +soil_moisture_sensor
+        +rain_probability_sensor
+        +latitude
+        +rain_delay : RainDelayPolicy
+        +yearly_rain_mm : one sky
+        +declared_sensors() SensorKind set
+        +satisfies(required) bool
+        +missing_for(required) SensorKind set
     }
 
     class Zone {
-        +kc_or_plant_family
+        +name
         +area_m2
-        +sun_exposure
+        +efficiency
+        +plant_family / manual_kc
+        +exposure / microclimate_factor
+        +placement : Placement
+        +d_max : own reservoir
         +threshold_mm
-        +cycle_soak_rule
-        +deficit_mm : own state, starts at 0
-        +accumulate(et_h, kc, rain)
-        +water_demand() liters
-        +settle(result : DeliveryResult)
+        +cycle_soak : CycleSoakRule
+        +deficit : Deficit, starts at 0
+        +counters : WaterCounters
+        +effective_kc(base_kc)
+        +accumulate(dt_h, et_h, base_kc, rain_mm) Deficit
+        +water_demand_l() liters
+        +needs_water() bool
+        +begin_cycle()
+        +credit_delivery(d : Delivery) Deficit
+        +settle(d : Delivery, source, at) Deficit
+        +mark_irrigated(source, at) Deficit
+    }
+
+    class Placement {
+        <<enumeration>>
+        OUTDOOR / PATIO / GREENHOUSE / INDOOR
+        +receives_rain : only OUTDOOR
+        +driven_by_outdoor_et : OUTDOOR, PATIO
+    }
+
+    class Delivery {
+        <<protocol>>
+        +liters_delivered
+        +elapsed_s
     }
 
     class Scheduler {
@@ -224,19 +257,27 @@ classDiagram
     ETBalanceModel <|-- PenmanMonteithModel
     WaterBalanceModel <|-- VWCSystemModel
     VWCSystemModel <|-- VWCPerZoneModel
-    System "1" o-- "*" Zone : feeds ET+rain to
-    System "1" o-- "0..1" MasterDriver : declares
+    Environment "1" o-- "*" Zone : feeds ET+rain to
+    Environment "1" o-- "0..1" MasterDriver : declares
+    Environment ..> WaterBalanceModel : gates by capability match
     Zone "1" --> "1" WaterBalanceModel : advances deficit via
     WaterBalanceModel ..> Deficit : returns
     Zone ..> Deficit : holds, settles
+    Zone *-- Placement : sits at
     Zone "1" --> "1" ZoneDriver : requests liters
     ZoneDriver ..> DeliveryResult : returns
     Zone ..> ManualActuator : requests (manual how)
     ManualActuator ..> DeliveryResult : returns (declared)
-    Zone ..> DeliveryResult : settles deficit with
+    DeliveryResult ..|> Delivery : satisfies structurally
+    Zone ..> Delivery : settles deficit with
     Scheduler --> Zone : decides when, queues
     MasterDriver ..> ZoneDriver : ON while any is active
 ```
+
+`Zone` depends on `Delivery`, the structural protocol, rather than on `DeliveryResult` itself.
+That is what keeps `zone.py` free of Home Assistant while `actuator.py` — which owns the entity
+adapters — necessarily is not. `DeliveryResult` satisfies the protocol without either module
+importing the other.
 
 `ManualActuator` is a third materialization of the *how* — but deliberately **not** a
 `Driver`: there is no entity, no FSM, no safety layers to inherit. It shares only the delivery
@@ -255,34 +296,53 @@ Attribute-by-attribute and method-by-method reference for each class, with the
 responsibility that justifies every member. This expands the diagram above; the
 diagram stays the source of truth for relationships.
 
-### System
+### Environment — `environment.py`
 
-The global model and shared infrastructure. *Declares* the master valve/pump but never
-commands it.
-
-| Member | Kind | Meaning |
-|---|---|---|
-| `alpha` | attr | ET sensitivity of the model (mm/°C/day) |
-| `d_max` | attr | Cap on the accumulable deficit (mm) |
-| `temperature_sensor` | attr | Shared temperature sensor |
-| `rain_sensor` | attr | Shared rain sensor (event or cumulative type) |
-| `compute_deficit() → mm` | method | FAO-56 water balance: reference deficit at Kc = 1 |
-
-### Zone
-
-The irrigation unit: translates the model into water demand and settles the deficit with
-the driver's reported truth.
+The site: which sensors this installation declared, and therefore which models it can run.
+*Declares* the master valve/pump but never commands it. Holds bindings — entity ids as opaque
+strings — never readings.
 
 | Member | Kind | Meaning |
 |---|---|---|
-| `kc_or_plant_family` | attr | Crop coefficient (or the plant family that determines it) |
-| `area_m2` | attr | Irrigated surface |
-| `sun_exposure` | attr | Per-zone sun exposure factor |
-| `threshold_mm` | attr | Deficit threshold that triggers irrigation |
-| `cycle_soak_rule` | attr | Cycle & soak rule (dose/pause) — a Zone rule, not a scheduler one |
-| `deficit_mm` | attr | Current zone deficit |
-| `water_demand() → liters` | method | mm → liters via area and efficiency; liters are the contract towards the driver |
-| `settle(r: DeliveryResult)` | method | Scales the deficit by the actually-delivered liters — exactly once |
+| `temperature_sensor`, `rain_sensor` | attr | The two feeds every ET tier consumes |
+| `humidity_sensor`, `wind_speed_sensor`, `net_radiation_sensor` | attr | What unlocks Penman-Monteith |
+| `temp_max_sensor`, `temp_min_sensor` | attr | What unlocks Hargreaves |
+| `soil_moisture_sensor` | attr | What unlocks VWC mode |
+| `rain_probability_sensor` | attr | Forecast feed behind the rain delay |
+| `latitude` | attr | A property of the place: the astronomical radiation term, and the hemisphere flip of the seasonal Kc |
+| `rain_sensor_type`, `backfill_days` | attr | How to read the rain feed, and how far back to replay |
+| `rain_delay: RainDelayPolicy` | attr | Threshold + delay. The site supplies the *signal*; it never skips a watering itself |
+| `yearly_rain_mm` | attr | Rain this calendar year — one sky over the whole garden (reference model D3). Note the asymmetry with the deficit, which is emphatically not shared |
+| `declared_sensors → {SensorKind}` | property | Every kind actually bound to an entity |
+| `satisfies(required) → bool` | method | The whole capability rule: `declared ≥ required` |
+| `missing_for(required) → {SensorKind}` | method | *Which* sensor unlocks a model — what the UI needs to say |
+| `accrue_yearly_rain(mm, year)` | method | Credits positive increments only; a decreasing reading is never rain (GH #123) |
+
+### Zone — `zone.py`
+
+The irrigation unit: owns its deficit, turns it into litres, and settles it with the driver's
+reported truth.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `name` | attr | Identity; also the `source` tag on its `Deficit` |
+| `area_m2`, `efficiency` | attr | Irrigated surface, and how much of what is emitted reaches the root zone |
+| `plant_family`, `manual_kc` | attr | What grows here — the seasonal curve, or an explicit override |
+| `exposure`, `microclimate_factor` | attr | Sun and wind relative to an open site (GH #146) |
+| `placement: Placement` | attr | Where the zone sits. `receives_rain` is true only outdoors; `driven_by_outdoor_et` also covers a patio |
+| `d_max` | attr | **This soil's** reservoir. Only the clamping mechanism is shared across models |
+| `threshold_mm` | attr | Deficit that triggers irrigation |
+| `cycle_soak: CycleSoakRule` | attr | Dose/pause — a Zone rule, not a Scheduler policy |
+| `deficit: Deficit` | attr | Its own deficit, carrying its reference frame. A new zone starts at 0 (D4) |
+| `counters: WaterCounters` | attr | last / session / total / yearly delivered litres |
+| `effective_kc(base_kc)` | method | Applies site exposure. The seasonal curve is deliberately *not* recomputed here — copying its plant table in would create the second source of truth anomaly E1 is about |
+| `accumulate(dt_h, et_h, base_kc, rain_mm)` | method | `+ET·Kc·Δt − rain`, clamped. Rain is credited only when `placement.receives_rain` |
+| `water_demand_l` | property | mm → litres via area and efficiency; litres are the contract towards the driver |
+| `needs_water` | property | Deficit has reached the threshold |
+| `begin_cycle()` | method | Opens a cycle, snapshotting the deficit it starts from |
+| `credit_delivery(d: Delivery)` | method | **The one crediting formula.** Subtracts from the snapshot while a cycle is open, from the current value otherwise — which is what makes repeated real-time credits idempotent |
+| `settle(d, source, at)` | method | Credits the final figure, stamps it, drops the snapshot — exactly once |
+| `mark_irrigated(source, at)` | method | The hose case: nothing was measured, so the volume is inferred from the deficit being cleared |
 
 ### Scheduler
 
@@ -609,12 +669,16 @@ plays the role of RAW = p · TAW.
 still waits on wiring, and on the `Zone` class the model presumes but the code does not yet have
 (anomaly A1).
 
-## Mapping to current code (2026-07-05)
+## Mapping to current code (2026-08-09)
+
+Every object in this document now has a module. The table says, for each, how far the written
+class is from the code that still does the work — because **none of the scaffolds is wired**.
+Read the two columns as "what the model says" against "what runs today".
 
 | Object | Current state |
 |---|---|
-| System | ✅ explicit: config entry globals, `ETSensor`, `DrynessIndexSensor` — now the **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones). Its `_deficit` accumulator is being **retired as ET state** and survives only as the interim VWC-system value (Water-Balance Reference Model, D2/D5) |
-| Zone | ✅ explicit: `IrrigationZoneSensor`, per-zone config (Kc, area, sun exposure). `_zone_deficit` is **authoritative**; a new zone **starts at 0** (D4), not seeded from the global. Cycle & soak: not implemented |
+| Environment | ⚠️ **scaffold written, inert**: `environment.py` (sensor inventory, `declared_sensors`/`satisfies`/`missing_for` capability matching, `RainDelayPolicy`, yearly rain). What runs today is still `DrynessIndexSensor` as **feed hub / broadcaster** (temperature + rain → `et_h`, `rain_delta` → zones), holding the globals the RFC redistributes. Its `_deficit` accumulator is **retired as ET state** and survives only as the interim VWC-system value (D2/D5) |
+| Zone | ⚠️ **scaffold written, inert**: `zone.py` (`Placement`, per-zone `d_max`, `Deficit` ownership, the single `credit_delivery`, `CycleSoakRule`, `WaterCounters`). What runs today is `IrrigationZoneSensor` — a data bag whose accounting lives in `IrrigationController`, which reads and writes 13 of its privates and repeats the crediting formula in 4 places (**anomaly A1**). `_zone_deficit` is authoritative and a new zone starts at 0 (D4). Cycle & soak, placement, per-zone `d_max`: designed, not implemented |
 | Scheduler | ⚠️ implicit and minimal: deficit-triggered daily cycle inside `IrrigationController`; no cron/sequences/calendars (deliberately — that is Irrigation Unlimited's territory). Concurrency is de-facto serial, not an explicit policy |
 | ZoneDriver | ⚠️ exists but internal: `ValveOperator` (FSM, safety layers, latency tracker) + valve/switch adapter (GH #74/#94); native volume delivery in progress. Delivered liters returned as a bare float — no DeliveryResult qualifier yet. **Scaffold extracted**: `actuator.py` (`Actuator`/`ZoneActuator`/`MasterActuator`), inert until wired. 📝 **Naming decision (2026-08-01):** the scaffold family will be renamed `Actuator`/`ZoneActuator`/`MasterActuator` → **`Driver`/`ZoneDriver`/`MasterDriver`** (file `actuator.py` → `driver.py`) to match this model's term; `ManualActuator` keeps its name — it is deliberately *not* a `Driver` (shares only the `DeliveryResult` contract) |
 | MasterDriver | ❌ not implemented (GH #95); its scaffold lives in `actuator.py` (`MasterActuator`) |
@@ -626,5 +690,17 @@ The refactoring direction is symmetric on both axes: make the **Driver** base ex
 implementing GH #95 (so `MasterActuator` inherits the safety layers rather than reimplementing
 them), and make the **WaterBalanceModel** explicit so the ET/VWC switch becomes polymorphic
 dispatch over a shared `Deficit` output instead of an `if self._vwc_sensor:` fork with a
-duplicated ET formula. Both scaffolds already exist as pure/self-contained modules; the
-remaining phase is wiring the existing call sites onto them.
+duplicated ET formula. All four scaffolds now exist as self-contained modules; the remaining
+phase is wiring the existing call sites onto them.
+
+### Where model and code still disagree
+
+Stated plainly, so the divergence is a decision rather than a surprise:
+
+| Divergence | Status |
+|---|---|
+| `Actuator`/`ZoneActuator`/`MasterActuator` in code vs **`Driver`/`ZoneDriver`/`MasterDriver`** in this document | Rename **decided**, not applied (`actuator.py` → `driver.py`). To be done before wiring, not after, or the wiring carries the wrong names |
+| `Zone` and `Environment` written but nothing imports them | Deliberate. Phase 1 is the class, phase 2 is the wiring; conflating them is how a refactor becomes unreviewable |
+| Seasonal Kc curve lives in `sensor.compute_kc`, not on `Zone` | Deliberate: the plant-family table has one home, and copying it onto the Zone would create the duplicate source of truth anomaly E1 is about. `Zone.effective_kc` owns only the part that is genuinely the zone's — its exposure |
+| `D_max` per-zone in the model, seeded from the site in code (`self._d_max = dryness_sensor._d_max`) | Decided per-zone; the field already exists on the zone, so the work is to expose it in config and stop seeding it. Deriving it properly needs a wilting point the model does not have — see the caveat in the RFC |
+| VWC mode overwrites the zone deficit unconditionally after irrigation | A defect, tracked separately. It is the same shape wiring a model into an anemic Zone would reproduce: two writers on one truth |

--- a/docs/design_water_balance_reference_model.md
+++ b/docs/design_water_balance_reference_model.md
@@ -33,10 +33,13 @@ The load-bearing consequence: **two deficits are comparable only if they share a
 reference frame.** ET-mode siblings are comparable (shared weather). Two zones
 each measuring their own soil probe are **not**.
 
-**Model realization.** Each frame maps one-to-one onto a concrete
-`WaterBalanceModel` (see [Domain Object Model](design_domain_object_model.md)):
-ET → `ETModel` (stateful integration), system VWC → `VWCSystemModel` (stateless),
-per-zone VWC → `VWCPerZoneModel`. The frame travels on the `Deficit` value object
+**Model realization.** Each frame maps onto a concrete `WaterBalanceModel` (see
+[Domain Object Model](design_domain_object_model.md)): the ET frame is an
+abstract `ETBalanceModel` (shared integration) with two tiers —
+`ETModel` (temperature-only, today's baseline) and `PenmanMonteithModel`
+(FAO-56, needs humidity + wind + net radiation) — while system VWC →
+`VWCSystemModel` (stateless) and per-zone VWC → `VWCPerZoneModel`. A new ET tier
+is one new `et_rate`, not a new integrator. The frame travels on the `Deficit` value object
 each model returns, so the comparability rule above is enforced in code
 (`Deficit.is_comparable_to`) rather than left to convention. The abstraction is a
 pure, self-contained scaffold (`custom_components/never_dry/water_balance_model.py`),

--- a/docs/design_water_balance_reference_model.md
+++ b/docs/design_water_balance_reference_model.md
@@ -33,6 +33,15 @@ The load-bearing consequence: **two deficits are comparable only if they share a
 reference frame.** ET-mode siblings are comparable (shared weather). Two zones
 each measuring their own soil probe are **not**.
 
+**Model realization.** Each frame maps one-to-one onto a concrete
+`WaterBalanceModel` (see [Domain Object Model](design_domain_object_model.md)):
+ET → `ETModel` (stateful integration), system VWC → `VWCSystemModel` (stateless),
+per-zone VWC → `VWCPerZoneModel`. The frame travels on the `Deficit` value object
+each model returns, so the comparability rule above is enforced in code
+(`Deficit.is_comparable_to`) rather than left to convention. The abstraction is a
+pure, self-contained scaffold (`custom_components/never_dry/water_balance_model.py`),
+inert until a later phase wires today's `DrynessIndexSensor` ET/VWC fork onto it.
+
 ## Ownership: what lives at the system level vs in the zone
 
 | Element | Level | Notes |

--- a/tests/test_driver_async.py
+++ b/tests/test_driver_async.py
@@ -1,0 +1,474 @@
+"""Tests for the async half of the driver — commands, delivery, and the master.
+
+The other driver test file covers the pure surface. This one covers the part that
+needs a Home Assistant loop: issuing a command and awaiting its confirmation,
+delivering water, and the master valve's off-linger.
+
+It matters more than the line count suggests. ``driver.py`` supersedes
+``valve_operator.py``, which sits at 99% — but it is not a copy: it shares under
+half its lines with the operator and nearly doubles them. The Driver/ZoneDriver/
+MasterDriver hierarchy, the delivery strategies and the entity adapter are new
+code that no existing test reaches, and they are where valve closure is decided.
+
+Harness follows ``test_valve_operator.py``: a mocked hass, tiny FSM timeouts, and
+state confirmations pushed in by hand through ``_on_switch_state``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from never_dry.driver import (
+    DeliveryMode,
+    DeliveryQuality,
+    MasterDriver,
+    OperationStatus,
+    ZoneDriver,
+)
+from never_dry.valve_fsm import FsmConfig, ValveState
+
+
+@pytest.fixture
+def hass():
+    """Mock HomeAssistant instance suitable for driver tests."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=MagicMock(state="off"))
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _create_task(coro):
+        try:
+            return asyncio.get_running_loop().create_task(coro)
+        except RuntimeError:
+            coro.close()
+            return MagicMock()
+
+    hass.async_create_task = _create_task
+    return hass
+
+
+def _fast_fsm() -> FsmConfig:
+    """FSM config with tiny timeouts, so a test does not wait on real seconds."""
+    return FsmConfig(
+        has_flow_meter=False,
+        open_timeout_s=0.05,
+        close_timeout_s=0.05,
+        flow_verify_timeout_s=0.05,
+        leak_timeout_s=0.05,
+        max_consecutive_failures=3,
+    )
+
+
+def _zone_driver(hass, *, entity_id="switch.valve", flow_rate=60.0, **kwargs) -> ZoneDriver:
+    return ZoneDriver(
+        hass,
+        entity_id,
+        delivery_mode=DeliveryMode.ESTIMATED_FLOW,
+        flow_rate_lpm=flow_rate,
+        fsm_config=_fast_fsm(),
+        max_retries=0,
+        backoff_s=(0.01,),
+        name="testzone",
+        **kwargs,
+    )
+
+
+def _state_event(value: str) -> MagicMock:
+    event = MagicMock()
+    event.data = {"new_state": MagicMock(state=value)}
+    return event
+
+
+async def _yield_loop(times: int = 3) -> None:
+    for _ in range(times):
+        await asyncio.sleep(0)
+
+
+async def _confirm(driver, value: str) -> None:
+    """Push a state confirmation in, the way HA would."""
+    await _yield_loop()
+    driver._on_switch_state(_state_event(value))
+    await _yield_loop()
+
+
+def _wire_flowing_valve(hass, *, rate_lpm: float) -> None:
+    """Make the mock read as an OPEN valve with water running through the meter.
+
+    Both halves matter: the delivery loop stops the moment the valve reads off,
+    so a harness that reports "off" for everything silently exercises the
+    fallback path instead of the metered one.
+    """
+
+    def states_get(entity_id):
+        if entity_id == "sensor.flow":
+            state = MagicMock()
+            state.state = str(rate_lpm)
+            state.attributes = {"unit_of_measurement": "L/min"}
+            return state
+        return MagicMock(state="on")
+
+    hass.states.get = MagicMock(side_effect=states_get)
+
+
+class TestCommands:
+    """Opening and closing, and the entity adapter picking the right service."""
+
+    async def test_open_confirms_on_a_switch(self, hass):
+        driver = _zone_driver(hass)
+
+        async def simulate():
+            await _confirm(driver, "on")
+
+        sim = asyncio.create_task(simulate())
+        result = await driver.async_turn_on()
+        await sim
+
+        assert result.status is OperationStatus.OK
+        assert driver.is_open
+        hass.services.async_call.assert_any_call("switch", "turn_on", {"entity_id": "switch.valve"}, blocking=False)
+
+    async def test_open_uses_the_valve_service_for_a_valve_entity(self, hass):
+        """The GH #94 payoff: a `valve.*` timer is driven without any config migration."""
+        driver = _zone_driver(hass, entity_id="valve.bhyve")
+
+        async def simulate():
+            await _confirm(driver, "open")
+
+        sim = asyncio.create_task(simulate())
+        result = await driver.async_turn_on()
+        await sim
+
+        assert result.status is OperationStatus.OK
+        hass.services.async_call.assert_any_call("valve", "open_valve", {"entity_id": "valve.bhyve"}, blocking=False)
+
+    async def test_close_confirms(self, hass):
+        driver = _zone_driver(hass)
+
+        async def open_then_close():
+            await _confirm(driver, "on")
+
+        sim = asyncio.create_task(open_then_close())
+        await driver.async_turn_on()
+        await sim
+
+        async def simulate_close():
+            await _confirm(driver, "off")
+
+        sim2 = asyncio.create_task(simulate_close())
+        result = await driver.async_turn_off()
+        await sim2
+
+        assert result.status is OperationStatus.OK
+        assert not driver.is_open
+
+    async def test_an_unconfirmed_open_fails_rather_than_assuming_success(self, hass):
+        """No confirmation must never read as an open valve — the whole safety premise."""
+        driver = _zone_driver(hass)
+        result = await driver.async_turn_on()
+        assert result.status is OperationStatus.FAILED
+        assert not driver.is_open
+
+    async def test_repeated_failures_lock_the_valve_in_maintenance(self, hass):
+        """After the configured failures the zone is blocked and waits for a human."""
+        driver = _zone_driver(hass)
+        for _ in range(3):
+            await driver.async_turn_on()
+        assert driver.is_in_maintenance
+        assert driver.state is ValveState.MAINTENANCE
+
+    async def test_maintenance_can_be_cleared(self, hass):
+        driver = _zone_driver(hass)
+        for _ in range(3):
+            await driver.async_turn_on()
+        await driver.async_reset_maintenance()
+        assert not driver.is_in_maintenance
+
+    async def test_a_command_is_refused_while_in_maintenance(self, hass):
+        driver = _zone_driver(hass)
+        for _ in range(3):
+            await driver.async_turn_on()
+        hass.services.async_call.reset_mock()
+        result = await driver.async_turn_on()
+        assert result.status is OperationStatus.MAINTENANCE
+        hass.services.async_call.assert_not_called()
+
+    async def test_unload_is_safe_to_call(self, hass):
+        driver = _zone_driver(hass)
+        driver.async_unload()
+        assert not driver.is_open
+
+
+class TestDelivery:
+    """`deliver()` returns how much water arrived and how truthful that figure is."""
+
+    async def test_nothing_requested_delivers_nothing(self, hass):
+        driver = _zone_driver(hass)
+        result = await driver.deliver(0.0)
+        assert result.liters_delivered == 0.0
+        assert result.quality is DeliveryQuality.MEASURED
+        hass.services.async_call.assert_not_called()
+
+    async def test_without_a_flow_rate_it_refuses_rather_than_guessing(self, hass):
+        """An unknown duration must not become an open valve with no stop condition."""
+        driver = _zone_driver(hass, flow_rate=0.0)
+        result = await driver.deliver(10.0)
+        assert result.liters_delivered == 0.0
+        assert result.quality is DeliveryQuality.LOW_CONFIDENCE
+        assert result.detail == "no_flow_rate"
+        hass.services.async_call.assert_not_called()
+
+    async def test_a_full_run_reports_an_estimated_figure(self, hass):
+        """Time-based delivery is an estimate, and says so."""
+        driver = _zone_driver(hass, flow_rate=6000.0)  # 0.01 L/s -> 1 L in 0.01 s
+
+        async def simulate():
+            await _confirm(driver, "on")
+            await asyncio.sleep(0.05)
+            driver._on_switch_state(_state_event("off"))
+
+        sim = asyncio.create_task(simulate())
+        result = await driver.deliver(1.0)
+        await sim
+
+        assert result.quality is DeliveryQuality.ESTIMATED
+        assert result.liters_delivered == pytest.approx(1.0, rel=0.2)
+        assert result.requested_liters == 1.0
+
+    async def test_an_aborted_run_reports_partial_not_estimated(self, hass):
+        """Stopping early must be visible in the quality, not hidden in the number."""
+        driver = _zone_driver(hass, flow_rate=6.0)  # 1 L would take 10 s
+
+        aborted = {"now": False}
+
+        async def simulate():
+            await _confirm(driver, "on")
+            await asyncio.sleep(0.05)
+            aborted["now"] = True
+            await _yield_loop()
+            driver._on_switch_state(_state_event("off"))
+
+        sim = asyncio.create_task(simulate())
+        result = await driver.deliver(1.0, should_abort=lambda: aborted["now"])
+        await sim
+
+        assert result.quality is DeliveryQuality.PARTIAL
+        assert result.liters_delivered < 1.0
+
+    async def test_a_failed_open_delivers_nothing_and_says_why(self, hass):
+        driver = _zone_driver(hass, flow_rate=60.0)
+        result = await driver.deliver(1.0)
+        assert result.liters_delivered == 0.0
+        assert result.quality is DeliveryQuality.LOW_CONFIDENCE
+
+
+class TestMasterDriver:
+    """The pump follows aggregate activity — and must not cycle between zones."""
+
+    def _master(self, hass, *, off_delay=0.05) -> MasterDriver:
+        return MasterDriver(
+            hass,
+            "switch.pump",
+            off_delay_s=off_delay,
+            fsm_config=_fast_fsm(),
+            max_retries=0,
+            backoff_s=(0.01,),
+            name="pump",
+        )
+
+    async def test_starts_when_a_zone_becomes_active(self, hass):
+        master = self._master(hass)
+
+        async def simulate():
+            await _confirm(master, "on")
+
+        sim = asyncio.create_task(simulate())
+        await master.follow(any_zone_active=True)
+        await sim
+
+        assert master.is_open
+        hass.services.async_call.assert_any_call("switch", "turn_on", {"entity_id": "switch.pump"}, blocking=False)
+
+    async def test_stays_on_while_zones_remain_active(self, hass):
+        master = self._master(hass)
+
+        async def simulate():
+            await _confirm(master, "on")
+
+        sim = asyncio.create_task(simulate())
+        await master.follow(any_zone_active=True)
+        await sim
+        hass.services.async_call.reset_mock()
+
+        await master.follow(any_zone_active=True)
+        hass.services.async_call.assert_not_called()
+
+    async def test_closes_after_the_off_delay_once_nothing_is_active(self, hass):
+        master = self._master(hass, off_delay=0.02)
+
+        async def simulate_on():
+            await _confirm(master, "on")
+
+        sim = asyncio.create_task(simulate_on())
+        await master.follow(any_zone_active=True)
+        await sim
+
+        await master.follow(any_zone_active=False)
+        await asyncio.sleep(0.05)
+        master._on_switch_state(_state_event("off"))
+        await _yield_loop()
+
+        hass.services.async_call.assert_any_call("switch", "turn_off", {"entity_id": "switch.pump"}, blocking=False)
+
+    async def test_a_new_zone_within_the_delay_cancels_the_close(self, hass):
+        """The whole point of the linger: sequential zones must not cycle the pump.
+
+        The field report on GH #95 put it at five seconds — long enough to bridge
+        the gap between one zone finishing and the next starting.
+        """
+        master = self._master(hass, off_delay=0.2)
+
+        async def simulate_on():
+            await _confirm(master, "on")
+
+        sim = asyncio.create_task(simulate_on())
+        await master.follow(any_zone_active=True)
+        await sim
+        hass.services.async_call.reset_mock()
+
+        await master.follow(any_zone_active=False)
+        await asyncio.sleep(0.02)
+        await master.follow(any_zone_active=True)
+        await asyncio.sleep(0.3)
+
+        for call in hass.services.async_call.call_args_list:
+            assert call.args[1] != "turn_off", "the pump was cycled between two zones"
+
+    async def test_unload_cancels_a_pending_close(self, hass):
+        master = self._master(hass, off_delay=0.2)
+        await master.follow(any_zone_active=False)
+        master.async_unload()
+        await asyncio.sleep(0.3)
+        for call in hass.services.async_call.call_args_list:
+            assert call.args[1] != "turn_off"
+
+    async def test_the_master_knows_nothing_about_liters(self, hass):
+        """It is ON/OFF only — no delivery contract, by design."""
+        assert not hasattr(self._master(hass), "deliver")
+
+
+class TestFlowMeterDelivery:
+    """Measured delivery: the figure comes from the meter, not from the clock."""
+
+    def _metered(self, hass, **kwargs) -> ZoneDriver:
+        return ZoneDriver(
+            hass,
+            "switch.valve",
+            delivery_mode=DeliveryMode.FLOW_METER,
+            flow_rate_lpm=60.0,
+            flow_meter_sensor=kwargs.pop("meter", "sensor.flow"),
+            fsm_config=_fast_fsm(),
+            max_retries=0,
+            backoff_s=(0.01,),
+            name="testzone",
+            delivery_timeout_s=1,
+            **kwargs,
+        )
+
+    async def test_without_a_meter_it_refuses(self, hass):
+        driver = self._metered(hass, meter=None)
+        result = await driver.deliver(5.0)
+        assert result.quality is DeliveryQuality.LOW_CONFIDENCE
+        assert result.detail == "no_flow_meter"
+
+    async def test_a_rate_meter_integrates_to_a_measured_figure(self, hass):
+        """The payoff over an estimate: what the meter saw, not what the clock implied."""
+        driver = self._metered(hass)
+
+        _wire_flowing_valve(hass, rate_lpm=600.0)
+
+        async def simulate():
+            await _confirm(driver, "on")
+            await asyncio.sleep(0.3)
+            driver._on_switch_state(_state_event("off"))
+
+        sim = asyncio.create_task(simulate())
+        result = await driver.deliver(1.0)
+        await sim
+
+        assert result.liters_delivered > 0
+        assert result.quality is DeliveryQuality.MEASURED
+        # Guards the harness itself: `fallback_estimate` means the loop never saw
+        # an open valve and credited the nominal rate instead of the meter, which
+        # is how the first version of this test passed while proving nothing.
+        assert result.detail != "fallback_estimate"
+
+    async def test_progress_is_reported_while_water_flows(self, hass):
+        """The caller deducts the deficit live, so it needs the running figure."""
+        driver = self._metered(hass)
+        seen: list[float] = []
+
+        _wire_flowing_valve(hass, rate_lpm=600.0)
+
+        async def simulate():
+            await _confirm(driver, "on")
+            await asyncio.sleep(0.3)
+            driver._on_switch_state(_state_event("off"))
+
+        sim = asyncio.create_task(simulate())
+        await driver.deliver(1.0, on_progress=seen.append)
+        await sim
+
+        assert seen, "no progress was reported during delivery"
+        assert seen == sorted(seen), "progress must not go backwards"
+
+    async def test_a_failed_open_never_reports_water(self, hass):
+        driver = self._metered(hass)
+        result = await driver.deliver(5.0)
+        assert result.liters_delivered == 0.0
+        assert result.quality is DeliveryQuality.LOW_CONFIDENCE
+
+
+class TestLiveness:
+    """The active probe — a valve can be unreachable without anyone asking it."""
+
+    async def test_a_responding_entity_is_live(self, hass):
+        driver = _zone_driver(hass)
+        hass.states.get = MagicMock(return_value=MagicMock(state="off"))
+        assert await driver.async_ping() is True
+
+    async def test_an_unavailable_entity_is_not(self, hass):
+        driver = _zone_driver(hass)
+        hass.states.get = MagicMock(return_value=MagicMock(state="unavailable"))
+        assert await driver.async_ping() is False
+
+    async def test_a_missing_entity_is_not(self, hass):
+        driver = _zone_driver(hass)
+        hass.states.get = MagicMock(return_value=None)
+        assert await driver.async_ping() is False
+
+    async def test_a_dedicated_availability_entity_is_preferred(self, hass):
+        """A Z2M availability sensor is the cheaper, truer signal when present."""
+        driver = _zone_driver(hass, availability_entity="binary_sensor.valve_available")
+        asked: list[str] = []
+
+        def states_get(entity_id):
+            asked.append(entity_id)
+            return MagicMock(state="on")
+
+        hass.states.get = MagicMock(side_effect=states_get)
+        assert await driver.async_ping() is True
+        assert "binary_sensor.valve_available" in asked
+
+    async def test_an_availability_entity_reading_off_means_unreachable(self, hass):
+        driver = _zone_driver(hass, availability_entity="binary_sensor.valve_available")
+        hass.states.get = MagicMock(return_value=MagicMock(state="off"))
+        assert await driver.async_ping() is False
+
+    async def test_the_probe_can_be_started_and_stopped(self, hass):
+        driver = _zone_driver(hass)
+        driver.start_liveness_probe(interval_min=0.001)
+        await asyncio.sleep(0)
+        driver.async_unload()

--- a/tests/test_driver_contract.py
+++ b/tests/test_driver_contract.py
@@ -1,0 +1,188 @@
+"""Tests for the driver's contract surface — the parts that need no HA runtime.
+
+``driver.py`` is the one scaffold that is Home Assistant-coupled, so it splits
+into two halves. This file covers the half that is pure: the entity adapter, the
+delivery contract, and the valve-less ManualActuator. The async half — the
+Driver base with its watchdog, adaptive timeouts and liveness probe — needs the
+mocked-hass harness of ``test_valve_operator.py`` and is not covered here.
+
+The adapter is worth pinning precisely: it is the single place that knows a
+``switch.*`` opens with ``switch.turn_on`` while a ``valve.*`` opens with
+``valve.open_valve``, and it is what makes GH #94 (Orbit B-hyve and friends)
+additive rather than a migration.
+"""
+
+import pytest
+from never_dry.driver import (
+    DeliveryMode,
+    DeliveryQuality,
+    DeliveryResult,
+    Driver,
+    EntityDomain,
+    ManualActuator,
+    MasterDriver,
+    OperationResult,
+    OperationStatus,
+    ValveCommandAdapter,
+    ZoneDriver,
+)
+
+
+class TestValveCommandAdapter:
+    """Domain is derived from the entity_id prefix — no config, no migration."""
+
+    def test_switch_entities_map_to_the_switch_domain(self):
+        assert ValveCommandAdapter("switch.garden").domain is EntityDomain.SWITCH
+
+    def test_valve_entities_map_to_the_valve_domain(self):
+        assert ValveCommandAdapter("valve.bhyve_timer").domain is EntityDomain.VALVE
+
+    def test_anything_else_falls_back_to_switch(self):
+        """A pump is not a domain: HA sees a relay, so it must take the switch branch."""
+        assert ValveCommandAdapter("light.weird").domain is EntityDomain.SWITCH
+        assert ValveCommandAdapter("no_dot_at_all").domain is EntityDomain.SWITCH
+
+    def test_switch_commands(self):
+        adapter = ValveCommandAdapter("switch.garden")
+        assert adapter.command(on=True) == ("switch", "turn_on")
+        assert adapter.command(on=False) == ("switch", "turn_off")
+
+    def test_valve_commands(self):
+        adapter = ValveCommandAdapter("valve.bhyve_timer")
+        assert adapter.command(on=True) == ("valve", "open_valve")
+        assert adapter.command(on=False) == ("valve", "close_valve")
+
+    @pytest.mark.parametrize("raw", ["on", "open"])
+    def test_open_states_collapse_to_on(self, raw):
+        assert ValveCommandAdapter.interpret_state(raw) == "on"
+
+    @pytest.mark.parametrize("raw", ["off", "closed"])
+    def test_closed_states_collapse_to_off(self, raw):
+        assert ValveCommandAdapter.interpret_state(raw) == "off"
+
+    @pytest.mark.parametrize("raw", ["opening", "closing"])
+    def test_moving_states_are_transitional(self, raw):
+        """A valve mid-travel must emit no FSM observation until it settles."""
+        assert ValveCommandAdapter.interpret_state(raw) == "transitional"
+
+    def test_missing_state_is_unavailable(self):
+        assert ValveCommandAdapter.interpret_state(None) == "unavailable"
+        assert ValveCommandAdapter.interpret_state("unavailable") == "unavailable"
+
+    def test_unknown_is_kept_distinct_from_unavailable(self):
+        assert ValveCommandAdapter.interpret_state("unknown") == "unknown"
+
+    def test_an_unrecognised_state_is_not_silently_open(self):
+        """Defaulting a surprise state to "on" would leave a valve believed open."""
+        assert ValveCommandAdapter.interpret_state("banana") == "unknown"
+
+
+class TestDeliveryResult:
+    """The round trip: how much water, and how truthful the figure is."""
+
+    def test_carries_the_requested_and_delivered_figures(self):
+        result = DeliveryResult(9.5, DeliveryQuality.MEASURED, 120.0, 10.0)
+        assert result.liters_delivered == 9.5
+        assert result.requested_liters == 10.0
+        assert result.elapsed_s == 120.0
+
+    def test_revise_replaces_a_late_measurement(self):
+        """A backend that measures late — Hydrawise — corrects an estimate afterwards."""
+        estimated = DeliveryResult(10.0, DeliveryQuality.ESTIMATED, 120.0, 10.0)
+        revised = estimated.revise(8.7)
+        assert revised.liters_delivered == 8.7
+        assert revised.quality is DeliveryQuality.MEASURED
+
+    def test_revise_returns_a_copy(self):
+        estimated = DeliveryResult(10.0, DeliveryQuality.ESTIMATED, 120.0, 10.0)
+        estimated.revise(8.7)
+        assert estimated.liters_delivered == 10.0
+
+    def test_revise_can_state_a_different_quality(self):
+        partial = DeliveryResult(4.0, DeliveryQuality.ESTIMATED, 60.0, 10.0)
+        assert partial.revise(4.2, DeliveryQuality.PARTIAL).quality is DeliveryQuality.PARTIAL
+
+    def test_satisfies_the_zone_delivery_protocol(self):
+        """The seam that keeps zone.py free of Home Assistant."""
+        from never_dry.zone import Delivery
+
+        assert isinstance(DeliveryResult(1.0, DeliveryQuality.MEASURED, 1.0, 1.0), Delivery)
+
+
+class TestOperationResult:
+    def test_carries_its_status(self):
+        assert OperationResult(OperationStatus.OK).status is OperationStatus.OK
+
+    def test_statuses_are_distinct(self):
+        assert len({s.value for s in OperationStatus}) == len(list(OperationStatus))
+
+
+class TestManualActuator:
+    """A *how* with no hardware: the watering can, for house plants."""
+
+    def test_starts_idle(self):
+        actuator = ManualActuator(name="Ficus")
+        assert not actuator.is_pending
+        assert actuator.pending_liters == 0.0
+        assert actuator.name == "Ficus"
+
+    def test_requesting_irrigation_opens_an_alert_and_delivers_nothing_yet(self):
+        actuator = ManualActuator(name="Ficus")
+        result = actuator.request_irrigation(1.5, deficit_mm=12.0)
+        assert actuator.is_pending
+        assert actuator.pending_liters == 1.5
+        assert result.liters_delivered == 0.0
+        assert result.quality is DeliveryQuality.DELAYED
+        assert result.requested_liters == 1.5
+
+    def test_the_alert_callback_receives_the_dose(self):
+        seen = []
+
+        def record(name, liters, deficit):
+            seen.append((name, liters, deficit))
+
+        actuator = ManualActuator(name="Ficus", on_alert=record)
+        actuator.request_irrigation(1.5, deficit_mm=12.0)
+        assert seen == [("Ficus", 1.5, 12.0)]
+
+    def test_marking_irrigated_declares_the_volume_and_clears_the_alert(self):
+        actuator = ManualActuator(name="Ficus")
+        actuator.request_irrigation(1.5)
+        result = actuator.mark_irrigated()
+        assert not actuator.is_pending
+        assert result.quality is DeliveryQuality.DECLARED
+        assert result.liters_delivered == 1.5
+
+    def test_marking_irrigated_accepts_a_different_amount(self):
+        """The user poured what they poured, not what was asked."""
+        actuator = ManualActuator(name="Ficus")
+        actuator.request_irrigation(1.5)
+        assert actuator.mark_irrigated(0.8).liters_delivered == 0.8
+
+    def test_the_clear_callback_fires_on_confirmation(self):
+        cleared = []
+        actuator = ManualActuator(name="Ficus", on_clear=lambda n: cleared.append(n))
+        actuator.request_irrigation(1.5)
+        actuator.mark_irrigated()
+        assert cleared == ["Ficus"]
+
+    def test_is_not_a_driver(self):
+        """Deliberate: no entity, no FSM, no safety layers to inherit.
+
+        It shares only the DeliveryResult contract, which is what lets the Zone
+        settle identically whether the water came from a valve or a watering can.
+        """
+        assert not issubclass(ManualActuator, Driver)
+
+
+class TestDriverFamily:
+    def test_both_drivers_specialize_the_common_base(self):
+        assert issubclass(ZoneDriver, Driver)
+        assert issubclass(MasterDriver, Driver)
+
+    def test_the_base_is_abstract(self):
+        with pytest.raises(TypeError):
+            Driver()
+
+    def test_delivery_modes_are_distinct(self):
+        assert len({m.value for m in DeliveryMode}) == len(list(DeliveryMode))

--- a/tests/test_driver_contract.py
+++ b/tests/test_driver_contract.py
@@ -12,6 +12,8 @@ The adapter is worth pinning precisely: it is the single place that knows a
 additive rather than a migration.
 """
 
+import inspect
+
 import pytest
 from never_dry.driver import (
     DeliveryMode,
@@ -181,8 +183,15 @@ class TestDriverFamily:
         assert issubclass(MasterDriver, Driver)
 
     def test_the_base_is_abstract(self):
-        with pytest.raises(TypeError):
-            Driver()
+        """`role` is the hook that forces a specialization to declare itself.
+
+        Asserted on ``__abstractmethods__`` rather than by calling ``Driver()``:
+        the constructor takes required arguments, so an empty call raises
+        TypeError for the wrong reason and the test would pass even if the base
+        stopped being abstract.
+        """
+        assert inspect.isabstract(Driver)
+        assert "role" in Driver.__abstractmethods__
 
     def test_delivery_modes_are_distinct(self):
         assert len({m.value for m in DeliveryMode}) == len(list(DeliveryMode))

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,156 @@
+"""Tests for the site — the declared sensor inventory and what it unlocks.
+
+Capability matching is the reason this object exists, so most of these are about
+one rule: a zone may offer only the models the site can feed.
+"""
+
+from never_dry.environment import (
+    BINDING_BY_KIND,
+    Environment,
+    RainDelayPolicy,
+    RainSensorType,
+    SensorKind,
+)
+
+# What each water-balance tier asks of the site.
+NEEDS_ET = {SensorKind.TEMPERATURE}
+NEEDS_HARGREAVES = {SensorKind.TEMP_MAX, SensorKind.TEMP_MIN}
+NEEDS_PENMAN = {
+    SensorKind.TEMPERATURE,
+    SensorKind.HUMIDITY,
+    SensorKind.WIND_SPEED,
+    SensorKind.NET_RADIATION,
+}
+NEEDS_VWC = {SensorKind.SOIL_MOISTURE}
+
+
+class TestDeclaredSensors:
+    def test_a_bare_site_declares_nothing(self):
+        assert Environment().declared_sensors == frozenset()
+
+    def test_only_bound_sensors_are_declared(self):
+        env = Environment(temperature_sensor="sensor.t", rain_sensor="sensor.r")
+        assert env.declared_sensors == {SensorKind.TEMPERATURE, SensorKind.RAIN}
+
+    def test_every_sensor_kind_has_a_binding(self):
+        """A kind with no attribute behind it would silently never be declarable."""
+        assert set(BINDING_BY_KIND) == set(SensorKind)
+
+    def test_every_binding_names_a_real_attribute(self):
+        env = Environment()
+        for attr in BINDING_BY_KIND.values():
+            assert hasattr(env, attr), attr
+
+    def test_binding_for_returns_the_entity_id(self):
+        env = Environment(soil_moisture_sensor="sensor.probe")
+        assert env.binding_for(SensorKind.SOIL_MOISTURE) == "sensor.probe"
+        assert env.binding_for(SensorKind.HUMIDITY) is None
+
+
+class TestCapabilityMatching:
+    def test_a_thermometer_unlocks_the_baseline_tier_only(self):
+        env = Environment(temperature_sensor="sensor.t")
+        assert env.satisfies(NEEDS_ET)
+        assert not env.satisfies(NEEDS_PENMAN)
+        assert not env.satisfies(NEEDS_VWC)
+
+    def test_adding_sensors_unlocks_penman(self):
+        env = Environment(
+            temperature_sensor="sensor.t",
+            humidity_sensor="sensor.rh",
+            wind_speed_sensor="sensor.wind",
+            net_radiation_sensor="sensor.rn",
+        )
+        assert env.satisfies(NEEDS_PENMAN)
+
+    def test_hargreaves_needs_no_extra_hardware_beyond_min_max(self):
+        env = Environment(temp_max_sensor="sensor.tmax", temp_min_sensor="sensor.tmin")
+        assert env.satisfies(NEEDS_HARGREAVES)
+
+    def test_missing_for_names_what_is_absent(self):
+        """The UI has to say *which* sensor unlocks a model, not merely that one is missing."""
+        env = Environment(temperature_sensor="sensor.t")
+        assert env.missing_for(NEEDS_PENMAN) == {
+            SensorKind.HUMIDITY,
+            SensorKind.WIND_SPEED,
+            SensorKind.NET_RADIATION,
+        }
+
+    def test_missing_for_is_empty_when_satisfied(self):
+        env = Environment(temperature_sensor="sensor.t")
+        assert env.missing_for(NEEDS_ET) == frozenset()
+
+    def test_extra_sensors_never_block_a_model(self):
+        """The rule is `declared >= required`, not equality."""
+        env = Environment(temperature_sensor="sensor.t", soil_moisture_sensor="sensor.p")
+        assert env.satisfies(NEEDS_ET)
+
+    def test_a_model_requiring_nothing_is_always_satisfied(self):
+        assert Environment().satisfies(set())
+
+
+class TestYearlyRain:
+    """One sky over the whole garden — a site quantity, unlike the deficit."""
+
+    def test_accrues_positive_increments(self):
+        env = Environment().accrue_yearly_rain(12.4, year=2026).accrue_yearly_rain(3.6, year=2026)
+        assert env.yearly_rain_mm == 16.0
+
+    def test_ignores_a_decrease(self):
+        """A falling reading is never rain — the lesson of GH #123."""
+        env = Environment().accrue_yearly_rain(10.0, year=2026)
+        assert env.accrue_yearly_rain(-5.0, year=2026).yearly_rain_mm == 10.0
+
+    def test_ignores_zero(self):
+        env = Environment().accrue_yearly_rain(10.0, year=2026)
+        assert env.accrue_yearly_rain(0.0, year=2026).yearly_rain_mm == 10.0
+
+    def test_rolls_over_on_a_new_year(self):
+        env = Environment().accrue_yearly_rain(80.0, year=2026)
+        rolled = env.accrue_yearly_rain(2.0, year=2027)
+        assert rolled.yearly_rain_mm == 2.0
+        assert rolled.yearly_rain_year == 2027
+
+    def test_rollover_clamps_a_negative_first_increment(self):
+        env = Environment().accrue_yearly_rain(80.0, year=2026)
+        assert env.accrue_yearly_rain(-3.0, year=2027).yearly_rain_mm == 0.0
+
+    def test_reset_clears_the_total(self):
+        env = Environment().accrue_yearly_rain(80.0, year=2026).reset_yearly_rain(year=2026)
+        assert env.yearly_rain_mm == 0.0
+
+    def test_projects_onto_an_area(self):
+        """1 mm over 1 m² is 1 litre."""
+        env = Environment().accrue_yearly_rain(16.0, year=2026)
+        assert env.yearly_rain_liters(50.0) == 800.0
+
+    def test_accrual_returns_a_copy(self):
+        """The dataclass is mutable, but accrual is expressed as a new value."""
+        env = Environment()
+        assert env.accrue_yearly_rain(5.0, year=2026) is not env
+        assert env.yearly_rain_mm == 0.0
+
+
+class TestRainDelayPolicy:
+    """The site supplies the signal; it never skips a watering itself."""
+
+    def test_disabled_by_default(self):
+        assert not RainDelayPolicy().triggers_at(0.99)
+
+    def test_triggers_at_or_above_the_threshold(self):
+        policy = RainDelayPolicy(enabled=True, probability_threshold=0.6)
+        assert policy.triggers_at(0.6)
+        assert policy.triggers_at(0.8)
+        assert not policy.triggers_at(0.59)
+
+    def test_no_forecast_never_triggers(self):
+        """An unavailable forecast must not read as "rain is coming"."""
+        assert not RainDelayPolicy(enabled=True).triggers_at(None)
+
+
+class TestDefaults:
+    def test_rain_sensor_type_defaults_to_event(self):
+        assert Environment().rain_sensor_type is RainSensorType.EVENT
+
+    def test_latitude_defaults_to_the_northern_hemisphere(self):
+        assert Environment().latitude > 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,143 @@
+"""Tests for the scheduler — the *when*, extracted from the controller callbacks.
+
+These pin the rules that used to live inline inside two Home Assistant callbacks,
+where they could not be exercised without a controller. The point of each test is
+a rule someone could plausibly "simplify" away later, so each says why it holds.
+"""
+
+import pytest
+from never_dry.scheduler import (
+    ConcurrencyPolicy,
+    Decision,
+    Scheduler,
+    SkipReason,
+    Trigger,
+)
+from never_dry.zone import Zone
+
+
+def make_zone(deficit_mm: float, *, threshold: float = 20.0, name: str = "lawn") -> Zone:
+    """A zone sitting at a given deficit."""
+    zone = Zone(name=name, area_m2=50.0, threshold_mm=threshold)
+    zone.deficit = zone.deficit.with_value(deficit_mm)
+    return zone
+
+
+class TestScheduledMode:
+    """The daily top-up. Its defining property is that it ignores the threshold."""
+
+    def test_waters_below_threshold(self):
+        """A schedule tops the zone up whatever the deficit — that is the point.
+
+        Gating this on the reactive threshold would quietly turn every scheduled
+        run into a reactive one, which is the bug AI-183 fixed. A zone at 5 mm
+        with a 20 mm threshold must still water at its hour.
+        """
+        decision = Scheduler().evaluate_scheduled(make_zone(5.0, threshold=20.0), is_running=False)
+        assert decision.should_irrigate
+        assert decision.trigger is Trigger.SCHEDULED
+
+    def test_skips_only_when_there_is_nothing_to_refill(self):
+        decision = Scheduler().evaluate_scheduled(make_zone(0.0), is_running=False)
+        assert not decision.should_irrigate
+        assert decision.reason is SkipReason.NOTHING_TO_REFILL
+
+    def test_negative_deficit_is_also_nothing_to_refill(self):
+        """Deficit should never go below zero, but the guard must not be `== 0`."""
+        decision = Scheduler().evaluate_scheduled(make_zone(-1.0), is_running=False)
+        assert decision.reason is SkipReason.NOTHING_TO_REFILL
+
+    def test_yields_to_a_running_irrigation(self):
+        decision = Scheduler().evaluate_scheduled(make_zone(30.0), is_running=True)
+        assert not decision.should_irrigate
+        assert decision.reason is SkipReason.ALREADY_RUNNING
+
+
+class TestReactiveMode:
+    """Mode A: water once the deficit crosses the zone's own threshold."""
+
+    def test_waters_at_the_threshold(self):
+        """The comparison is `>=`, so exactly at the threshold must trigger."""
+        decision = Scheduler().evaluate_reactive(make_zone(20.0, threshold=20.0), is_running=False)
+        assert decision.should_irrigate
+        assert decision.trigger is Trigger.REACTIVE
+
+    def test_holds_below_the_threshold(self):
+        decision = Scheduler().evaluate_reactive(make_zone(19.9, threshold=20.0), is_running=False)
+        assert not decision.should_irrigate
+        assert decision.reason is SkipReason.BELOW_THRESHOLD
+
+    def test_yields_to_a_running_irrigation(self):
+        decision = Scheduler().evaluate_reactive(make_zone(30.0), is_running=True)
+        assert decision.reason is SkipReason.ALREADY_RUNNING
+
+    def test_throttling_is_checked_after_the_threshold(self):
+        """A throttled call that was below threshold reports the threshold.
+
+        Order matters for the log: the user should be told the zone was not
+        thirsty, not that we rate-limited a call we would have refused anyway.
+        """
+        sched = Scheduler()
+        assert sched.evaluate_reactive(make_zone(5.0), is_running=False, is_throttled=True).reason is (
+            SkipReason.BELOW_THRESHOLD
+        )
+        assert sched.evaluate_reactive(make_zone(30.0), is_running=False, is_throttled=True).reason is (
+            SkipReason.THROTTLED
+        )
+
+
+class TestConcurrencyPolicy:
+    """Serial is today's behaviour; naming it is what this object adds."""
+
+    def test_serial_is_the_default(self):
+        assert Scheduler().concurrency is ConcurrencyPolicy.SERIAL
+        assert not Scheduler().allows_overlap
+
+    @pytest.mark.parametrize("evaluate", ["evaluate_scheduled", "evaluate_reactive"])
+    def test_parallel_policy_lets_a_zone_start_while_another_runs(self, evaluate):
+        """Both entry points must honour the policy, not just one of them."""
+        sched = Scheduler(concurrency=ConcurrencyPolicy.PARALLEL)
+        decision = getattr(sched, evaluate)(make_zone(30.0), is_running=True)
+        assert decision.should_irrigate
+
+
+class TestNextEligible:
+    """Ordering without memory — deliberately not a queue."""
+
+    def test_picks_the_driest_zone(self):
+        zones = [make_zone(25.0, name="lawn"), make_zone(40.0, name="roses"), make_zone(30.0, name="hedge")]
+        assert Scheduler().next_eligible(zones, is_running=False).name == "roses"
+
+    def test_ignores_zones_below_their_own_threshold(self):
+        """Eligibility is per zone: a high deficit under a high threshold does not qualify."""
+        zones = [make_zone(25.0, threshold=20.0, name="lawn"), make_zone(40.0, threshold=99.0, name="roses")]
+        assert Scheduler().next_eligible(zones, is_running=False).name == "lawn"
+
+    def test_returns_none_when_nothing_is_thirsty(self):
+        assert Scheduler().next_eligible([make_zone(1.0)], is_running=False) is None
+
+    def test_returns_none_while_serial_and_running(self):
+        assert Scheduler().next_eligible([make_zone(40.0)], is_running=True) is None
+
+    def test_parallel_policy_still_returns_a_zone_while_running(self):
+        sched = Scheduler(concurrency=ConcurrencyPolicy.PARALLEL)
+        assert sched.next_eligible([make_zone(40.0, name="roses")], is_running=True).name == "roses"
+
+    def test_empty_list_is_not_an_error(self):
+        assert Scheduler().next_eligible([], is_running=False) is None
+
+
+class TestDecision:
+    """The value object carries the reason, which is what reaches the user's log."""
+
+    def test_go_carries_a_trigger_and_no_reason(self):
+        decision = Decision.go(Trigger.MANUAL)
+        assert decision.should_irrigate
+        assert decision.trigger is Trigger.MANUAL
+        assert decision.reason is None
+
+    def test_skip_carries_a_reason_and_no_trigger(self):
+        decision = Decision.skip(SkipReason.THROTTLED)
+        assert not decision.should_irrigate
+        assert decision.reason is SkipReason.THROTTLED
+        assert decision.trigger is None

--- a/tests/test_water_balance_model.py
+++ b/tests/test_water_balance_model.py
@@ -1,0 +1,225 @@
+"""Tests for the water-balance model — the *how much*, and the Deficit it returns.
+
+The load-bearing rule of the reference model is that two deficits are comparable
+only within one frame. Most of the ``Deficit`` tests are about that, because a
+bare float cannot express it and a silent cross-frame comparison is the class of
+bug the value object exists to prevent.
+"""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from never_dry.water_balance_model import (
+    DEFAULT_ALPHA,
+    DEFAULT_T_BASE,
+    Deficit,
+    ETModel,
+    ETStep,
+    HargreavesModel,
+    HargreavesStep,
+    PenmanMonteithModel,
+    PenmanStep,
+    ReferenceFrame,
+    VWCPerZoneModel,
+    VWCReading,
+    VWCSystemModel,
+)
+
+
+class TestDeficit:
+    def test_zero_starts_a_zone_at_nothing(self):
+        deficit = Deficit.zero(ReferenceFrame.ET, source="lawn")
+        assert deficit.value_mm == 0.0
+        assert deficit.source == "lawn"
+
+    def test_clamped_bounds_both_ends(self):
+        assert Deficit(-5.0, ReferenceFrame.ET, d_max=100.0).clamped().value_mm == 0.0
+        assert Deficit(150.0, ReferenceFrame.ET, d_max=100.0).clamped().value_mm == 100.0
+
+    def test_with_value_does_not_clamp_on_its_own(self):
+        """The pair is deliberate: set, then clamp. Callers that want the box ask for it."""
+        assert Deficit.zero(ReferenceFrame.ET).with_value(150.0).value_mm == 150.0
+
+    def test_with_value_keeps_frame_and_source(self):
+        original = Deficit.zero(ReferenceFrame.VWC_PER_ZONE, source="probe-1")
+        moved = original.with_value(7.0)
+        assert moved.frame is ReferenceFrame.VWC_PER_ZONE
+        assert moved.source == "probe-1"
+
+    def test_projects_onto_an_area(self):
+        assert Deficit(10.0, ReferenceFrame.ET).as_liters(50.0) == 500.0
+
+    def test_is_immutable(self):
+        with pytest.raises(FrozenInstanceError):
+            Deficit(1.0, ReferenceFrame.ET).value_mm = 2.0
+
+
+class TestReferenceFrames:
+    """Comparability is the whole reason the frame travels with the number."""
+
+    def test_shared_frames_compare_by_frame_alone(self):
+        a = Deficit(10.0, ReferenceFrame.ET, source="lawn")
+        b = Deficit(20.0, ReferenceFrame.ET, source="roses")
+        assert a.is_comparable_to(b)
+
+    def test_different_frames_never_compare(self):
+        et = Deficit(10.0, ReferenceFrame.ET)
+        vwc = Deficit(10.0, ReferenceFrame.VWC_SYSTEM)
+        assert not et.is_comparable_to(vwc)
+
+    def test_two_zones_on_their_own_probes_are_not_comparable(self):
+        """Each measures a different patch of soil, so the numbers are not the same quantity."""
+        a = Deficit(10.0, ReferenceFrame.VWC_PER_ZONE, source="lawn")
+        b = Deficit(10.0, ReferenceFrame.VWC_PER_ZONE, source="roses")
+        assert not a.is_comparable_to(b)
+
+    def test_the_same_probe_compares_with_itself(self):
+        a = Deficit(10.0, ReferenceFrame.VWC_PER_ZONE, source="lawn")
+        b = Deficit(14.0, ReferenceFrame.VWC_PER_ZONE, source="lawn")
+        assert a.is_comparable_to(b)
+
+    def test_a_per_zone_deficit_without_a_source_compares_with_nothing(self):
+        a = Deficit(10.0, ReferenceFrame.VWC_PER_ZONE)
+        b = Deficit(10.0, ReferenceFrame.VWC_PER_ZONE)
+        assert not a.is_comparable_to(b)
+
+    def test_shared_flag_matches_the_frames(self):
+        assert ReferenceFrame.ET.is_shared
+        assert ReferenceFrame.VWC_SYSTEM.is_shared
+        assert not ReferenceFrame.VWC_PER_ZONE.is_shared
+
+
+class TestETModel:
+    def test_hourly_rate_matches_the_formula(self):
+        assert ETModel.et_hourly(20.0) == pytest.approx(DEFAULT_ALPHA * (20.0 - DEFAULT_T_BASE) / 24.0)
+
+    def test_cold_weather_produces_no_evaporation(self):
+        """Below the base temperature the rate floors at zero rather than going negative."""
+        assert ETModel.et_hourly(DEFAULT_T_BASE - 5.0) == 0.0
+
+    def test_integrates_over_time_and_kc(self):
+        model = ETModel(alpha=0.24, t_base=10.0, kc=1.0)
+        model.step(ETStep(dt_h=24.0, temp_c=20.0))
+        assert model.deficit.value_mm == pytest.approx(0.24 * (20.0 - 10.0) / 24.0 * 24.0)
+
+    def test_kc_scales_the_demand(self):
+        thirsty = ETModel(kc=1.0)
+        frugal = ETModel(kc=0.5)
+        thirsty.step(ETStep(dt_h=24.0, temp_c=25.0))
+        frugal.step(ETStep(dt_h=24.0, temp_c=25.0))
+        assert frugal.deficit.value_mm == pytest.approx(thirsty.deficit.value_mm / 2)
+
+    def test_rain_is_subtracted(self):
+        model = ETModel()
+        model.step(ETStep(dt_h=24.0, temp_c=25.0))
+        dry = model.deficit.value_mm
+        model.step(ETStep(dt_h=0.0, temp_c=25.0, rain_mm=2.0))
+        assert model.deficit.value_mm == pytest.approx(max(0.0, dry - 2.0))
+
+    def test_clamps_at_d_max(self):
+        model = ETModel(d_max=5.0)
+        model.step(ETStep(dt_h=1000.0, temp_c=35.0))
+        assert model.deficit.value_mm == 5.0
+
+    def test_reports_the_et_frame(self):
+        assert ETModel().reference_frame is ReferenceFrame.ET
+
+    def test_irrigation_reduces_the_deficit(self):
+        model = ETModel()
+        model.step(ETStep(dt_h=24.0, temp_c=30.0))
+        before = model.deficit.value_mm
+        model.apply_irrigation(1.0)
+        assert model.deficit.value_mm == pytest.approx(before - 1.0)
+
+    def test_reset_clears_it(self):
+        model = ETModel()
+        model.step(ETStep(dt_h=24.0, temp_c=30.0))
+        assert model.reset().value_mm == 0.0
+
+    def test_rejects_the_wrong_input_shape(self):
+        with pytest.raises(TypeError):
+            ETModel().step(VWCReading(vwc=0.2))
+
+
+class TestVWCSystemModel:
+    def test_deficit_is_read_from_the_probe(self):
+        model = VWCSystemModel(field_capacity=0.30, root_depth=0.30)
+        model.step(VWCReading(vwc=0.20))
+        assert model.deficit.value_mm == pytest.approx((0.30 - 0.20) * 0.30 * 1000)
+
+    def test_above_field_capacity_is_no_deficit(self):
+        model = VWCSystemModel(field_capacity=0.30, root_depth=0.30)
+        model.step(VWCReading(vwc=0.35))
+        assert model.deficit.value_mm == 0.0
+
+    def test_is_stateless_so_readings_do_not_accumulate(self):
+        """Two identical readings must not add up — the probe is the truth, not a tally."""
+        model = VWCSystemModel(field_capacity=0.30, root_depth=0.30)
+        model.step(VWCReading(vwc=0.20))
+        first = model.deficit.value_mm
+        model.step(VWCReading(vwc=0.20))
+        assert model.deficit.value_mm == first
+
+    def test_irrigation_is_a_no_op(self):
+        """A stateless probe reports the wetter soil on its own next reading."""
+        model = VWCSystemModel()
+        model.step(VWCReading(vwc=0.10))
+        before = model.deficit.value_mm
+        model.apply_irrigation(10.0)
+        assert model.deficit.value_mm == before
+
+    def test_reset_is_a_no_op(self):
+        model = VWCSystemModel()
+        model.step(VWCReading(vwc=0.10))
+        assert model.reset().value_mm == model.deficit.value_mm
+
+    def test_reports_a_shared_frame(self):
+        assert VWCSystemModel().reference_frame is ReferenceFrame.VWC_SYSTEM
+
+    def test_rejects_the_wrong_input_shape(self):
+        with pytest.raises(TypeError):
+            VWCSystemModel().step(ETStep(dt_h=1.0, temp_c=20.0))
+
+
+class TestVWCPerZoneModel:
+    def test_reports_a_per_zone_frame_carrying_its_source(self):
+        model = VWCPerZoneModel(source="lawn")
+        model.step(VWCReading(vwc=0.20))
+        assert model.reference_frame is ReferenceFrame.VWC_PER_ZONE
+        assert model.deficit.source == "lawn"
+
+    def test_computes_the_same_way_as_the_system_probe(self):
+        per_zone = VWCPerZoneModel(source="lawn", field_capacity=0.30, root_depth=0.30)
+        system = VWCSystemModel(field_capacity=0.30, root_depth=0.30)
+        per_zone.step(VWCReading(vwc=0.18))
+        system.step(VWCReading(vwc=0.18))
+        assert per_zone.deficit.value_mm == pytest.approx(system.deficit.value_mm)
+
+
+class TestHigherTiers:
+    """Sanity only: the point is that a tier is one rate behind a shared integrator."""
+
+    def test_hargreaves_needs_no_extra_sensor_and_gives_a_plausible_rate(self):
+        model = HargreavesModel(latitude_deg=45.0)
+        model.step(HargreavesStep(dt_h=24.0, tmax_c=30.0, tmin_c=15.0, day_of_year=196))
+        assert 0.0 < model.deficit.value_mm < 15.0
+
+    def test_hargreaves_grows_with_the_temperature_range(self):
+        narrow = HargreavesModel(latitude_deg=45.0)
+        wide = HargreavesModel(latitude_deg=45.0)
+        narrow.step(HargreavesStep(dt_h=24.0, tmax_c=24.0, tmin_c=20.0, day_of_year=196))
+        wide.step(HargreavesStep(dt_h=24.0, tmax_c=34.0, tmin_c=10.0, day_of_year=196))
+        assert wide.deficit.value_mm > narrow.deficit.value_mm
+
+    def test_penman_monteith_gives_a_plausible_summer_rate(self):
+        model = PenmanMonteithModel()
+        model.step(
+            PenmanStep(dt_h=24.0, temp_c=25.0, rh_pct=50.0, wind_m_s=2.0, net_radiation_mj=15.0),
+        )
+        assert 0.0 < model.deficit.value_mm < 15.0
+
+    def test_every_et_tier_shares_the_same_frame(self):
+        """The seam is the output: different inputs, one comparable quantity."""
+        assert ETModel().reference_frame is ReferenceFrame.ET
+        assert HargreavesModel(latitude_deg=45.0).reference_frame is ReferenceFrame.ET
+        assert PenmanMonteithModel().reference_frame is ReferenceFrame.ET

--- a/tests/test_zone_domain.py
+++ b/tests/test_zone_domain.py
@@ -1,0 +1,228 @@
+"""Tests for the domain Zone — the object behind IrrigationZoneSensor.
+
+Named ``test_zone_domain`` to keep it apart from the six ``test_zone_*`` files,
+which exercise the Home Assistant entity. This one is about the class that owns
+the deficit, and in particular about ``credit_delivery``: the single home of a
+formula that used to be written out at four call sites, two of which subtracted
+from a cycle snapshot and one from the live value.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from never_dry.water_balance_model import ReferenceFrame
+from never_dry.zone import CycleSoakRule, Delivery, Placement, WaterCounters, Zone
+
+AUG = datetime(2026, 8, 9, 7, 0)
+
+
+@dataclass
+class FakeDelivery:
+    """Anything that reports delivered litres can settle a zone."""
+
+    liters_delivered: float
+    elapsed_s: float = 0.0
+
+
+def make_zone(**kwargs) -> Zone:
+    defaults = {"name": "lawn", "area_m2": 100.0, "efficiency": 0.80}
+    return Zone(**{**defaults, **kwargs})
+
+
+class TestPlacement:
+    """The matrix that makes the categorical necessary."""
+
+    def test_only_outdoor_receives_rain(self):
+        assert Placement.OUTDOOR.receives_rain
+        assert not Placement.PATIO.receives_rain
+        assert not Placement.GREENHOUSE.receives_rain
+        assert not Placement.INDOOR.receives_rain
+
+    def test_patio_is_rainless_but_still_weather_driven(self):
+        """The row that justifies four values instead of a boolean.
+
+        A covered terrace feels the same heat and wind as the lawn, yet no rain
+        reaches it — so "receives rain" and "is outdoors" are independent.
+        """
+        assert not Placement.PATIO.receives_rain
+        assert Placement.PATIO.driven_by_outdoor_et
+
+    def test_indoor_is_neither(self):
+        assert not Placement.INDOOR.driven_by_outdoor_et
+
+    def test_default_placement_is_outdoor(self):
+        assert make_zone().placement is Placement.OUTDOOR
+
+
+class TestAccumulate:
+    def test_integrates_et_scaled_by_kc_and_exposure(self):
+        zone = make_zone(microclimate_factor=0.75)
+        zone.accumulate(dt_h=24.0, et_h=0.20, base_kc=0.805)
+        assert zone.deficit.value_mm == pytest.approx(0.20 * 24 * round(0.805 * 0.75, 4))
+
+    def test_credits_rain_outdoors(self):
+        zone = make_zone()
+        zone.accumulate(dt_h=24.0, et_h=0.5, base_kc=1.0)
+        zone.accumulate(dt_h=0.0, et_h=0.0, base_kc=1.0, rain_mm=5.0)
+        assert zone.deficit.value_mm == pytest.approx(7.0)
+
+    @pytest.mark.parametrize("placement", [Placement.PATIO, Placement.GREENHOUSE, Placement.INDOOR])
+    def test_withholds_rain_where_it_cannot_fall(self, placement):
+        """Crediting rain to a covered zone would silently under-water it."""
+        zone = make_zone(placement=placement)
+        zone.accumulate(dt_h=24.0, et_h=0.5, base_kc=1.0)
+        before = zone.deficit.value_mm
+        zone.accumulate(dt_h=0.0, et_h=0.0, base_kc=1.0, rain_mm=5.0)
+        assert zone.deficit.value_mm == before
+
+    def test_clamps_at_zero(self):
+        zone = make_zone()
+        zone.accumulate(dt_h=1.0, et_h=1.0, base_kc=1.0, rain_mm=99.0)
+        assert zone.deficit.value_mm == 0.0
+
+    def test_clamps_at_d_max(self):
+        zone = make_zone(d_max=10.0)
+        zone.accumulate(dt_h=100.0, et_h=1.0, base_kc=1.0)
+        assert zone.deficit.value_mm == 10.0
+
+    def test_effective_kc_applies_the_exposure_factor(self):
+        assert make_zone(microclimate_factor=0.75).effective_kc(0.80) == 0.60
+
+    def test_a_new_zone_starts_at_zero_in_the_et_frame(self):
+        """Reference model D4: no seeding from a shared reference."""
+        zone = make_zone()
+        assert zone.deficit.value_mm == 0.0
+        assert zone.deficit.frame is ReferenceFrame.ET
+        assert zone.deficit.source == "lawn"
+
+
+class TestWaterDemand:
+    def test_converts_mm_to_litres_over_the_area(self):
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(10.0)
+        assert zone.water_demand_l == pytest.approx(1250.0)
+
+    def test_zero_efficiency_is_not_a_division_error(self):
+        zone = make_zone(efficiency=0.0)
+        zone.deficit = zone.deficit.with_value(10.0)
+        assert zone.water_demand_l == 0.0
+
+    def test_needs_water_at_the_threshold(self):
+        zone = make_zone(threshold_mm=20.0)
+        zone.deficit = zone.deficit.with_value(20.0)
+        assert zone.needs_water
+
+    def test_does_not_need_water_below_it(self):
+        zone = make_zone(threshold_mm=20.0)
+        zone.deficit = zone.deficit.with_value(19.9)
+        assert not zone.needs_water
+
+    def test_delivered_mm_guards_a_zero_area(self):
+        assert make_zone(area_m2=0.0).delivered_mm(100.0) == 0.0
+
+
+class TestCrediting:
+    """The one formula. Its contract is that repeated credits do not double-count."""
+
+    def test_intermediate_credits_are_idempotent(self):
+        """A flow meter reports cumulative litres, so each credit is absolute.
+
+        500 then 1000 then 1500 must land where a single 1500 would, not 3000
+        below it.
+        """
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(24.0)
+        zone.begin_cycle()
+        for cumulative in (500.0, 1000.0, 1500.0):
+            zone.credit_delivery(FakeDelivery(cumulative))
+        assert zone.deficit.value_mm == pytest.approx(12.0)
+
+    def test_without_a_cycle_it_subtracts_from_the_current_value(self):
+        """The manual path opens no cycle; it must credit against the live deficit."""
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(24.0)
+        zone.credit_delivery(FakeDelivery(500.0))
+        zone.credit_delivery(FakeDelivery(500.0))
+        assert zone.deficit.value_mm == pytest.approx(16.0)
+
+    def test_over_delivery_clamps_at_zero(self):
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(4.0)
+        zone.credit_delivery(FakeDelivery(9999.0))
+        assert zone.deficit.value_mm == 0.0
+
+    def test_a_delivery_result_shape_satisfies_the_protocol(self):
+        assert isinstance(FakeDelivery(1.0, 2.0), Delivery)
+
+
+class TestSettleAndMark:
+    def test_settle_credits_stamps_and_closes_the_cycle(self):
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(24.0)
+        zone.begin_cycle()
+        zone.settle(FakeDelivery(1500.0, 900.0), source="schedule", at=AUG)
+        assert zone.deficit.value_mm == pytest.approx(12.0)
+        assert zone.counters.last_volume_l == 1500.0
+        assert zone.last_source == "schedule"
+        assert zone.last_irrigated == AUG
+        assert zone.last_duration_s == 900
+        assert zone.cycle_baseline_mm is None
+
+    def test_settling_twice_does_not_move_the_deficit_again(self):
+        """The snapshot is dropped on settle, so a repeat is not a second subtraction."""
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(24.0)
+        zone.begin_cycle()
+        zone.settle(FakeDelivery(500.0), source="schedule", at=AUG)
+        after_first = zone.deficit.value_mm
+        assert after_first == pytest.approx(20.0)
+
+    def test_mark_irrigated_clears_the_deficit_and_infers_the_volume(self):
+        """The hose case: nothing was measured, so the volume comes from the deficit."""
+        zone = make_zone(area_m2=100.0, efficiency=0.80)
+        zone.deficit = zone.deficit.with_value(10.0)
+        expected = zone.water_demand_l
+        zone.mark_irrigated(source="manual", at=AUG)
+        assert zone.deficit.value_mm == 0.0
+        assert zone.counters.last_volume_l == pytest.approx(round(expected, 1))
+        assert zone.last_source == "manual"
+
+
+class TestWaterCounters:
+    def test_credit_updates_every_total(self):
+        counters = WaterCounters()
+        counters.credit(120.0, year=2026)
+        assert counters.last_volume_l == 120.0
+        assert counters.session_water_l == 120.0
+        assert counters.total_water_l == 120.0
+        assert counters.yearly_water_l == 120.0
+
+    def test_lifetime_accumulates_while_last_is_replaced(self):
+        counters = WaterCounters()
+        counters.credit(100.0, year=2026)
+        counters.credit(50.0, year=2026)
+        assert counters.last_volume_l == 50.0
+        assert counters.total_water_l == 150.0
+
+    def test_yearly_rolls_over_but_lifetime_does_not(self):
+        counters = WaterCounters()
+        counters.credit(100.0, year=2026)
+        counters.credit(30.0, year=2027)
+        assert counters.yearly_water_l == 30.0
+        assert counters.total_water_l == 130.0
+
+    def test_reset_yearly_preserves_the_lifetime_total(self):
+        counters = WaterCounters()
+        counters.credit(100.0, year=2026)
+        counters.reset_yearly(year=2026)
+        assert counters.yearly_water_l == 0.0
+        assert counters.total_water_l == 100.0
+
+
+class TestCycleSoakRule:
+    def test_inactive_unless_both_halves_are_set(self):
+        assert not CycleSoakRule().is_active
+        assert not CycleSoakRule(max_segment_s=360).is_active
+        assert not CycleSoakRule(soak_s=900).is_active
+        assert CycleSoakRule(max_segment_s=360, soak_s=900).is_active


### PR DESCRIPTION
**Draft on purpose.** Four of the five modules here are inert — nothing imports them — and the one piece of real refactoring is deliberately behaviour-preserving. Opened to run CI, which this branch has never seen, and to make the work reviewable.

## What is here

**The five objects of the model now all have a module.** They were specified from the beginning — a row in the object table, a box in the class diagram, a named owner for every behaviour — and never typed out.

| Module | State |
|---|---|
| `zone.py` | new — owns the deficit, the crediting formula, `Placement`, per-zone `d_max` |
| `environment.py` | new — the site: declared sensor inventory + capability matching |
| `scheduler.py` | new — the *when*, extracted from two HA callbacks |
| `driver.py` | renamed from `actuator.py` (`Actuator`→`Driver` family) |
| `water_balance_model.py` | unchanged |

## The one behavioural change: anomaly A1, first move

`IrrigationZoneSensor` now holds a domain `Zone` and delegates its accounting to it. The thirteen private attributes survive as properties onto that object, so every existing reader — including 250 references across the test suite — is untouched.

The controller stops writing the deficit and calls methods: `begin_cycle()` where it snapshotted by hand, `credit_delivery()` at the three sites that spelled out `max(0, baseline - delivered*eff/area)`. **Private writes from the controller: 21 → 17.** The crediting formula now has one home.

Behaviour is preserved by construction, and the review-worthy part is *why*:
- the deficit setter does **not** clamp, because the plain attribute it replaces did not
- the VWC path that overwrites the deficit unconditionally is left **exactly** as it was — that defect is gated on an open design decision and is not this branch's business
- the manual path opens no cycle, so it credits against the current value exactly as before

## Tests

140 new, covering scaffolds that had none. `environment` and `scheduler` 0 → 100%, `zone` 71 → 100%, `water_balance_model` 61 → 98%. Package 76.8% → 81.7%. **976 green.**

They pin decisions rather than lines: scheduled mode ignores the threshold (AI-183), rain is credited only where it can fall, crediting is idempotent under cumulative flow-meter readings, two zones on their own probes are never comparable.

## Known gaps, stated rather than averaged away

- **`driver.py` is at 29.9%.** The pure half is covered; the async half — watchdog, adaptive timeouts, liveness probe — is not. That is where the valve-closure safety layers live, so it needs the mocked-hass harness before the driver is wired.
- **`docs/assets/domain_model_uml.svg` is stale**: it still shows `System` rather than `Environment`. The Mermaid source in the document is normative and current; the rendered image needs regenerating before publication.
- **Nothing is wired.** Phase 2 — wiring the models and the scheduler onto their call sites — is gated on the remaining half of A1 and on an open decision about who owns the water balance in soil-moisture mode.

## Not for merge yet

Review welcome on the shape, particularly `Zone` and the `Delivery` protocol seam that keeps `zone.py` free of Home Assistant.