### PR TITLE
release: bump version to 0.11.1-beta.5

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.4"
+  "version": "0.11.1-beta.5"
 }


### PR DESCRIPTION
Beta of the 0.11.1 line carrying #168 (one rule for the three preset/override pairs) and #167 (an override can be cleared again, #165).

**What testers will notice**

- Each of the three preset dropdowns — system type, plant family, site exposure — now has a **Custom** entry, and the box beside it is used *only* when Custom is selected. Pick a preset and your value is not applied, and the form tells you so on save.
- Choosing Custom and leaving the box empty is refused.
- The efficiency field is a box instead of a slider, with step 0.01, and can be cleared. Previously an accidental slider move was permanent (#165).
- The zone form is grouped into three collapsible sections: ground and location, valve and pipe, scheduling.

**What does not change: how anyone's garden is watered.** Migration 2 → 3 marks as Custom every zone whose own value was already in force, so the same number stays in charge. Only the configuration becomes explicit about it.

**Minimum Home Assistant is now 2024.6** — collapsible sections need it.

Version bump only. The code has been running on a live four-zone installation since the previous day: entry migrated, zones unchanged, Kc identical, error log clean.