### PR TITLE
fix: update every URL after the transfer to the never-dry organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,12 @@ First stable of the 0.11 line. Theme: **trust your water balance**.
 
 ---
 
-For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/drake69/NeverDry/releases) page.
+For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/never-dry/NeverDry/releases) page.
 
-[Unreleased]: https://github.com/drake69/NeverDry/compare/v0.11.0...HEAD
-[0.11.0]: https://github.com/drake69/NeverDry/releases/tag/v0.11.0
-[#146]: https://github.com/drake69/NeverDry/issues/146
-[#142]: https://github.com/drake69/NeverDry/pull/142
-[#139]: https://github.com/drake69/NeverDry/issues/139
-[#123]: https://github.com/drake69/NeverDry/issues/123
-[#116]: https://github.com/drake69/NeverDry/issues/116
+[Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.0
+[#146]: https://github.com/never-dry/NeverDry/issues/146
+[#142]: https://github.com/never-dry/NeverDry/pull/142
+[#139]: https://github.com/never-dry/NeverDry/issues/139
+[#123]: https://github.com/never-dry/NeverDry/issues/123
+[#116]: https://github.com/never-dry/NeverDry/issues/116

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ ET-based smart irrigation. Contributions of all kinds are welcome: bug reports,
 fixes, features, documentation, and help verifying the science.
 
 <!-- CI status — for contributors (user-facing trust badges live in README) -->
-[![Tests](https://github.com/drake69/NeverDry/actions/workflows/tests.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/tests.yml)
-[![codecov](https://codecov.io/gh/drake69/NeverDry/graph/badge.svg)](https://codecov.io/gh/drake69/NeverDry)
-[![HACS Validation](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/hacs.yml)
-[![Lint](https://github.com/drake69/NeverDry/actions/workflows/lint.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/lint.yml)
-[![Security](https://github.com/drake69/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/security.yml)
-[![Release](https://github.com/drake69/NeverDry/actions/workflows/release.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/release.yml)
+[![Tests](https://github.com/never-dry/NeverDry/actions/workflows/tests.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/never-dry/NeverDry/graph/badge.svg)](https://codecov.io/gh/never-dry/NeverDry)
+[![HACS Validation](https://github.com/never-dry/NeverDry/actions/workflows/hacs.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/hacs.yml)
+[![Lint](https://github.com/never-dry/NeverDry/actions/workflows/lint.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/lint.yml)
+[![Security](https://github.com/never-dry/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/security.yml)
+[![Release](https://github.com/never-dry/NeverDry/actions/workflows/release.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/release.yml)
 
 ## Ways to contribute
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **Smart irrigation for Home Assistant** — knows exactly when your garden needs water, calculates how long to run the valve, and makes sure it actually closes.
 
-[![Security](https://github.com/drake69/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/drake69/NeverDry/actions/workflows/security.yml)
+[![Security](https://github.com/never-dry/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/security.yml)
 [![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
-[![GitHub release](https://img.shields.io/github/v/release/drake69/NeverDry)](https://github.com/drake69/NeverDry/releases)
-[![Downloads](https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%29)](https://github.com/drake69/NeverDry/releases)
+[![GitHub release](https://img.shields.io/github/v/release/never-dry/NeverDry)](https://github.com/never-dry/NeverDry/releases)
+[![Downloads](https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%29)](https://github.com/never-dry/NeverDry/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![HA Community](https://img.shields.io/badge/Home%20Assistant-Community%20thread-41BDF5?logo=home-assistant&logoColor=white)](https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835)
 <!-- Active installs (Home Assistant analytics). Currently no data: `never_dry` is not yet listed
@@ -15,7 +15,7 @@
 -->
 
 
-If NeverDry is useful to you, **[leave a star](https://github.com/drake69/NeverDry/stargazers)** ⭐ — it helps others find the project.
+If NeverDry is useful to you, **[leave a star](https://github.com/never-dry/NeverDry/stargazers)** ⭐ — it helps others find the project.
 
 > 🌱 **Vision** — what NeverDry is for, and why: [`docs/VISION.md`](docs/VISION.md).
 > 🤝 **Want to contribute?** See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the [design notes](docs/design/README.md).
@@ -95,7 +95,7 @@ All sensors that carry a physical unit declare the proper HA `device_class` (e.g
 NeverDry ships a custom Lovelace card that shows everything about **one zone** at a glance. The card is bundled with the integration and **auto-registered** — no manual resource to add: after install it appears directly in the **"Add card"** picker as *NeverDry Zone Card*. Pick the zone in the card editor and you're done.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" width="320">
+  <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" width="320">
 </p>
 
 Each card groups a zone's entities by time horizon:
@@ -140,7 +140,7 @@ Each zone can be assigned a plant family with seasonal Kc values (northern hemis
 | Native ground cover | 0.25 | 0.45 | 0.55 | 0.35 |
 | Mixed garden (default) | 0.40 | 0.70 | 0.90 | 0.55 |
 
-You can also set a **manual Kc override** per zone (0.1–2.0) if you know the exact value. Not sure which Kc fits your setup? Use **[NeverDry Planner](https://drake69.github.io/neverdry-planner/)** to calculate the irrigated area and the right Kc to copy directly into NeverDry.
+You can also set a **manual Kc override** per zone (0.1–2.0) if you know the exact value. Not sure which Kc fits your setup? Use **[NeverDry Planner](https://never-dry.github.io/neverdry-planner/)** to calculate the irrigated area and the right Kc to copy directly into NeverDry.
 
 ## Site Exposure
 
@@ -168,7 +168,7 @@ The presets come from the landscape coefficient method (`K_L = k_s × k_d × k_m
 
 ### HACS (recommended)
 
-[![Open your Home Assistant instance and open NeverDry in HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration)
+[![Open your Home Assistant instance and open NeverDry in HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration)
 
 Or manually:
 
@@ -189,7 +189,7 @@ Or manually:
 
 **Via HACS**: HACS notifies you when a new version is available. Click **Update** and restart HA.
 
-**Manual**: Download the latest `never_dry.zip` from [Releases](https://github.com/drake69/NeverDry/releases), replace the `custom_components/never_dry/` folder, and restart HA.
+**Manual**: Download the latest `never_dry.zip` from [Releases](https://github.com/never-dry/NeverDry/releases), replace the `custom_components/never_dry/` folder, and restart HA.
 
 Your configuration and sensor history are preserved automatically. If the new version changes the config schema, settings are migrated seamlessly — no need to remove and re-add the integration.
 
@@ -221,7 +221,7 @@ NeverDry is configured entirely through the UI — no YAML required.
 | System type | Yes | — | Drip / micro-sprinkler / sprinkler / manual |
 | Efficiency | No | (from type) | Override distribution efficiency [0.1–1.0] |
 | Plant family | No | — | Sets seasonal Kc profile |
-| Custom Kc | No | — | Override Kc [0.1–2.0] — use [NeverDry Planner](https://drake69.github.io/neverdry-planner/) to estimate it |
+| Custom Kc | No | — | Override Kc [0.1–2.0] — use [NeverDry Planner](https://never-dry.github.io/neverdry-planner/) to estimate it |
 | Site exposure | No | Full sun, open | Sun/wind exposure preset — multiplies the Kc [0.60–1.20] |
 | Custom microclimate factor | Advanced only | — | Explicit exposure factor [0.1–1.5], used when exposure is *Advanced* |
 | Guard flow rate | For timer mode | — | Valve flow rate [L/min]. Required for timer-based zones; recommended for flow-meter and volume-dosing zones too, where it drives the expected duration and the safety-timeout scaling |
@@ -258,21 +258,21 @@ t    = V / FlowRate × 60                   [s]     irrigation duration
 
 - [User Manual](docs/user_manual.md)
 - [Developer Manual](docs/developer_manual.md)
-- [Project Homepage](https://drake69.github.io/NeverDry/)
+- [Project Homepage](https://never-dry.github.io/NeverDry/)
 
 ## Bugs & Feature Requests
 
 Found a bug or have an idea? Open an issue — reports from real gardens are what drive this project forward:
 
-- 🐛 **[Report a bug](https://github.com/drake69/NeverDry/issues/new?template=bug_report.md)** — include your HA version, NeverDry version, valve hardware, and the relevant `custom_components.never_dry` debug log lines
-- 💡 **[Request a feature](https://github.com/drake69/NeverDry/issues/new?template=feature_request.md)** — describe your irrigation setup and what you're trying to achieve
+- 🐛 **[Report a bug](https://github.com/never-dry/NeverDry/issues/new?template=bug_report.md)** — include your HA version, NeverDry version, valve hardware, and the relevant `custom_components.never_dry` debug log lines
+- 💡 **[Request a feature](https://github.com/never-dry/NeverDry/issues/new?template=feature_request.md)** — describe your irrigation setup and what you're trying to achieve
 - 💬 **[HA Community thread](https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835)** — for setup questions and general discussion
 
 ## Support
 
 NeverDry is free and open source. If it's useful to you, leave a star — it costs nothing and helps others find the project:
 
-<a href="https://github.com/drake69/NeverDry/stargazers"><img src="https://img.shields.io/badge/Star_on_GitHub-24292e?style=for-the-badge&logo=github&logoColor=white" alt="Star on GitHub" height="35"></a>
+<a href="https://github.com/never-dry/NeverDry/stargazers"><img src="https://img.shields.io/badge/Star_on_GitHub-24292e?style=for-the-badge&logo=github&logoColor=white" alt="Star on GitHub" height="35"></a>
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ If you discover a security vulnerability in NeverDry, **please do not open a pub
 
 Instead, report it privately:
 
-1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/drake69/NeverDry/security/advisories) and click **"Report a vulnerability"**
+1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/never-dry/NeverDry/security/advisories) and click **"Report a vulnerability"**
 2. **Email**: Send details to the repository owner via the email listed on the [GitHub profile](https://github.com/drake69)
 
 ### What to include

--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -12,9 +12,9 @@
     "http",
     "lovelace"
   ],
-  "documentation": "https://github.com/drake69/NeverDry",
+  "documentation": "https://github.com/never-dry/NeverDry",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/drake69/NeverDry/issues",
+  "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
   "version": "0.11.1-beta.3"
 }

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -730,7 +730,7 @@ if (!window.customCards.some((c) => c.type === "never-dry-zone-card")) {
     name: "NeverDry Zone Card",
     description: "All entities of one NeverDry irrigation zone in a clean layout.",
     preview: false,
-    documentationURL: "https://github.com/drake69/dryness_index",
+    documentationURL: "https://github.com/never-dry/NeverDry",
   });
 }
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,13 +22,13 @@ New contributors: see [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) first.
 **2. Direction (open for input)**
 - [`actuator-abstraction.md`](actuator-abstraction.md) — **Draft** proposal for
   the valve/actuator abstraction and controller orchestration (soak, master
-  pump). Discussion: [#74](https://github.com/drake69/NeverDry/issues/74).
+  pump). Discussion: [#74](https://github.com/never-dry/NeverDry/issues/74).
   *Status: Draft → Proposed (RFC) → Accepted (ADR).*
 - [`soil-moisture-model.md`](soil-moisture-model.md) — **Draft**: what a soil
   probe's reading is allowed to mean. Argues that "site-level" is not a physical
   category for soil, and documents a suspected defect in how the per-zone deficit
   is derived in VWC mode. Discussion:
-  [#126](https://github.com/drake69/NeverDry/issues/126).
+  [#126](https://github.com/never-dry/NeverDry/issues/126).
   *Status: Draft → Proposed (RFC) → Accepted (ADR).*
 
 **3. The science**

--- a/docs/design/field-test-checklist.md
+++ b/docs/design/field-test-checklist.md
@@ -413,7 +413,7 @@ debugging, into the project's `~/.code_reader/` inbox.
 7. **Bundle** all of the above (`home-assistant.log`, add-on log,
    diagnostics JSON, screenshot, notes) into a single `.zip`:
    - File name pattern: `neverdry_test_YYYYMMDD_HHMM_step.zip`.
-8. **Attach** the zip to a GitHub issue (`drake69/NeverDry/issues/new`)
+8. **Attach** the zip to a GitHub issue (`never-dry/NeverDry/issues/new`)
    with a title like *"Field test — step C.6 failure"*.
 
 ### CLI shortcut for power users

--- a/docs/design/soil-moisture-model.md
+++ b/docs/design/soil-moisture-model.md
@@ -1,7 +1,7 @@
 # Soil Moisture — Model of Use
 
 **Status:** Draft → Proposed (RFC) → Accepted (ADR). Currently **Draft**.
-**Discussion:** [#126](https://github.com/drake69/NeverDry/issues/126)
+**Discussion:** [#126](https://github.com/never-dry/NeverDry/issues/126)
 **Companions:** [`soil-sensors.md`](soil-sensors.md) (the *hardware*: reliability,
 selection, placement, wiring), [`scientific-model.md`](scientific-model.md) (the ET
 water balance), `design_domain_object_model.md` (where objects live).
@@ -212,7 +212,7 @@ they would actually buy. Both bear directly on this.
 
 ## 6. Contrast: why site exposure was free and this is not
 
-The per-zone site exposure factor ([#146](https://github.com/drake69/NeverDry/issues/146),
+The per-zone site exposure factor ([#146](https://github.com/never-dry/NeverDry/issues/146),
 merged) is a useful counter-example, and the contrast is what makes the criterion
 legible.
 
@@ -250,7 +250,7 @@ question as where the probe is.
 
 ## 8. What we need from the field
 
-These map to the numbered questions in [#126](https://github.com/drake69/NeverDry/issues/126).
+These map to the numbered questions in [#126](https://github.com/never-dry/NeverDry/issues/126).
 The suspected defect in §3 is confirmed or refuted by direct observation, without
 needing a lab reproduction.
 

--- a/docs/design/soil-sensors.md
+++ b/docs/design/soil-sensors.md
@@ -11,7 +11,7 @@ Companion: `scientific-model.md` (the ET model & references),
 > wire it. What a probe's reading is then allowed to *mean* — and why a
 > system-level probe cannot stand in for the whole garden — is a separate,
 > currently unsettled question: see [`soil-moisture-model.md`](soil-moisture-model.md)
-> (**Draft**, discussion [#126](https://github.com/drake69/NeverDry/issues/126)).
+> (**Draft**, discussion [#126](https://github.com/never-dry/NeverDry/issues/126)).
 
 ---
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell weiß, wann und wie lang Ihr Garten gegossen gehört. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Intelligente Bewässerung für Home Assistant">
     <meta property="og:description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell weiß, wann und wie lang Ihr Garten gegossen gehört. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/at.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/at.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Intelligente Bewässerung für Home Assistant">
     <meta name="twitter:description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell weiß, wann und wie lang Ihr Garten gegossen gehört. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "de-AT",
       "description": "NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell weiß, wann und wie lang Ihr Garten gegossen gehört. Das Ventil schließt immer. Ein-Klick-Installation über HACS.",
-      "url": "https://drake69.github.io/NeverDry/at.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/at.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligente Bew&auml;sserung f&uuml;r Home Assistant. A wissenschaftliches Wasserbilanzmodell, das wei&szlig;, wann und wie lang Ihr Garten gegossen geh&ouml;rt.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">In Home Assistant installieren</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Ein Klick &uuml;ber HACS &mdash; NeverDry ist im Standard-Repository.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Nutzen Sie es bereits? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
+        Nutzen Sie es bereits? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Direkt &uuml;ber HACS installieren &mdash; ein Klick:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Home Assistant &ouml;ffnen und NeverDry &uuml;ber HACS installieren." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuell</h3>
             <ol>
-                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
+                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
                 <li><code>custom_components/never_dry/</code> ins HA-Konfigurationsverzeichnis kopieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Integration &uuml;ber die Oberfl&auml;che hinzuf&uuml;gen</li>
@@ -254,13 +254,13 @@
     <h2>Projekt unterst&uuml;tzen</h2>
     <p>NeverDry ist kostenlos und quelloffen &mdash; der beste Weg, es zu unterst&uuml;tzen, ist ein Stern und Weitersagen:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Kennen Sie jemanden mit Garten und Home Assistant? Sagen Sie es weiter:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Diese &Uuml;bersetzung wurde automatisch erstellt. Beitr&auml;ge zur Verbesserung san herzlich willkommen —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">&ouml;ffne a Issue</a> oder schick an Pull Request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">&ouml;ffne a Issue</a> oder schick an Pull Request.
     </div>
 </section>
 

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell entscheidet, wann und wie lange Ihr Garten bewässert wird. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Intelligente Bewässerung für Home Assistant">
     <meta property="og:description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell entscheidet, wann und wie lange Ihr Garten bewässert wird. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/de.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/de.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Intelligente Bewässerung für Home Assistant">
     <meta name="twitter:description" content="NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell entscheidet, wann und wie lange Ihr Garten bewässert wird. Das Ventil schließt immer. Ein-Klick-Installation über HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "de",
       "description": "NeverDry ist die kostenlose Home-Assistant-Integration, die mit einem wissenschaftlichen FAO-56-Wasserbilanzmodell entscheidet, wann und wie lange Ihr Garten bewässert wird. Das Ventil schließt immer. Ein-Klick-Installation über HACS.",
-      "url": "https://drake69.github.io/NeverDry/de.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/de.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligente Bew&auml;sserung f&uuml;r Home Assistant. Ein wissenschaftliches Wasserbilanzmodell, das wei&szlig;, wann und wie lange Ihr Garten gegossen werden muss.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">In Home Assistant installieren</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Ein Klick &uuml;ber HACS &mdash; NeverDry ist im Standard-Repository.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentation</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Nutzen Sie es bereits? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
+        Nutzen Sie es bereits? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">vergeben Sie einen ⭐</a> damit andere es leichter finden.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Direkt &uuml;ber HACS installieren &mdash; ein Klick:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Home Assistant &ouml;ffnen und NeverDry &uuml;ber HACS installieren." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuell</h3>
             <ol>
-                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
+                <li>Neueste <code>never_dry.zip</code> von <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> herunterladen und entpacken</li>
                 <li><code>custom_components/never_dry/</code> in Ihr HA-Konfigurationsverzeichnis kopieren</li>
                 <li>Home Assistant neu starten</li>
                 <li>Integration &uuml;ber die Oberfl&auml;che hinzuf&uuml;gen</li>
@@ -254,13 +254,13 @@
     <h2>Projekt unterst&uuml;tzen</h2>
     <p>NeverDry ist kostenlos und quelloffen &mdash; der beste Weg, es zu unterst&uuml;tzen, ist ein Stern und Weitersagen:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Stern auf GitHub geben</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Kennen Sie jemanden mit Garten und Home Assistant? Sagen Sie es weiter:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Auf Facebook teilen</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Auf Reddit teilen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Auf X teilen</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Diese &Uuml;bersetzung wurde automatisch erstellt. Beitr&auml;ge zur Verbesserung sind herzlich willkommen —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">&ouml;ffne ein Issue</a> oder sende einen Pull Request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">&ouml;ffne ein Issue</a> oder sende einen Pull Request.
     </div>
 </section>
 

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry es la integración gratuita para Home Assistant que decide cuándo y cuánto regar tu jardín con un modelo científico de balance hídrico FAO-56. La válvula siempre se cierra. Instalación con un clic vía HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Riego Inteligente para Home Assistant">
     <meta property="og:description" content="NeverDry es la integración gratuita para Home Assistant que decide cuándo y cuánto regar tu jardín con un modelo científico de balance hídrico FAO-56. La válvula siempre se cierra. Instalación con un clic vía HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/es.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/es.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Riego Inteligente para Home Assistant">
     <meta name="twitter:description" content="NeverDry es la integración gratuita para Home Assistant que decide cuándo y cuánto regar tu jardín con un modelo científico de balance hídrico FAO-56. La válvula siempre se cierra. Instalación con un clic vía HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "es",
       "description": "NeverDry es la integración gratuita para Home Assistant que decide cuándo y cuánto regar tu jardín con un modelo científico de balance hídrico FAO-56. La válvula siempre se cierra. Instalación con un clic vía HACS.",
-      "url": "https://drake69.github.io/NeverDry/es.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/es.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Riego inteligente para Home Assistant. Un modelo cient&iacute;fico de balance h&iacute;drico que sabe cu&aacute;ndo y cu&aacute;nto tiempo regar tu jard&iacute;n.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Instalar en Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un clic v&iacute;a HACS &mdash; NeverDry est&aacute; en el repositorio por defecto.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentaci&oacute;n</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentaci&oacute;n</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        &iquest;Ya lo usas? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deja una &#11088;</a> para ayudar a otros a descubrirlo.
+        &iquest;Ya lo usas? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deja una &#11088;</a> para ayudar a otros a descubrirlo.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Instalar directamente desde HACS &mdash; un clic:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Abre tu instancia de Home Assistant e instala NeverDry desde HACS." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
-                <li>Descargar el &uacute;ltimo <code>never_dry.zip</code> desde <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> y extraerlo</li>
+                <li>Descargar el &uacute;ltimo <code>never_dry.zip</code> desde <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> y extraerlo</li>
                 <li>Copiar <code>custom_components/never_dry/</code> en el directorio config de HA</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>A&ntilde;adir la integraci&oacute;n desde la interfaz</li>
@@ -254,13 +254,13 @@
     <h2>Apoya el Proyecto</h2>
     <p>NeverDry es gratuito y de c&oacute;digo abierto &mdash; la mejor forma de apoyarlo es darle una estrella y correr la voz:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deja una estrella en GitHub</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Deja una estrella en GitHub</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">&iquest;Conoces a alguien con un jard&iacute;n y Home Assistant? Corre la voz:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Compartir en Facebook</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Compartir en Reddit</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Compartir en X</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Compartir en Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Compartir en Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Compartir en X</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Esta traducci&oacute;n fue generada autom&aacute;ticamente. Cualquier contribuci&oacute;n para mejorarla es bienvenida —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">abre un issue</a> o env&iacute;a un pull request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">abre un issue</a> o env&iacute;a un pull request.
     </div>
 </section>
 

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry est l'intégration gratuite pour Home Assistant qui décide quand et combien de temps arroser votre jardin grâce à un modèle scientifique de bilan hydrique FAO-56. La vanne se ferme toujours. Installation en un clic via HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Irrigation Intelligente pour Home Assistant">
     <meta property="og:description" content="NeverDry est l'intégration gratuite pour Home Assistant qui décide quand et combien de temps arroser votre jardin grâce à un modèle scientifique de bilan hydrique FAO-56. La vanne se ferme toujours. Installation en un clic via HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/fr.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/fr.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Irrigation Intelligente pour Home Assistant">
     <meta name="twitter:description" content="NeverDry est l'intégration gratuite pour Home Assistant qui décide quand et combien de temps arroser votre jardin grâce à un modèle scientifique de bilan hydrique FAO-56. La vanne se ferme toujours. Installation en un clic via HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "fr",
       "description": "NeverDry est l'intégration gratuite pour Home Assistant qui décide quand et combien de temps arroser votre jardin grâce à un modèle scientifique de bilan hydrique FAO-56. La vanne se ferme toujours. Installation en un clic via HACS.",
-      "url": "https://drake69.github.io/NeverDry/fr.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/fr.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irrigation intelligente pour Home Assistant. Un mod&egrave;le scientifique de bilan hydrique qui sait quand et combien de temps arroser votre jardin.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Installer dans Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un seul clic via HACS &mdash; NeverDry est dans le d&eacute;p&ocirc;t par d&eacute;faut.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Vous l'utilisez d&eacute;j&agrave;&nbsp;? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">laissez une ⭐</a> pour aider les autres &agrave; le d&eacute;couvrir.
+        Vous l'utilisez d&eacute;j&agrave;&nbsp;? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">laissez une ⭐</a> pour aider les autres &agrave; le d&eacute;couvrir.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Installer directement depuis HACS &mdash; un seul clic&nbsp;:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Ouvrez votre instance Home Assistant et installez NeverDry depuis HACS." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manuel</h3>
             <ol>
-                <li>T&eacute;l&eacute;charger le dernier <code>never_dry.zip</code> depuis <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> et l'extraire</li>
+                <li>T&eacute;l&eacute;charger le dernier <code>never_dry.zip</code> depuis <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> et l'extraire</li>
                 <li>Copier <code>custom_components/never_dry/</code> dans le r&eacute;pertoire config de HA</li>
                 <li>Red&eacute;marrer Home Assistant</li>
                 <li>Ajouter l'int&eacute;gration depuis l'interface</li>
@@ -254,13 +254,13 @@
     <h2>Soutenir le Projet</h2>
     <p>NeverDry est gratuit et open source &mdash; la meilleure fa&ccedil;on de le soutenir est de lui donner une &eacute;toile et d'en parler autour de vous&nbsp;:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Laissez une &eacute;toile sur GitHub</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Laissez une &eacute;toile sur GitHub</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Vous connaissez quelqu'un avec un jardin et Home Assistant&nbsp;? Faites passer le mot&nbsp;:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partager sur Facebook</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partager sur Reddit</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partager sur X</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partager sur Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partager sur Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partager sur X</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Cette traduction a &eacute;t&eacute; g&eacute;n&eacute;r&eacute;e automatiquement. Toute contribution pour l'am&eacute;liorer est la bienvenue —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">ouvrez une issue</a> ou envoyez une pull request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">ouvrez une issue</a> ou envoyez une pull request.
     </div>
 </section>
 

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry je besplatna integracija za Home Assistant koja pomoću znanstvenog FAO-56 modela vodne bilance odlučuje kada i koliko dugo zalijevati vaš vrt. Ventil se uvijek zatvara. Instalacija jednim klikom putem HACS-a.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Pametno Navodnjavanje za Home Assistant">
     <meta property="og:description" content="NeverDry je besplatna integracija za Home Assistant koja pomoću znanstvenog FAO-56 modela vodne bilance odlučuje kada i koliko dugo zalijevati vaš vrt. Ventil se uvijek zatvara. Instalacija jednim klikom putem HACS-a.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/hr.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/hr.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Pametno Navodnjavanje za Home Assistant">
     <meta name="twitter:description" content="NeverDry je besplatna integracija za Home Assistant koja pomoću znanstvenog FAO-56 modela vodne bilance odlučuje kada i koliko dugo zalijevati vaš vrt. Ventil se uvijek zatvara. Instalacija jednim klikom putem HACS-a.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "hr",
       "description": "NeverDry je besplatna integracija za Home Assistant koja pomoću znanstvenog FAO-56 modela vodne bilance odlučuje kada i koliko dugo zalijevati vaš vrt. Ventil se uvijek zatvara. Instalacija jednim klikom putem HACS-a.",
-      "url": "https://drake69.github.io/NeverDry/hr.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/hr.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Pametno navodnjavanje za Home Assistant. Znanstveni model vodne bilance koji zna kada i koliko dugo zalijevati va&scaron; vrt.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Instaliraj u Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Jedan klik putem HACS-a — NeverDry je u zadanom repozitoriju.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentacija</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokumentacija</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Ve&cacute; ga koristite? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">ostavite ⭐</a> kako bi ga drugi lak&scaron;e prona&scaron;li.
+        Ve&cacute; ga koristite? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">ostavite ⭐</a> kako bi ga drugi lak&scaron;e prona&scaron;li.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Instalirajte izravno putem HACS-a &mdash; jedan klik:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Otvorite svoju instancu Home Assistanta i instalirajte NeverDry putem HACS-a." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Ru&ccaron;no</h3>
             <ol>
-                <li>Preuzmite najnoviji <code>never_dry.zip</code> s <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> i raspakirajte ga</li>
+                <li>Preuzmite najnoviji <code>never_dry.zip</code> s <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> i raspakirajte ga</li>
                 <li>Kopirajte <code>custom_components/never_dry/</code> u HA config direktorij</li>
                 <li>Ponovo pokrenite Home Assistant</li>
                 <li>Dodajte integraciju iz su&ccaron;elja</li>
@@ -254,13 +254,13 @@
     <h2>Podr&zcaron;i Projekt</h2>
     <p>NeverDry je besplatan i otvorenog koda — najbolji na&ccaron;in da ga podr&zcaron;ite jest da mu dodijelite zvjezdicu i pro&scaron;irite glas:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Ostavite zvjezdicu na GitHubu</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Ostavite zvjezdicu na GitHubu</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Poznajete nekoga s vrtom i Home Assistantom? Pro&scaron;irite glas:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Podijeli na Facebooku</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Podijeli na Redditu</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Podijeli na X-u</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Podijeli na Facebooku</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Podijeli na Redditu</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Podijeli na X-u</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Ovaj prijevod je izra&dstrok;en automatski. Svaki doprinos za pobolj&scaron;anje je dobrodo&scaron;ao —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">otvori issue</a> ili po&scaron;alji pull request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">otvori issue</a> ili po&scaron;alji pull request.
     </div>
 </section>
 

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="A NeverDry ingyenes Home Assistant integráció, amely tudományos FAO-56 vízmérleg-modell alapján dönti el, mikor és mennyi ideig kell öntözni a kertet. A szelep mindig bezár. Telepítés egy kattintással a HACS-on keresztül.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Intelligens Öntözés a Home Assistant-hez">
     <meta property="og:description" content="A NeverDry ingyenes Home Assistant integráció, amely tudományos FAO-56 vízmérleg-modell alapján dönti el, mikor és mennyi ideig kell öntözni a kertet. A szelep mindig bezár. Telepítés egy kattintással a HACS-on keresztül.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/hu.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/hu.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Intelligens Öntözés a Home Assistant-hez">
     <meta name="twitter:description" content="A NeverDry ingyenes Home Assistant integráció, amely tudományos FAO-56 vízmérleg-modell alapján dönti el, mikor és mennyi ideig kell öntözni a kertet. A szelep mindig bezár. Telepítés egy kattintással a HACS-on keresztül.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "hu",
       "description": "A NeverDry ingyenes Home Assistant integráció, amely tudományos FAO-56 vízmérleg-modell alapján dönti el, mikor és mennyi ideig kell öntözni a kertet. A szelep mindig bezár. Telepítés egy kattintással a HACS-on keresztül.",
-      "url": "https://drake69.github.io/NeverDry/hu.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/hu.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Intelligens &ouml;nt&ouml;z&eacute;s a Home Assistant-hez. Tudom&aacute;nyos v&iacute;zm&eacute;rleg modell, amely tudja, mikor &eacute;s mennyi ideig kell &ouml;nt&ouml;zni a kertj&eacute;t.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Telep&iacute;t&eacute;s a Home Assistant-be</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Egy kattint&aacute;s a HACS-on kereszt&uuml;l — a NeverDry az alap&eacute;rtelmezett t&aacute;rol&oacute;ban tal&aacute;lhat&oacute;.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokument&aacute;ci&oacute;</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Dokument&aacute;ci&oacute;</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        M&aacute;r haszn&aacute;lod? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">adj egy ⭐-ot</a>, hogy m&aacute;sok is r&aacute;tal&aacute;ljanak.
+        M&aacute;r haszn&aacute;lod? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">adj egy ⭐-ot</a>, hogy m&aacute;sok is r&aacute;tal&aacute;ljanak.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Telep&iacute;t&eacute;s k&ouml;zvetlen&uuml;l HACS-b&oacute;l &mdash; egy kattint&aacute;s:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Nyissa meg a Home Assistant p&eacute;ld&aacute;ny&aacute;t, &eacute;s telep&iacute;tse a NeverDry-t HACS-b&oacute;l." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manu&aacute;lis</h3>
             <ol>
-                <li>A legfrissebb <code>never_dry.zip</code> let&ouml;lt&eacute;se a <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> oldalr&oacute;l &eacute;s kicsomagol&aacute;sa</li>
+                <li>A legfrissebb <code>never_dry.zip</code> let&ouml;lt&eacute;se a <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> oldalr&oacute;l &eacute;s kicsomagol&aacute;sa</li>
                 <li><code>custom_components/never_dry/</code> m&aacute;sol&aacute;sa a HA config k&ouml;nyvt&aacute;rba</li>
                 <li>Home Assistant &uacute;jraind&iacute;t&aacute;sa</li>
                 <li>Integr&aacute;ci&oacute; hozz&aacute;ad&aacute;sa a fel&uuml;letr&odblac;l</li>
@@ -254,13 +254,13 @@
     <h2>T&aacute;mogasd a Projektet</h2>
     <p>A NeverDry ingyenes &eacute;s ny&iacute;lt forr&aacute;s&uacute; — a legjobb t&aacute;mogat&aacute;s, ha csillagot adsz neki &eacute;s tov&aacute;bbadod a h&iacute;r&eacute;t:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Adj csillagot a GitHubon</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Adj csillagot a GitHubon</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Ismersz valakit, akinek kertje &eacute;s Home Assistant-je van? Add tov&aacute;bb a h&iacute;r&eacute;t:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Megoszt&aacute;s Facebookon</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Megoszt&aacute;s Redditen</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Megoszt&aacute;s X-en</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Megoszt&aacute;s Facebookon</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Megoszt&aacute;s Redditen</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Megoszt&aacute;s X-en</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Ez a ford&iacute;t&aacute;s automatikusan k&eacute;sz&uuml;lt. Sz&iacute;vesen fogadunk minden hozz&aacute;j&aacute;rul&aacute;st a jav&iacute;t&aacute;s&aacute;hoz —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">nyiss egy issue-t</a> vagy k&uuml;ldj egy pull requestet.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">nyiss egy issue-t</a> vagy k&uuml;ldj egy pull requestet.
     </div>
 </section>
 

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry is a free Home Assistant integration that decides when and how long to water your garden with a scientific FAO-56 water-balance model — and guarantees the valve always closes. One-click install via HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Smart Irrigation for Home Assistant">
     <meta property="og:description" content="NeverDry is a free Home Assistant integration that decides when and how long to water your garden with a scientific FAO-56 water-balance model — and guarantees the valve always closes. One-click install via HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Smart Irrigation for Home Assistant">
     <meta name="twitter:description" content="NeverDry is a free Home Assistant integration that decides when and how long to water your garden with a scientific FAO-56 water-balance model — and guarantees the valve always closes. One-click install via HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "en",
       "description": "NeverDry is a free Home Assistant integration that decides when and how long to water your garden with a scientific FAO-56 water-balance model — and guarantees the valve always closes. One-click install via HACS.",
-      "url": "https://drake69.github.io/NeverDry/",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -87,18 +87,18 @@
 
 <!-- Hero -->
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Your garden tells you when it's thirsty. NeverDry listens — and makes sure the valve always closes.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/security.yml?label=security&style=flat-square" alt="Security">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/security.yml?label=security&style=flat-square" alt="Security">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
         <a href="https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835"><img src="https://img.shields.io/badge/support-HA%20Community-41BDF5?style=flat-square&logo=home-assistant&logoColor=white" alt="HA Community support"></a>
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Install in Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">One click via HACS — NeverDry is in the default repository.</div>
@@ -112,12 +112,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentation</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Already using it? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">leave a ⭐</a> to help others find it.
+        Already using it? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">leave a ⭐</a> to help others find it.
     </div>
 </section>
 
@@ -192,7 +192,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -205,7 +205,7 @@
             1 mm of deficit = 1 litre of water needed per square metre
         </div>
         <p>When the deficit crosses your threshold, NeverDry opens the valve for exactly as long as needed to fill it back up. When it rains, the deficit drops automatically. After irrigation, it resets. Plants that drink more in summer get a higher multiplier — so the lawn and the lavender each get the right amount, without any manual adjustment.</p>
-        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;">For the technically curious, the full water balance formula is in the <a href="https://github.com/drake69/NeverDry#scientific-background">README</a>.</p>
+        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;">For the technically curious, the full water balance formula is in the <a href="https://github.com/never-dry/NeverDry#scientific-background">README</a>.</p>
     </div>
 </section>
 
@@ -232,7 +232,7 @@
         </table>
         <p style="margin-top: 1.5em; text-align: center; font-size: 0.95em; opacity: 0.85;">
             Want a more detailed drip irrigation setup?
-            Use <a href="https://drake69.github.io/neverdry-planner/" style="color: #2196F3; font-weight: 600;">NeverDry Planner</a>
+            Use <a href="https://never-dry.github.io/neverdry-planner/" style="color: #2196F3; font-weight: 600;">NeverDry Planner</a>
             to calculate the irrigated area and the Kc value to copy directly into NeverDry.
         </p>
     </div>
@@ -245,7 +245,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Install directly from HACS — one click:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration" data-vmtrc="InstallClicked" data-vmtrc-location="install-section">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration" data-vmtrc="InstallClicked" data-vmtrc-location="install-section">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open your Home Assistant instance and open NeverDry in HACS." height="48">
                 </a>
             </div>
@@ -258,7 +258,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
-                <li>Download the latest <code>never_dry.zip</code> from <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> and extract it</li>
+                <li>Download the latest <code>never_dry.zip</code> from <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> and extract it</li>
                 <li>Copy <code>custom_components/never_dry/</code> to your HA config directory</li>
                 <li>Restart Home Assistant</li>
                 <li>Add the integration from the UI</li>
@@ -277,7 +277,7 @@
             <li><strong>Deficit settles on delivery timeout</strong> — if the flow sensor reads zero while the valve is actually watering, the delivered volume is now estimated from the configured flow rate, so the deficit no longer stays stuck (and irrigation no longer repeats endlessly).</li>
             <li><strong>Config sanity guards</strong> — unusual zone values (area below 5 m², flow rate below 10 L/h or above 1800 L/h — usually a L/min vs L/h mix-up) now ask for confirmation before saving, and a new "Check configured zones" menu entry audits existing zones.</li>
         </ul>
-        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/drake69/NeverDry/releases/tag/v0.10.9">Full release notes on GitHub →</a></p>
+        <p style="margin-top: 1.5em; font-size: 0.9em; opacity: 0.7;"><a href="https://github.com/never-dry/NeverDry/releases/tag/v0.10.9">Full release notes on GitHub →</a></p>
         <details style="max-width: 680px; margin: 1.5em auto 0; text-align: left; opacity: 0.7; font-size: 0.9em;">
             <summary style="cursor: pointer;">v0.10.8 — 2026-07-04</summary>
             <ul style="line-height: 2; margin-top: 0.5em;">
@@ -327,7 +327,7 @@
     <h2>Get Help</h2>
     <p style="margin-bottom: 1.5em;">Questions about setup or behaviour? Join the conversation.</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/issues">🐛 GitHub Issues</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/issues">🐛 GitHub Issues</a>
         <a class="kofi-btn" style="background: #03a9f4;" href="https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835">💬 HA Community</a>
     </div>
 </section>
@@ -337,13 +337,13 @@
     <h2>Support the Project</h2>
     <p>NeverDry is free and open source — the best way to support it is to star it and spread the word:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Star on GitHub</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Star on GitHub</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Know someone with a garden and Home Assistant? Spread the word:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Share on Facebook</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Share on Reddit</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Share on X</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Share on Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Share on Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Share on X</a>
     </div>
 </section>
 

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry è l'integrazione gratuita per Home Assistant che decide quando e quanto irrigare il giardino con un modello scientifico di bilancio idrico FAO-56. La valvola si chiude sempre. Installazione in un clic via HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Irrigazione Intelligente per Home Assistant">
     <meta property="og:description" content="NeverDry è l'integrazione gratuita per Home Assistant che decide quando e quanto irrigare il giardino con un modello scientifico di bilancio idrico FAO-56. La valvola si chiude sempre. Installazione in un clic via HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/it.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/it.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Irrigazione Intelligente per Home Assistant">
     <meta name="twitter:description" content="NeverDry è l'integrazione gratuita per Home Assistant che decide quando e quanto irrigare il giardino con un modello scientifico di bilancio idrico FAO-56. La valvola si chiude sempre. Installazione in un clic via HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "it",
       "description": "NeverDry è l'integrazione gratuita per Home Assistant che decide quando e quanto irrigare il giardino con un modello scientifico di bilancio idrico FAO-56. La valvola si chiude sempre. Installazione in un clic via HACS.",
-      "url": "https://drake69.github.io/NeverDry/it.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/it.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irrigazione intelligente per Home Assistant. Un modello scientifico di bilancio idrico che decide quando e quanto irrigare in base al fabbisogno reale del giardino.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Installa in Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Un solo clic tramite HACS — NeverDry &egrave; nel repository predefinito.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentazione</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documentazione</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        Lo usi gi&agrave;? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">lascia una ⭐</a> per aiutare altri a scoprirlo.
+        Lo usi gi&agrave;? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">lascia una ⭐</a> per aiutare altri a scoprirlo.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Installa direttamente da HACS — un solo clic:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Apri Home Assistant e installa NeverDry da HACS." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Installazione manuale</h3>
             <ol>
-                <li>Scarica l'ultima versione di <code>never_dry.zip</code> dalla pagina <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> ed estraila</li>
+                <li>Scarica l'ultima versione di <code>never_dry.zip</code> dalla pagina <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> ed estraila</li>
                 <li>Copia la cartella <code>custom_components/never_dry/</code> nella directory di configurazione di Home Assistant.</li>
                 <li>Riavvia Home Assistant.</li>
                 <li>Aggiungi l'integrazione dall'interfaccia.</li>
@@ -254,13 +254,13 @@
     <h2>Sostieni il progetto</h2>
     <p>NeverDry &egrave; gratuito e open source — il modo migliore per sostenerlo &egrave; mettere una stella e farlo conoscere:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Lascia una stella su GitHub</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Lascia una stella su GitHub</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Conosci qualcuno con un giardino e Home Assistant? Fai girare la voce:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Condividi su Facebook</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Condividi su Reddit</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Condividi su X</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Condividi su Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Condividi su Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Condividi su X</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Questa pagina &egrave; tradotta in italiano. Per segnalazioni o miglioramenti puoi
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">aprire una issue</a> o inviare una pull request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">aprire una issue</a> o inviare una pull request.
     </div>
 </section>
 

--- a/docs/gh-pages/llms.txt
+++ b/docs/gh-pages/llms.txt
@@ -6,14 +6,14 @@ NeverDry maintains a per-zone soil water deficit: `D(t) = D(t-1) + ETh × Kc × 
 
 ## Documentation
 
-- [User manual](https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md): installation, zone setup, plant families, irrigation modes.
-- [README](https://github.com/drake69/NeverDry/blob/main/README.md): feature overview, screenshots, quick start.
-- [Landing page](https://drake69.github.io/NeverDry/): product overview (multilingual: EN, IT, DE, AT, ES, FR, PT, HR, HU).
+- [User manual](https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md): installation, zone setup, plant families, irrigation modes.
+- [README](https://github.com/never-dry/NeverDry/blob/main/README.md): feature overview, screenshots, quick start.
+- [Landing page](https://never-dry.github.io/NeverDry/): product overview (multilingual: EN, IT, DE, AT, ES, FR, PT, HR, HU).
 
 ## Source & distribution
 
-- [GitHub repository](https://github.com/drake69/NeverDry): full source, issues, releases (MIT license).
-- [Install via HACS](https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration): one-click install; NeverDry is in the HACS default repository.
+- [GitHub repository](https://github.com/never-dry/NeverDry): full source, issues, releases (MIT license).
+- [Install via HACS](https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration): one-click install; NeverDry is in the HACS default repository.
 
 ## Scientific basis
 

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -17,23 +17,23 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="description" content="NeverDry é a integração gratuita para Home Assistant que decide quando e por quanto tempo regar o seu jardim com um modelo científico de balanço hídrico FAO-56. A válvula fecha sempre. Instalação num clique via HACS.">
     <meta name="robots" content="index, follow, max-image-preview:large">
-    <link rel="canonical" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/">
-    <link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html">
-    <link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html">
-    <link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html">
-    <link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html">
-    <link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html">
-    <link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html">
-    <link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html">
-    <link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html">
-    <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/">
+    <link rel="canonical" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/">
+    <link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html">
+    <link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html">
+    <link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html">
+    <link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html">
+    <link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html">
+    <link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html">
+    <link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html">
+    <link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html">
+    <link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="NeverDry">
     <meta property="og:title" content="NeverDry — Irrigação Inteligente para Home Assistant">
     <meta property="og:description" content="NeverDry é a integração gratuita para Home Assistant que decide quando e por quanto tempo regar o seu jardim com um modelo científico de balanço hídrico FAO-56. A válvula fecha sempre. Instalação num clique via HACS.">
-    <meta property="og:url" content="https://drake69.github.io/NeverDry/pt.html">
-    <meta property="og:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta property="og:url" content="https://never-dry.github.io/NeverDry/pt.html">
+    <meta property="og:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="NeverDry — smart irrigation for Home Assistant">
@@ -49,7 +49,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="NeverDry — Irrigação Inteligente para Home Assistant">
     <meta name="twitter:description" content="NeverDry é a integração gratuita para Home Assistant que decide quando e por quanto tempo regar o seu jardim com um modelo científico de balanço hídrico FAO-56. A válvula fecha sempre. Instalação num clique via HACS.">
-    <meta name="twitter:image" content="https://drake69.github.io/NeverDry/social-card.png">
+    <meta name="twitter:image" content="https://never-dry.github.io/NeverDry/social-card.png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -59,10 +59,10 @@
       "operatingSystem": "Home Assistant",
       "inLanguage": "pt",
       "description": "NeverDry é a integração gratuita para Home Assistant que decide quando e por quanto tempo regar o seu jardim com um modelo científico de balanço hídrico FAO-56. A válvula fecha sempre. Instalação num clique via HACS.",
-      "url": "https://drake69.github.io/NeverDry/pt.html",
-      "downloadUrl": "https://github.com/drake69/NeverDry",
-      "softwareHelp": "https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md",
-      "license": "https://github.com/drake69/NeverDry/blob/main/LICENSE",
+      "url": "https://never-dry.github.io/NeverDry/pt.html",
+      "downloadUrl": "https://github.com/never-dry/NeverDry",
+      "softwareHelp": "https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md",
+      "license": "https://github.com/never-dry/NeverDry/blob/main/LICENSE",
       "author": { "@type": "Person", "name": "drake69", "url": "https://github.com/drake69" },
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
     }
@@ -85,18 +85,18 @@
 </nav>
 
 <section class="hero">
-    <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
+    <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/custom_components/never_dry/brand/icon.png" alt="NeverDry" width="84" height="84" style="margin-bottom: 0.1em;">
     <h1>NeverDry</h1>
     <p class="tagline">Irriga&ccedil;&atilde;o inteligente para Home Assistant. Um modelo cient&iacute;fico de balan&ccedil;o h&iacute;drico que sabe quando e por quanto tempo regar o seu jardim.</p>
     <div class="badges">
-        <img src="https://img.shields.io/github/actions/workflow/status/drake69/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
-        <img src="https://img.shields.io/codecov/c/github/drake69/NeverDry?style=flat-square" alt="Coverage">
-        <img src="https://img.shields.io/github/v/release/drake69/NeverDry?style=flat-square" alt="Release">
-        <img src="https://img.shields.io/github/downloads/drake69/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
+        <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
+        <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
+        <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>
     <!-- Primary CTA: one-click HACS install (moved up from the Install section, 2026-07-22) -->
-    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration"
+    <a class="cta" href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration"
        data-vmtrc="InstallClicked" data-vmtrc-location="hero"
        style="font-size: 1.2em; padding: 14px 40px;">Instalar no Home Assistant</a>
     <div style="margin-top: 0.6em; font-size: 0.9em; opacity: 0.8;">Um clique via HACS &mdash; o NeverDry est&aacute; no reposit&oacute;rio predefinido.</div>
@@ -110,12 +110,12 @@
 
     <!-- Secondary links -->
     <div style="margin-top: 1.6em;">
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
-        <a class="cta secondary" href="https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documenta&ccedil;&atilde;o</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry" data-vmtrc="GitHubClicked" data-vmtrc-location="hero">GitHub</a>
+        <a class="cta secondary" href="https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md" data-vmtrc="DocsClicked" data-vmtrc-location="hero">Documenta&ccedil;&atilde;o</a>
     </div>
 
     <div style="margin-top: 1.1em; font-size: 0.8em; opacity: 0.6;">
-        J&aacute; o utiliza? <a href="https://github.com/drake69/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deixe uma ⭐</a> para ajudar outros a encontr&aacute;-lo.
+        J&aacute; o utiliza? <a href="https://github.com/never-dry/NeverDry/stargazers" data-vmtrc="StarClicked" data-vmtrc-location="hero" style="color: white; text-decoration: underline;">deixe uma ⭐</a> para ajudar outros a encontr&aacute;-lo.
     </div>
 </section>
 
@@ -183,7 +183,7 @@
         <h2 style="text-align: center; font-size: 2em; margin-bottom: 0.5em; color: var(--accent);">See every zone at a glance</h2>
         <p style="max-width: 700px; margin: 1em auto; text-align: center;">NeverDry ships a custom Lovelace card &mdash; <strong>auto-registered</strong> on install, with no resource to add. It shows up in the &ldquo;Add card&rdquo; picker as <em>NeverDry Zone Card</em>: choose a zone to see its valve status, deficit vs threshold, next and last session, totals, parameters, and action buttons &mdash; all in one place.</p>
         <p style="text-align: center; margin-top: 1.5em;">
-            <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
+            <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" style="max-width: 300px; width: 100%; border-radius: 14px; box-shadow: 0 6px 20px rgba(0,0,0,0.18);">
         </p>
     </div>
 </section>
@@ -228,7 +228,7 @@
         <div class="install-steps">
             <div style="text-align: center; margin-bottom: 2em; padding: 24px; background: var(--accent-light); border-radius: 12px;">
                 <p style="font-size: 1.05em; margin-bottom: 1em; font-weight: 600;">Instalar diretamente pelo HACS &mdash; um clique:</p>
-                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=drake69&repository=NeverDry&category=integration">
+                <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=never-dry&repository=NeverDry&category=integration">
                     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Abra sua inst&acirc;ncia do Home Assistant e instale o NeverDry pelo HACS." height="48">
                 </a>
             </div>
@@ -241,7 +241,7 @@
             </ol>
             <h3 style="margin-top: 1.5em;">Manual</h3>
             <ol>
-                <li>Descarregar o &uacute;ltimo <code>never_dry.zip</code> em <a href="https://github.com/drake69/NeverDry/releases/latest">Releases</a> e extrair</li>
+                <li>Descarregar o &uacute;ltimo <code>never_dry.zip</code> em <a href="https://github.com/never-dry/NeverDry/releases/latest">Releases</a> e extrair</li>
                 <li>Copiar <code>custom_components/never_dry/</code> para o diret&oacute;rio config do HA</li>
                 <li>Reiniciar Home Assistant</li>
                 <li>Adicionar a integra&ccedil;&atilde;o pela interface</li>
@@ -254,13 +254,13 @@
     <h2>Apoie o Projeto</h2>
     <p>O NeverDry &eacute; gratuito e de c&oacute;digo aberto &mdash; a melhor forma de o apoiar &eacute; dar-lhe uma estrela e espalhar a palavra:</p>
     <div style="display: flex; gap: 1em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/drake69/NeverDry/stargazers">&#11088; Deixe uma estrela no GitHub</a>
+        <a class="kofi-btn" style="background: #24292e;" href="https://github.com/never-dry/NeverDry/stargazers">&#11088; Deixe uma estrela no GitHub</a>
     </div>
     <p style="margin-top: 1.8em; margin-bottom: 0.8em; opacity: 0.8;">Conhece algu&eacute;m com um jardim e Home Assistant? Espalhe a palavra:</p>
     <div style="display: flex; gap: 0.8em; justify-content: center; flex-wrap: wrap;">
-        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partilhar no Facebook</a>
-        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partilhar no Reddit</a>
-        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fdrake69.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partilhar no X</a>
+        <a class="kofi-btn" style="background: #1877F2; padding: 10px 22px; font-size: 1em;" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="facebook">Partilhar no Facebook</a>
+        <a class="kofi-btn" style="background: #FF4500; padding: 10px 22px; font-size: 1em;" href="https://www.reddit.com/submit?url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F&title=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="reddit">Partilhar no Reddit</a>
+        <a class="kofi-btn" style="background: #111111; padding: 10px 22px; font-size: 1em;" href="https://twitter.com/intent/tweet?text=NeverDry%20%E2%80%94%20smart%20irrigation%20for%20Home%20Assistant%20(FAO-56%20water%20balance)&url=https%3A%2F%2Fnever-dry.github.io%2FNeverDry%2F" target="_blank" rel="noopener" data-vmtrc="ShareClicked" data-vmtrc-network="x">Partilhar no X</a>
     </div>
 </section>
 
@@ -286,7 +286,7 @@
 <section style="background: var(--accent-light); padding: 16px 20px; text-align: center; font-size: 0.85em; color: #555;">
     <div class="container">
         Esta tradu&ccedil;&atilde;o foi gerada automaticamente. Qualquer contribui&ccedil;&atilde;o para melhor&aacute;-la &eacute; bem-vinda —
-        <a href="https://github.com/drake69/NeverDry/issues" style="color: var(--accent);">abra uma issue</a> ou envie um pull request.
+        <a href="https://github.com/never-dry/NeverDry/issues" style="color: var(--accent);">abra uma issue</a> ou envie um pull request.
     </div>
 </section>
 

--- a/docs/gh-pages/robots.txt
+++ b/docs/gh-pages/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt — NeverDry landing (https://drake69.github.io/NeverDry/)
+# robots.txt — NeverDry landing (https://never-dry.github.io/NeverDry/)
 # Explicit crawler policy (PRODUCT_BLUEPRINT §4.2):
 # NeverDry is a free, open-source project that WANTS discovery and citation,
 # so search crawlers AND AI/GEO crawlers are allowed on purpose.
@@ -22,4 +22,4 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
-Sitemap: https://drake69.github.io/NeverDry/sitemap.xml
+Sitemap: https://never-dry.github.io/NeverDry/sitemap.xml

--- a/docs/gh-pages/sitemap.xml
+++ b/docs/gh-pages/sitemap.xml
@@ -2,120 +2,120 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://drake69.github.io/NeverDry/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/it.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/it.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/de.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/de.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/at.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/at.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/es.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/es.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/fr.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/fr.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/pt.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/pt.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/hr.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/hr.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
   <url>
-    <loc>https://drake69.github.io/NeverDry/hu.html</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/NeverDry/"/>
-    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/NeverDry/it.html"/>
-    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/NeverDry/de.html"/>
-    <xhtml:link rel="alternate" hreflang="de-AT" href="https://drake69.github.io/NeverDry/at.html"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/NeverDry/es.html"/>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/NeverDry/fr.html"/>
-    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/NeverDry/pt.html"/>
-    <xhtml:link rel="alternate" hreflang="hr" href="https://drake69.github.io/NeverDry/hr.html"/>
-    <xhtml:link rel="alternate" hreflang="hu" href="https://drake69.github.io/NeverDry/hu.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/NeverDry/"/>
+    <loc>https://never-dry.github.io/NeverDry/hu.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://never-dry.github.io/NeverDry/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://never-dry.github.io/NeverDry/it.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://never-dry.github.io/NeverDry/de.html"/>
+    <xhtml:link rel="alternate" hreflang="de-AT" href="https://never-dry.github.io/NeverDry/at.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://never-dry.github.io/NeverDry/es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://never-dry.github.io/NeverDry/fr.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://never-dry.github.io/NeverDry/pt.html"/>
+    <xhtml:link rel="alternate" hreflang="hr" href="https://never-dry.github.io/NeverDry/hr.html"/>
+    <xhtml:link rel="alternate" hreflang="hu" href="https://never-dry.github.io/NeverDry/hu.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://never-dry.github.io/NeverDry/"/>
   </url>
 </urlset>

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -643,7 +643,7 @@ HACS checks for new releases automatically. You will see a notification in the H
 
 ### Manual update
 
-1. Download the latest release from [GitHub Releases](https://github.com/drake69/NeverDry/releases)
+1. Download the latest release from [GitHub Releases](https://github.com/never-dry/NeverDry/releases)
 2. Extract `never_dry.zip`
 3. Replace the contents of `config/custom_components/never_dry/` with the new files
 4. Restart Home Assistant
@@ -656,7 +656,7 @@ HACS checks for new releases automatically. You will see a notification in the H
 
 ### Version history
 
-Check the [GitHub Releases](https://github.com/drake69/NeverDry/releases) page for detailed release notes, including new features, bug fixes, and any breaking changes.
+Check the [GitHub Releases](https://github.com/never-dry/NeverDry/releases) page for detailed release notes, including new features, bug fixes, and any breaking changes.
 
 ## 12. Calibration guide
 
@@ -709,7 +709,7 @@ No manual seasonal adjustment is needed. If you find the model significantly ove
 NeverDry bundles a custom Lovelace card that shows everything about **one zone** at a glance. It is installed with the integration and **auto-registered** — you do **not** need to add a Lovelace resource manually. After install (and a browser refresh) it appears in the **"Add card"** picker as *NeverDry Zone Card*; open the card editor, pick the zone, and save.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/drake69/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" width="320">
+  <img src="https://raw.githubusercontent.com/never-dry/NeverDry/main/docs/assets/zone-card.png" alt="NeverDry Zone Card" width="320">
 </p>
 
 The card groups the zone's entities by time horizon:

--- a/info.md
+++ b/info.md
@@ -20,5 +20,5 @@ NeverDry is a custom integration that calculates a real-time **soil water defici
 
 ### Links
 
-- [User Manual](https://github.com/drake69/NeverDry/blob/main/docs/user_manual.md)
-- [Project Homepage](https://drake69.github.io/NeverDry/)
+- [User Manual](https://github.com/never-dry/NeverDry/blob/main/docs/user_manual.md)
+- [Project Homepage](https://never-dry.github.io/NeverDry/)


### PR DESCRIPTION
The repository moved to the `never-dry` organisation. Repository URLs redirect; **GitHub Pages does not**.

`https://drake69.github.io/NeverDry/` returns **404** as of now, and `https://never-dry.github.io/NeverDry/` returns 200. So every link to the landing page was already broken, including the ones the landing page makes about itself.

## What was actually damaging

- `index.html` declared `<link rel="canonical">` and nine `hreflang` alternates pointing at a URL that 404s
- `sitemap.xml` listed **99** dead URLs

A search engine drops a page whose canonical does not resolve. This was live damage to positioning work already done, not a tidiness issue.

## What was functional

Twenty one-click install badges carried `owner=drake69&repository=NeverDry` — that parameter is what tells `my.home-assistant.io` which repository to open in HACS.

## Scope

24 files, in every form the old owner appeared: plain URLs, `raw.githubusercontent.com`, shields.io paths, and the **percent-encoded** copies inside the Facebook/Reddit/X share buttons, which a pass over plain text does not catch.

`neverdry-planner` moved to the organisation as well, so its three links follow.

## Deliberately left alone

The `@drake69` codeowner in the manifest, and the profile links in the credits, `SECURITY.md` and the schema.org author block. Those are the person, not the repository.

## Unrelated fix while passing

The Lovelace card pointed its `documentationURL` at `drake69/dryness_index`, the project's former name — a 404 independently of this move.

836 tests green, every touched JSON still valid.