### PR TITLE
fix(sensor): a probe reporting percentages no longer silences a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zone Kc sensor attributes `kc_base`, `exposure` and `microclimate_factor`, so an effective Kc can be traced back to the curve and the factor it came from.
 
 ### Fixed
+- Soil-moisture probes reporting a **percentage** no longer stop a zone from watering ([#170]). A reading of 45 rather than 0.45 made `(field_capacity − vwc)` negative for every possible value — including a bone-dry 15 % — and the clamp that keeps a deficit from going negative pinned it at exactly zero, silently and forever. Readings are now normalised at the input boundary: above 1 is read as a percentage, exactly 1.0 as a saturated fraction. Consumer probes (Ecowitt, most Zigbee models) work without a template-sensor helper.
+- A moisture reading that is not a water content on either scale — a raw ADC count, a negative, a NaN — is now refused instead of being clamped to "saturated": the last good deficit is held and one warning is logged, naming the sensor.
 - Imperial units in the config flow and displays ([#139]):
   - Zone threshold help text no longer hardcodes "(mm)" — the field label already shows the user's unit (mm or in).
   - Deficit, threshold and ET sensors now declare a display precision, so imperial users see meaningful decimals instead of values rounded to whole inches.
@@ -55,6 +57,7 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/never
 
 [Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.0
+[#170]: https://github.com/never-dry/NeverDry/issues/170
 [#146]: https://github.com/never-dry/NeverDry/issues/146
 [#142]: https://github.com/never-dry/NeverDry/pull/142
 [#139]: https://github.com/never-dry/NeverDry/issues/139

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -105,6 +105,7 @@ from .const import (
 from .controller import IrrigationController
 from .services import async_setup_services
 from .unit_convert import LPM_TO_GPH, LPM_TO_LPH
+from .water_balance_model import vwc_to_fraction
 from .zone import Zone as DomainZone
 
 _LOGGER = logging.getLogger(__name__)
@@ -682,6 +683,10 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
         self._yearly_rain: float = 0.0
         self._yearly_rain_year: int = datetime.now().year
         self._temp_buffer = SensorBuffer(ET_BUFFER_SIZE, valid_range=ET_TEMP_VALID_RANGE)
+        # One warning per condition, not one per poll: a probe reporting
+        # percentages does so at every reading, and an unreadable one likewise.
+        self._vwc_percent_warned = False
+        self._vwc_invalid_warned = False
         if device_info:
             self._attr_device_info = device_info
 
@@ -825,17 +830,51 @@ class DrynessIndexSensor(SensorEntity, RestoreEntity):
             listener(dt_h, et_h, rain)
 
     def _update_from_vwc(self) -> None:
-        """Update deficit from direct VWC measurement."""
+        """Update deficit from direct VWC measurement.
+
+        The probe's reading is normalised to a ``[0, 1]`` fraction before it
+        meets ``field_capacity`` (see :func:`vwc_to_fraction`): a percentage
+        left unconverted drives the bracket negative for every reading and the
+        clamp below silently pins the deficit at zero forever (GH #170).
+        """
         vwc_state = self._hass.states.get(self._vwc_sensor)
         if vwc_state is None:
             return
         try:
-            vwc = float(vwc_state.state)
-            self._deficit = max(0.0, (self._field_cap - vwc) * self._root_depth * 1000)
+            raw = float(vwc_state.state)
         except (ValueError, TypeError):
             # VWC sensor not yet numeric (boot / unavailable):
             # keep the previous self._deficit unchanged.
-            pass
+            return
+
+        vwc = vwc_to_fraction(raw)
+        if vwc is None:
+            # Not a water content on any scale (raw ADC count, negative, NaN).
+            # Refusing it keeps the last good deficit instead of asserting a
+            # saturated soil we have no evidence for.
+            if not self._vwc_invalid_warned:
+                self._vwc_invalid_warned = True
+                _LOGGER.warning(
+                    "VWC sensor '%s' reported %s, which is not a volumetric water content "
+                    "on either scale (expected 0-1 or 0-100). Reading ignored, deficit held "
+                    "at its last value. If the sensor exposes a raw count, it needs "
+                    "calibration before NeverDry can read it",
+                    self._vwc_sensor,
+                    raw,
+                )
+            return
+
+        if raw > 1.0 and not self._vwc_percent_warned:
+            self._vwc_percent_warned = True
+            _LOGGER.warning(
+                "VWC sensor '%s' reports percentages (%s); reading it as %.3f. "
+                "No action needed — logged once so the conversion is visible",
+                self._vwc_sensor,
+                raw,
+                vwc,
+            )
+
+        self._deficit = max(0.0, (self._field_cap - vwc) * self._root_depth * 1000)
 
     def _compute_rain_delta(self) -> float:
         """Compute rain increment since last reading.

--- a/custom_components/never_dry/water_balance_model.py
+++ b/custom_components/never_dry/water_balance_model.py
@@ -37,8 +37,11 @@ References: ``docs/design_water_balance_reference_model.md`` (D1-D5, reference
 frames), ``docs/design_domain_object_model.md`` (the domain classes),
 GH #123 (the deficit reference-frame bug this model makes impossible).
 
-**Phase 1 — inert scaffold.** Nothing imports this module yet; wiring
-``DrynessIndexSensor`` / the per-zone loop onto it is a deliberate later phase.
+**Phase 1 — mostly inert scaffold.** The models themselves are not wired yet:
+``zone.py`` imports the :class:`Deficit` value object and ``sensor.py`` imports
+:func:`vwc_to_fraction`, but ``DrynessIndexSensor`` / the per-zone loop still
+compute their own deficit. Wiring them onto the models is a deliberate later
+phase.
 """
 
 from __future__ import annotations
@@ -222,10 +225,49 @@ class VWCReading:
     """One reading for a VWC model: the current volumetric water content.
 
     ``vwc`` is a volumetric fraction in ``[0, 1]`` (e.g. ``0.22`` = 22 %),
-    directly comparable to ``field_capacity``.
+    directly comparable to ``field_capacity``. Readings coming from a real
+    sensor must pass through :func:`vwc_to_fraction` first — that is where the
+    invariant is established, not here.
     """
 
     vwc: float
+
+
+def vwc_to_fraction(value: float) -> float | None:
+    """Normalise one raw soil-moisture reading to a VWC fraction, or reject it.
+
+    Consumer probes report percentages almost by definition (Ecowitt, most
+    Zigbee models): 45 rather than 0.45. Fed straight into
+    ``(field_capacity - vwc)``, a percentage makes the bracket negative for
+    *every* possible reading — even a bone-dry 15 % — and the clamp to zero
+    then hides it: the deficit sits at 0 forever and the zone never waters, in
+    silence (GH #170).
+
+    A reading above 1 is unambiguously a percentage. There is no soil whose
+    volumetric water content exceeds 1: soils saturate around 0.5 and peat
+    below 0.9, so the value disambiguates itself and no new setting is needed.
+    Exactly ``1.0`` is read as a fraction (fully saturated), not as 1 %, since
+    the latter is not a state soil can be in.
+
+    What remains outside ``[0, 1]`` after that conversion is **not a VWC** at
+    all — a raw ADC count (Ecowitt exposes 70..500), a negative, a NaN — and is
+    rejected rather than clamped. Clamping 310 to 1.0 would assert "saturated"
+    about a probe that is not measuring water content, which is the same
+    silence this function exists to remove. The caller keeps its previous
+    deficit and warns.
+
+    Note this is a safety net at the boundary, not a sensor model: it cannot
+    tell a *calibrated* percentage from an uncalibrated one. Mapping a probe's
+    own scale onto real VWC is two-point calibration, a separate concern.
+
+    Returns the fraction, or ``None`` when the reading cannot be one.
+    """
+    if math.isnan(value) or math.isinf(value):
+        return None
+    fraction = value / 100.0 if value > 1.0 else value
+    if not 0.0 <= fraction <= 1.0:
+        return None
+    return fraction
 
 
 # Union of everything a model's :meth:`WaterBalanceModel.step` may accept.

--- a/docs/design/soil-moisture-model.md
+++ b/docs/design/soil-moisture-model.md
@@ -214,6 +214,32 @@ NeverDry today expects a *fraction* (0–1) while these probes report a *percent
 factor of 100 at the input boundary, not a calibration question, and it is fixable on
 its own.
 
+### The scale question, settled at the boundary ([#170](https://github.com/never-dry/NeverDry/issues/170))
+
+It turned out not to be an inconvenience. `(field_capacity − vwc)` with a percentage
+in it is negative for *every* reading a probe can produce — a bone-dry 15 % gives
+`0.30 − 15` — and the clamp that keeps a deficit from going negative then pins it at
+exactly zero. **The zone never waters, and nothing says so.** The clamp is right in
+itself, and that is precisely what makes it a good hiding place: without it the value
+would read −13410 and the cause would be obvious in seconds.
+
+The rule now lives in `vwc_to_fraction()` (`water_balance_model.py`), applied by
+`sensor.py` before the reading meets `field_capacity`:
+
+- **above 1 → divide by 100.** No soil holds more than 1 of volumetric water content
+  — soils saturate near 0.5, peat below 0.9 — so the value disambiguates itself and
+  the user is asked nothing.
+- **exactly 1.0 → a fraction.** Saturation is a state soil can be in; 1 % is not.
+- **still outside [0, 1] afterwards → refused, not clamped.** A raw ADC count
+  (Ecowitt exposes 70..500), a negative, a NaN: none of these is a water content on
+  any scale. The reading is dropped, the last good deficit is held, and one warning
+  is logged. Clamping 310 to 1.0 would assert a soaked soil on no evidence — the same
+  silence this fix exists to remove.
+
+This is a safety net, **not a sensor model**. It cannot distinguish a calibrated
+percentage from an uncalibrated one, so it settles the scale and leaves §4 — what the
+number is worth once it is on the right scale — exactly where it was.
+
 ## 5. Which model is in charge — **the decision this document exists to force**
 
 Everything above is about *where* a probe is. This section is about something
@@ -316,4 +342,5 @@ needing a lab reproduction.
 | Date | Change |
 |---|---|
 | 2026-08-08 | Initial draft. Written after the per-zone site exposure review (#147) surfaced the question of where a microclimate correction belongs, which in turn exposed the soil-probe model. Pending field input on #126. |
+| 2026-08-13 | The scale question of §4 is settled and shipped: readings are normalised to a fraction at the boundary, and anything that is not a water content on either scale is refused rather than clamped (#170). It changes nothing about §4 or §5 — a probe now reads on the right scale, which says nothing yet about what its number is worth or who owns the deficit. |
 | 2026-08-10 | Field input arrived on #126 and is recorded in §4. It confirms the unit-mismatch hypothesis and names its mechanism (factory calibration against dry air and open water, neither of which is a soil state), reports the probe depth (~8 cm against a fixed 0.30 m root depth), and proposes a two-point calibration — recorded as the fallback to observing the drainage plateau, not as the primary answer. The percentage-vs-fraction input scale (#150) is called out as a separate, smaller problem. Status stays **Draft**: §5, the decision this document exists to force, is still open. |

--- a/tests/test_never_dry_sensor.py
+++ b/tests/test_never_dry_sensor.py
@@ -1,5 +1,6 @@
 """Tests for DrynessIndexSensor — cumulative soil water deficit."""
 
+import logging
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -209,6 +210,96 @@ class TestVWCMode:
 
         sensor._on_sensor_change(MagicMock())
         assert sensor._deficit == 0.0
+
+    def _vwc_sensor(self, hass_mock, field_capacity=0.30, root_depth=0.30):
+        """A DrynessIndexSensor in VWC mode with an explicit FC/root depth."""
+        from never_dry.const import (
+            CONF_FIELD_CAPACITY,
+            CONF_RAIN_SENSOR,
+            CONF_ROOT_DEPTH,
+            CONF_TEMP_SENSOR,
+            CONF_VWC_SENSOR,
+        )
+        from never_dry.sensor import DrynessIndexSensor
+
+        return DrynessIndexSensor(
+            hass_mock,
+            {
+                CONF_TEMP_SENSOR: "sensor.temperature",
+                CONF_RAIN_SENSOR: "sensor.rain",
+                CONF_VWC_SENSOR: "sensor.vwc",
+                CONF_FIELD_CAPACITY: field_capacity,
+                CONF_ROOT_DEPTH: root_depth,
+            },
+        )
+
+    def test_vwc_percentage_reading_waters_the_zone(self, hass_mock, make_state):
+        """Regression for #170: a probe reporting 15 % must read as 0.15, not 15.
+
+        Unconverted, ``(0.30 - 15)`` is negative for every reading a probe can
+        produce, the clamp pins the deficit at 0, and the zone never waters —
+        with no error and no log line.
+        """
+        sensor = self._vwc_sensor(hass_mock)
+
+        hass_mock.states.get.return_value = make_state(15.0)  # 15 %, bone dry
+        sensor._on_sensor_change(MagicMock())
+
+        # (0.30 - 0.15) * 0.30 * 1000 = 45 mm — not 0.
+        assert sensor._deficit == pytest.approx(45.0, abs=0.1)
+
+    def test_vwc_percentage_above_field_capacity_is_zero(self, hass_mock, make_state):
+        """45 % is wetter than a 0.30 field capacity: no deficit, and rightly so."""
+        sensor = self._vwc_sensor(hass_mock)
+
+        hass_mock.states.get.return_value = make_state(45.0)
+        sensor._on_sensor_change(MagicMock())
+
+        assert sensor._deficit == 0.0
+
+    def test_vwc_of_exactly_one_is_saturation(self, hass_mock, make_state):
+        """1.0 is a saturated fraction, not 1 % — the latter is not a soil state."""
+        sensor = self._vwc_sensor(hass_mock)
+
+        hass_mock.states.get.return_value = make_state(1.0)
+        sensor._on_sensor_change(MagicMock())
+
+        assert sensor._deficit == 0.0
+
+    def test_vwc_hundred_percent_is_saturation(self, hass_mock, make_state):
+        """100 normalises to a full 1.0, so a soaked probe reads as soaked."""
+        sensor = self._vwc_sensor(hass_mock)
+
+        hass_mock.states.get.return_value = make_state(100.0)
+        sensor._on_sensor_change(MagicMock())
+
+        assert sensor._deficit == 0.0
+
+    @pytest.mark.parametrize("reading", [310.0, 500.0, 101.0, -5.0, float("nan")])
+    def test_unreadable_probe_holds_the_last_deficit(self, hass_mock, make_state, reading):
+        """A raw ADC count is not a water content: hold, do not clamp to saturated.
+
+        Clamping 310 to 1.0 would assert a soaked soil on no evidence and stop
+        the zone watering — the very failure #170 is about.
+        """
+        sensor = self._vwc_sensor(hass_mock)
+        sensor._deficit = 12.0
+
+        hass_mock.states.get.return_value = make_state(reading)
+        sensor._on_sensor_change(MagicMock())
+
+        assert sensor._deficit == 12.0
+
+    def test_percentage_conversion_is_logged_once(self, hass_mock, make_state, caplog):
+        """The user must be able to see the conversion — once, not at every poll."""
+        sensor = self._vwc_sensor(hass_mock)
+        hass_mock.states.get.return_value = make_state(15.0)
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.never_dry.sensor"):
+            sensor._on_sensor_change(MagicMock())
+            sensor._on_sensor_change(MagicMock())
+
+        assert sum("reports percentages" in r.message for r in caplog.records) == 1
 
     def test_vwc_mode_accrues_yearly_rain_after_rain(self, hass_mock, make_state):
         """Regression for issue #144 — 'Yearly Rain always 0 in VWC mode'.

--- a/tests/test_water_balance_model.py
+++ b/tests/test_water_balance_model.py
@@ -23,7 +23,34 @@ from never_dry.water_balance_model import (
     VWCPerZoneModel,
     VWCReading,
     VWCSystemModel,
+    vwc_to_fraction,
 )
+
+
+class TestVWCToFraction:
+    """The boundary rule that keeps a percentage from silencing a zone (GH #170)."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (0.22, 0.22),  # already a fraction — untouched
+            (0.0, 0.0),  # bone dry
+            (45.0, 0.45),  # the Ecowitt case: a percentage
+            (15.0, 0.15),  # dry, and still a percentage
+            (100.0, 1.0),  # saturated, expressed as a percentage
+        ],
+    )
+    def test_reads_both_scales(self, raw, expected):
+        assert vwc_to_fraction(raw) == pytest.approx(expected)
+
+    def test_exactly_one_is_saturation_not_one_percent(self):
+        """1.0 is a fraction: soil cannot sit at 1 % water content, but it can saturate."""
+        assert vwc_to_fraction(1.0) == 1.0
+
+    @pytest.mark.parametrize("raw", [310.0, 500.0, 101.0, -5.0, -0.1, float("nan"), float("inf")])
+    def test_rejects_what_is_not_a_water_content(self, raw):
+        """Raw ADC counts and negatives are refused, never clamped into a lie."""
+        assert vwc_to_fraction(raw) is None
 
 
 class TestDeficit:


### PR DESCRIPTION
Closes #170.

`(field_capacity - vwc)` with a percentage in it is negative for every reading a probe can produce — a bone-dry 15 % gives `0.30 - 15` — and the clamp that keeps a deficit from going negative pins it at exactly zero. **The zone never waters, and nothing says so.** The clamp is right in itself, which is what makes it such a good hiding place: without it the value would read −13410 and the cause would be obvious in seconds.

This affects anyone using a soil probe, since consumer probes report percentages almost by definition (Ecowitt, most Zigbee models). It was first reported as a minor inconvenience — needing a template sensor to divide by 100 — in discussion #150.

## The rule

`vwc_to_fraction()` lives next to the model that declares the `[0, 1]` invariant rather than at the call site, so the later wiring phase cannot lose it:

- **above 1 → a percentage.** No soil holds more than 1 of volumetric water content: soils saturate near 0.5, peat below 0.9. The value disambiguates itself and the user is asked nothing.
- **exactly 1.0 → a fraction.** Saturation is a state soil can be in; 1 % is not.
- **still outside [0, 1] afterwards → refused, not clamped.** A raw ADC count (Ecowitt exposes 70..500), a negative, a NaN. The last good deficit is held and one warning names the sensor. Clamping 310 to 1.0 would assert a soaked soil on no evidence — the same silence this fix removes.

One warning per condition, not per poll: a probe on the wrong scale is on the wrong scale at every reading.

## Scope

This settles the input scale and nothing else. It cannot tell a calibrated percentage from an uncalibrated one — that is two-point calibration, still open with the field capacity work in #126.

## Verification

- 6 new tests on the live sensor path (percentage waters the zone, 1.0 is saturation, 310 / 500 / 101 / −5 / NaN hold the last deficit, the conversion logs once) and a parametrised suite on the pure rule.
- Full suite: 1053 passed. `ruff format --check` and `ruff check` clean.
- Design note recorded in `docs/design/soil-moisture-model.md` §4, with the boundary rule and why it is not a substitute for calibration.