### PR TITLE
ci: group dependabot action bumps into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # One PR for all action bumps, not one per action path. Without this,
+    # actions that must stay on the SAME version get split across PRs and
+    # each one lands half the pair: codeql-action/init and /analyze on
+    # different versions is the one combination CodeQL refuses to run, so
+    # both PRs go red on arrival and have to be re-done by hand. That
+    # happened twice in a single day (#154, #161) before this group existed.
+    # The wildcard also covers any future setup/use pair, which is the same
+    # trap wearing different clothes.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci"
     labels:


### PR DESCRIPTION
Closes the cause behind #154 and #161.

Dependabot opens one PR per action path. For actions that must stay pinned to the **same** version that is not noise, it is a broken build: `codeql-action/init` and `codeql-action/analyze` arriving in separate PRs leaves each one carrying half the pair, and a mismatched pair is the one combination CodeQL refuses to run. Both PRs land red and neither is mergeable as-is.

It was fixed by hand twice in a single day — #154 for v4.37.4, #161 for v4.37.6 — because both times only the symptom was addressed. Three lines of config address the cause:

```yaml
groups:
  github-actions:
    patterns: ["*"]
```

The wildcard also covers any future setup/use pair, which is the same trap wearing different clothes.

**Trade-off, accepted deliberately:** grouping means one misbehaving action blocks the whole group PR rather than only its own. With this few actions that is the cheaper of the two failures — and the current failure mode costs a hand-written PR every time.

Config only: dependabot.yml is read by Dependabot on the default branch, nothing in CI consumes it, so no workflow behaviour changes with this merge.