### PR TITLE
release: bump version to 0.11.1-beta.4

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.3"
+  "version": "0.11.1-beta.4"
 }


### PR DESCRIPTION
Beta of the 0.11.1 line carrying the first wired step of the domain object model (#155): the zone deficit acquires a single writer.

`IrrigationZoneSensor` builds a domain `Zone` and delegates the deficit and the water counters to it. The controller stops writing the deficit at the four sites that used to spell out `max(0, baseline - delivered * eff / area)` by hand. The other four domain modules ship in the package but are inert — nothing imports driver, scheduler or environment, so the valve is still driven by `valve_operator.py`. This beta changes who owns the accounting, not who opens the valve.

Also carries the organisation URLs in manifest and zone card (still pointing at the old owner after the transfer) and the codeql-action back-merge from main (#162).

**Field-tested before tagging.** The branch ran on a real installation for 16 hours across all four zones. A scheduled zone irrigated on real water: deficit 3.58 → 0.0 mm, 58.4 L delivered against 58.3 expected, yearly counter 5361.4 → 5419.8 L, valve closed, FSM back to idle, error log clean.

One thing this bump fixes on its own: the installed manifest was still reporting beta.3 while other code was running, so diagnostics were misreporting the version.

Version bump only.