### PR TITLE
ci: bump github/codeql-action to v4.37.6 (init + analyze together)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:python"


### PR DESCRIPTION
Supersedes #156 and #157.

Dependabot opens one PR per action path, so #156 raised `analyze` and #157 raised `init` — each leaving the workflow with the two halves on different versions, which is the one combination CodeQL refuses to run. Both were red for that reason alone, not because of v4.37.6 itself.

This raises both lines to the same SHA (`5595ccaf`, the commit behind tag v4.37.6, verified upstream), so CI checks the actual pair before merge. Same fix as #154.

Closes #156
Closes #157