### PR TITLE
fix(config_flow): the zone form shows labels again, not raw keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zone Kc sensor attributes `kc_base`, `exposure` and `microclimate_factor`, so an effective Kc can be traced back to the curve and the factor it came from.
 
 ### Fixed
+- Zone form fields showed their raw key instead of a label — `area_m2`, `flow_rate_lpm`, `plant_family` and every other field inside the three collapsible sections, in all languages including translated ones. Grouping the form into sections moved where Home Assistant looks a label up (`sections.<section>.data.<field>`), and the labels stayed at the step level where nothing reads them. Fields whose key happens to read like a word (`valve`, `name`) hid how widespread it was. The strings themselves were always there and are unchanged.
 - Imperial units in the config flow and displays ([#139]):
   - Zone threshold help text no longer hardcodes "(mm)" — the field label already shows the user's unit (mm or in).
   - Deficit, threshold and ET sensors now declare a display precision, so imperial users see meaningful decimals instead of values rounded to whole inches.

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -27,54 +27,66 @@
         "title": "Add irrigation zone",
         "description": "Configure zone #{zone_count}. You can add more zones after this.",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch (optional)",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency (overrides system type default)",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc (overrides plant family)",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Valve flow rate (estimated_flow only)",
-          "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
-          "volume_entity": "Volume target entity (volume_preset only)",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
+          "name": "Zone name"
         },
         "data_description": {
-          "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)",
-          "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
-          "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
-          "area_m2": "Surface area of this irrigation zone in square meters",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "flow_rate_lpm": "Water flow rate of the valve in liters per minute. Required for estimated_flow mode. Measure with a bucket and stopwatch",
-          "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
-          "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
-          "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level that triggers automatic irrigation for this zone",
-          "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
+          "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc (overrides plant family)",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "area_m2": "Surface area of this irrigation zone in square meters",
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch (optional)",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Valve flow rate (estimated_flow only)",
+              "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
+              "volume_entity": "Volume target entity (volume_preset only)",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency (overrides system type default)",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
+              "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
+              "flow_rate_lpm": "Water flow rate of the valve in liters per minute. Required for estimated_flow mode. Measure with a bucket and stopwatch",
+              "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
+              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
+              "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)"
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            },
+            "data_description": {
+              "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling",
+              "threshold": "Deficit level that triggers automatic irrigation for this zone"
+            }
           }
         }
       },
@@ -133,44 +145,52 @@
       "add_zone": {
         "title": "Add irrigation zone",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch (optional)",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Valve flow rate",
-          "flow_meter_sensor": "Flow meter sensor",
-          "volume_entity": "Volume target entity",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
-        },
-        "data_description": {
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored."
+          "name": "Zone name"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch (optional)",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Valve flow rate",
+              "flow_meter_sensor": "Flow meter sensor",
+              "volume_entity": "Volume target entity",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so."
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            }
           }
         }
       },
@@ -190,44 +210,52 @@
       "edit_zone_detail": {
         "title": "Edit zone: {zone_name}",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Valve flow rate",
-          "flow_meter_sensor": "Flow meter sensor",
-          "volume_entity": "Volume target entity",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
-        },
-        "data_description": {
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored."
+          "name": "Zone name"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Valve flow rate",
+              "flow_meter_sensor": "Flow meter sensor",
+              "volume_entity": "Volume target entity",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so."
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            }
           }
         }
       },

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -27,54 +27,66 @@
         "title": "Add irrigation zone",
         "description": "Configure zone #{zone_count}. You can add more zones after this.",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch (optional)",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency (overrides system type default)",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc (overrides plant family)",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Guard flow rate (all modes; required for estimated_flow)",
-          "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
-          "volume_entity": "Volume target entity (volume_preset only)",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
+          "name": "Zone name"
         },
         "data_description": {
-          "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)",
-          "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
-          "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
-          "area_m2": "Surface area of this irrigation zone in square meters",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "flow_rate_lpm": "Water flow rate of the valve in liters per hour (gal/h in imperial). Required for estimated_flow mode; recommended for flow_meter and volume_preset, where it drives the expected duration and the safety-timeout scaling (will become required in a future release). Measure with a bucket and stopwatch",
-          "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
-          "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
-          "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)",
-          "threshold": "Deficit level that triggers automatic irrigation for this zone",
-          "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling"
+          "name": "Display name for this zone (e.g., Vegetable Garden, Lawn)"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc (overrides plant family)",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "area_m2": "Surface area of this irrigation zone in square meters",
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch (optional)",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Guard flow rate (all modes; required for estimated_flow)",
+              "flow_meter_sensor": "Flow meter sensor (flow_meter only)",
+              "volume_entity": "Volume target entity (volume_preset only)",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency (overrides system type default)",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
+              "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
+              "flow_rate_lpm": "Water flow rate of the valve in liters per hour (gal/h in imperial). Required for estimated_flow mode; recommended for flow_meter and volume_preset, where it drives the expected duration and the safety-timeout scaling (will become required in a future release). Measure with a bucket and stopwatch",
+              "flow_meter_sensor": "Sensor entity that reports cumulative liters delivered. Required for flow_meter mode",
+              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
+              "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)"
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            },
+            "data_description": {
+              "irrigation_time": "Time of day when NeverDry checks the deficit and irrigates if above threshold. Leave empty to disable automatic scheduling",
+              "threshold": "Deficit level that triggers automatic irrigation for this zone"
+            }
           }
         }
       },
@@ -137,44 +149,52 @@
       "add_zone": {
         "title": "Add irrigation zone",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch (optional)",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Valve flow rate",
-          "flow_meter_sensor": "Flow meter sensor",
-          "volume_entity": "Volume target entity",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
-        },
-        "data_description": {
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored."
+          "name": "Zone name"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch (optional)",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Valve flow rate",
+              "flow_meter_sensor": "Flow meter sensor",
+              "volume_entity": "Volume target entity",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so."
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            }
           }
         }
       },
@@ -194,44 +214,52 @@
       "edit_zone_detail": {
         "title": "Edit zone: {zone_name}",
         "data": {
-          "name": "Zone name",
-          "valve": "Valve switch",
-          "delivery_mode": "Water delivery mode",
-          "area_m2": "Irrigated area",
-          "system_type": "Irrigation system type",
-          "efficiency": "Custom efficiency",
-          "plant_family": "Plant family",
-          "kc": "Custom crop coefficient Kc",
-          "exposure": "Site exposure",
-          "microclimate_factor": "Custom microclimate factor (Advanced only)",
-          "flow_rate_lpm": "Valve flow rate",
-          "flow_meter_sensor": "Flow meter sensor",
-          "volume_entity": "Volume target entity",
-          "delivery_timeout": "Safety timeout",
-          "irrigation_mode": "Irrigation mode",
-          "threshold": "Irrigation threshold",
-          "irrigation_time": "Daily irrigation time"
-        },
-        "data_description": {
-          "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
-          "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground.",
-          "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
-          "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-          "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
-          "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored."
+          "name": "Zone name"
         },
         "sections": {
           "ground_and_location": {
             "name": "Ground and location",
-            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is."
+            "description": "What is watered here: how big the zone is, what grows in it, and how exposed it is.",
+            "data": {
+              "area_m2": "Irrigated area",
+              "plant_family": "Plant family",
+              "kc": "Custom crop coefficient Kc",
+              "exposure": "Site exposure",
+              "microclimate_factor": "Custom microclimate factor (Advanced only)"
+            },
+            "data_description": {
+              "plant_family": "Sets the seasonal Kc curve for what grows here. Pick Custom to enter one fixed Kc below.",
+              "kc": "Used only when the plant family is Custom. With any other family the seasonal curve applies and this field is ignored.",
+              "exposure": "How much sun and wind this zone gets compared to an open site. Multiplies the Kc, so the zone keeps its seasonal curve instead of being frozen at one fixed value. Pick Custom to enter your own factor below.",
+              "microclimate_factor": "Used only when the exposure is Custom. Range 0.1–1.5; above 1.0 for zones that dry faster than open ground."
+            }
           },
           "valve_and_pipe": {
             "name": "Valve and pipe",
-            "description": "What waters it: the valve, how delivery is measured, and the irrigation system."
+            "description": "What waters it: the valve, how delivery is measured, and the irrigation system.",
+            "data": {
+              "valve": "Valve switch",
+              "delivery_mode": "Water delivery mode",
+              "flow_rate_lpm": "Valve flow rate",
+              "flow_meter_sensor": "Flow meter sensor",
+              "volume_entity": "Volume target entity",
+              "system_type": "Irrigation system type",
+              "efficiency": "Custom efficiency",
+              "delivery_timeout": "Safety timeout"
+            },
+            "data_description": {
+              "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
+              "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so."
+            }
           },
           "scheduling": {
             "name": "Scheduling",
-            "description": "When it waters: on a timer, on a deficit threshold, or only on request."
+            "description": "When it waters: on a timer, on a deficit threshold, or only on request.",
+            "data": {
+              "irrigation_mode": "Irrigation mode",
+              "irrigation_time": "Daily irrigation time",
+              "threshold": "Irrigation threshold"
+            }
           }
         }
       },

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -27,54 +27,66 @@
         "title": "Aggiungi zona di irrigazione",
         "description": "Configura la zona #{zone_count}. Potrai aggiungere altre zone successivamente.",
         "data": {
-          "name": "Nome della zona",
-          "valve": "Interruttore della valvola (opzionale)",
-          "delivery_mode": "Modalità di erogazione dell'acqua",
-          "area_m2": "Area irrigata",
-          "system_type": "Tipo di impianto di irrigazione",
-          "efficiency": "Efficienza personalizzata (sovrascrive il valore predefinito del tipo di impianto)",
-          "plant_family": "Famiglia di piante",
-          "kc": "Coefficiente colturale Kc personalizzato (sovrascrive la famiglia di piante)",
-          "exposure": "Esposizione del sito",
-          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
-          "flow_rate_lpm": "Portata di guardia (tutte le modalità; richiesta per estimated_flow)",
-          "flow_meter_sensor": "Sensore del flussometro (solo per flow_meter)",
-          "volume_entity": "Entità target del volume (solo per volume_preset)",
-          "delivery_timeout": "Timeout di sicurezza",
-          "irrigation_mode": "Modalità di irrigazione",
-          "threshold": "Soglia di irrigazione",
-          "irrigation_time": "Orario di irrigazione giornaliero"
+          "name": "Nome della zona"
         },
         "data_description": {
-          "name": "Nome visualizzato per questa zona (es. Orto, Prato)",
-          "valve": "L'entità interruttore (switch) che controlla la valvola di irrigazione di questa zona. Lascia vuoto per la modalità di solo monitoraggio (nessuna valvola)",
-          "delivery_mode": "Modalità di erogazione dell'acqua della valvola. Portata stimata (estimated flow): semplice valvola on/off, durata calcolata in base alla portata. Flussometro (flow meter): valvola con sensore di flusso, si chiude al raggiungimento del volume target. Volume preimpostato (volume preset): valvola intelligente che accetta un volume target e si chiude autonomamente.",
-          "area_m2": "Superficie di questa zona di irrigazione in metri quadrati",
-          "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
-          "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala.",
-          "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
-          "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato.",
-          "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
-          "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto.",
-          "flow_rate_lpm": "Portata d'acqua della valvola in litri all'ora (gal/h in imperiale). Richiesta per la modalità estimated_flow; raccomandata per flow_meter e volume_preset, dove determina la durata prevista e la scalatura del timeout di sicurezza (diventerà obbligatoria in una release futura). Misurala con un secchio e un cronometro",
-          "flow_meter_sensor": "Entità sensore che rileva i litri cumulativi erogati. Richiesto per la modalità flow_meter",
-          "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
-          "delivery_timeout": "Tempo massimo di attesa per l'erogazione con flow_meter o volume_preset prima di forzare la chiusura della valvola (limite di sicurezza)",
-          "threshold": "Livello di deficit che attiva l'irrigazione automatica per questa zona",
-          "irrigation_time": "Ora del giorno in cui NeverDry verifica il deficit e irriga se supera la soglia. Lascia vuoto per disabilitare la pianificazione automatica"
+          "name": "Nome visualizzato per questa zona (es. Orto, Prato)"
         },
         "sections": {
           "ground_and_location": {
             "name": "Terreno e posizione",
-            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta."
+            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta.",
+            "data": {
+              "area_m2": "Area irrigata",
+              "plant_family": "Famiglia di piante",
+              "kc": "Coefficiente colturale Kc personalizzato (sovrascrive la famiglia di piante)",
+              "exposure": "Esposizione del sito",
+              "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)"
+            },
+            "data_description": {
+              "area_m2": "Superficie di questa zona di irrigazione in metri quadrati",
+              "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
+              "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato.",
+              "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
+              "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto."
+            }
           },
           "valve_and_pipe": {
             "name": "Valvola e impianto",
-            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto."
+            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto.",
+            "data": {
+              "valve": "Interruttore della valvola (opzionale)",
+              "delivery_mode": "Modalità di erogazione dell'acqua",
+              "flow_rate_lpm": "Portata di guardia (tutte le modalità; richiesta per estimated_flow)",
+              "flow_meter_sensor": "Sensore del flussometro (solo per flow_meter)",
+              "volume_entity": "Entità target del volume (solo per volume_preset)",
+              "system_type": "Tipo di impianto di irrigazione",
+              "efficiency": "Efficienza personalizzata (sovrascrive il valore predefinito del tipo di impianto)",
+              "delivery_timeout": "Timeout di sicurezza"
+            },
+            "data_description": {
+              "valve": "L'entità interruttore (switch) che controlla la valvola di irrigazione di questa zona. Lascia vuoto per la modalità di solo monitoraggio (nessuna valvola)",
+              "delivery_mode": "Modalità di erogazione dell'acqua della valvola. Portata stimata (estimated flow): semplice valvola on/off, durata calcolata in base alla portata. Flussometro (flow meter): valvola con sensore di flusso, si chiude al raggiungimento del volume target. Volume preimpostato (volume preset): valvola intelligente che accetta un volume target e si chiude autonomamente.",
+              "flow_rate_lpm": "Portata d'acqua della valvola in litri all'ora (gal/h in imperiale). Richiesta per la modalità estimated_flow; raccomandata per flow_meter e volume_preset, dove determina la durata prevista e la scalatura del timeout di sicurezza (diventerà obbligatoria in una release futura). Misurala con un secchio e un cronometro",
+              "flow_meter_sensor": "Entità sensore che rileva i litri cumulativi erogati. Richiesto per la modalità flow_meter",
+              "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
+              "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
+              "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala.",
+              "delivery_timeout": "Tempo massimo di attesa per l'erogazione con flow_meter o volume_preset prima di forzare la chiusura della valvola (limite di sicurezza)"
+            }
           },
           "scheduling": {
             "name": "Programmazione",
-            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta."
+            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta.",
+            "data": {
+              "irrigation_mode": "Modalità di irrigazione",
+              "irrigation_time": "Orario di irrigazione giornaliero",
+              "threshold": "Soglia di irrigazione"
+            },
+            "data_description": {
+              "irrigation_time": "Ora del giorno in cui NeverDry verifica il deficit e irriga se supera la soglia. Lascia vuoto per disabilitare la pianificazione automatica",
+              "threshold": "Livello di deficit che attiva l'irrigazione automatica per questa zona"
+            }
           }
         }
       },
@@ -137,44 +149,52 @@
       "add_zone": {
         "title": "Aggiungi zona di irrigazione",
         "data": {
-          "name": "Nome della zona",
-          "valve": "Interruttore della valvola (opzionale)",
-          "delivery_mode": "Modalità di erogazione dell'acqua",
-          "area_m2": "Area irrigata",
-          "system_type": "Tipo di impianto di irrigazione",
-          "efficiency": "Efficienza personalizzata",
-          "plant_family": "Famiglia di piante",
-          "kc": "Coefficiente colturale Kc personalizzato",
-          "exposure": "Esposizione del sito",
-          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
-          "flow_rate_lpm": "Portata della valvola",
-          "flow_meter_sensor": "Sensore del flussometro",
-          "volume_entity": "Entità target del volume",
-          "delivery_timeout": "Timeout di sicurezza",
-          "irrigation_mode": "Modalità di irrigazione",
-          "threshold": "Soglia di irrigazione",
-          "irrigation_time": "Orario di irrigazione giornaliero"
-        },
-        "data_description": {
-          "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
-          "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto.",
-          "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
-          "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala.",
-          "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
-          "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato."
+          "name": "Nome della zona"
         },
         "sections": {
           "ground_and_location": {
             "name": "Terreno e posizione",
-            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta."
+            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta.",
+            "data": {
+              "area_m2": "Area irrigata",
+              "plant_family": "Famiglia di piante",
+              "kc": "Coefficiente colturale Kc personalizzato",
+              "exposure": "Esposizione del sito",
+              "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)"
+            },
+            "data_description": {
+              "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
+              "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato.",
+              "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
+              "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto."
+            }
           },
           "valve_and_pipe": {
             "name": "Valvola e impianto",
-            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto."
+            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto.",
+            "data": {
+              "valve": "Interruttore della valvola (opzionale)",
+              "delivery_mode": "Modalità di erogazione dell'acqua",
+              "flow_rate_lpm": "Portata della valvola",
+              "flow_meter_sensor": "Sensore del flussometro",
+              "volume_entity": "Entità target del volume",
+              "system_type": "Tipo di impianto di irrigazione",
+              "efficiency": "Efficienza personalizzata",
+              "delivery_timeout": "Timeout di sicurezza"
+            },
+            "data_description": {
+              "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
+              "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala."
+            }
           },
           "scheduling": {
             "name": "Programmazione",
-            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta."
+            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta.",
+            "data": {
+              "irrigation_mode": "Modalità di irrigazione",
+              "irrigation_time": "Orario di irrigazione giornaliero",
+              "threshold": "Soglia di irrigazione"
+            }
           }
         }
       },
@@ -194,44 +214,52 @@
       "edit_zone_detail": {
         "title": "Modifica zona: {zone_name}",
         "data": {
-          "name": "Nome della zona",
-          "valve": "Interruttore della valvola",
-          "delivery_mode": "Modalità di erogazione dell'acqua",
-          "area_m2": "Area irrigata",
-          "system_type": "Tipo di impianto di irrigazione",
-          "efficiency": "Efficienza personalizzata",
-          "plant_family": "Famiglia di piante",
-          "kc": "Coefficiente colturale Kc personalizzato",
-          "exposure": "Esposizione del sito",
-          "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)",
-          "flow_rate_lpm": "Portata della valvola",
-          "flow_meter_sensor": "Sensore del flussometro",
-          "volume_entity": "Entità target del volume",
-          "delivery_timeout": "Timeout di sicurezza",
-          "irrigation_mode": "Modalità di irrigazione",
-          "threshold": "Soglia di irrigazione",
-          "irrigation_time": "Orario di irrigazione giornaliero"
-        },
-        "data_description": {
-          "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
-          "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto.",
-          "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
-          "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala.",
-          "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
-          "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato."
+          "name": "Nome della zona"
         },
         "sections": {
           "ground_and_location": {
             "name": "Terreno e posizione",
-            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta."
+            "description": "Cosa si irriga: quanto è grande la zona, cosa ci cresce e quanto è esposta.",
+            "data": {
+              "area_m2": "Area irrigata",
+              "plant_family": "Famiglia di piante",
+              "kc": "Coefficiente colturale Kc personalizzato",
+              "exposure": "Esposizione del sito",
+              "microclimate_factor": "Fattore microclima personalizzato (solo Avanzato)"
+            },
+            "data_description": {
+              "plant_family": "Imposta la curva stagionale del Kc per ciò che cresce qui. Scegli Personalizzato per inserire un Kc fisso qui sotto.",
+              "kc": "Usato solo quando la famiglia di piante è Personalizzato. Con qualsiasi altra famiglia vale la curva stagionale e questo campo viene ignorato.",
+              "exposure": "Quanto sole e vento riceve questa zona rispetto a un sito aperto. Moltiplica il Kc, così la zona mantiene la curva stagionale invece di essere bloccata su un valore fisso. Scegli Personalizzato per inserire il tuo fattore qui sotto.",
+              "microclimate_factor": "Usato solo quando l'esposizione è Personalizzato. Intervallo 0.1–1.5; sopra 1.0 per zone che asciugano più in fretta del terreno aperto."
+            }
           },
           "valve_and_pipe": {
             "name": "Valvola e impianto",
-            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto."
+            "description": "Cosa la irriga: la valvola, come si misura l'erogazione e il tipo di impianto.",
+            "data": {
+              "valve": "Interruttore della valvola",
+              "delivery_mode": "Modalità di erogazione dell'acqua",
+              "flow_rate_lpm": "Portata della valvola",
+              "flow_meter_sensor": "Sensore del flussometro",
+              "volume_entity": "Entità target del volume",
+              "system_type": "Tipo di impianto di irrigazione",
+              "efficiency": "Efficienza personalizzata",
+              "delivery_timeout": "Timeout di sicurezza"
+            },
+            "data_description": {
+              "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
+              "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala."
+            }
           },
           "scheduling": {
             "name": "Programmazione",
-            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta."
+            "description": "Quando irriga: a orario, al superamento di una soglia, o solo su richiesta.",
+            "data": {
+              "irrigation_mode": "Modalità di irrigazione",
+              "irrigation_time": "Orario di irrigazione giornaliero",
+              "threshold": "Soglia di irrigazione"
+            }
           }
         }
       },

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -194,3 +194,99 @@ class TestResolveOptionsFromVariable:
     def test_unknown_variable_returns_none(self):
         src = "selector.SelectSelectorConfig(options=mystery, translation_key='x')\n"
         assert _options_of(src) is None
+
+
+# ── Sectioned form fields: labels must be section-qualified ────────────────
+
+
+_STRINGS = _COMPONENT / "strings.json"
+_IT_JSON = _COMPONENT / "translations" / "it.json"
+
+
+def _section_membership() -> dict[str, set[str]]:
+    """Map each ``section()`` key in ``config_flow.py`` to the fields it holds.
+
+    Parsed statically: a section appears as ``vol.Required(SECTION_X): section(
+    vol.Schema({vol.Optional(CONF_Y): ...}))``, so the section constant is the
+    dict key and the fields are the ``vol.Required``/``vol.Optional`` keys of
+    the nested schema. Constants resolve through ``const`` (the ``CONF_*``) and
+    through this module's own assignments (the ``SECTION_*``).
+    """
+    tree = ast.parse(_CONFIG_FLOW.read_text())
+    section_values = {
+        name: node.value
+        for name, node in _collect_assignments(tree).items()
+        if name.startswith("SECTION_") and isinstance(node, ast.Constant)
+    }
+
+    def field_names(call: ast.Call) -> set[str]:
+        fields: set[str] = set()
+        for inner in ast.walk(call):
+            if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
+                continue
+            if inner.func.attr not in ("Required", "Optional") or not inner.args:
+                continue
+            arg = inner.args[0]
+            if isinstance(arg, ast.Name) and arg.id.startswith("CONF_"):
+                fields.add(getattr(const, arg.id))
+        return fields
+
+    membership: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=False):
+            is_section_call = isinstance(value, ast.Call) and getattr(value.func, "id", None) == "section"
+            if not is_section_call or not isinstance(key, ast.Call) or not key.args:
+                continue
+            name = key.args[0]
+            if not (isinstance(name, ast.Name) and name.id in section_values):
+                continue
+            membership.setdefault(section_values[name.id], set()).update(field_names(value))
+    return membership
+
+
+def test_sectioned_fields_are_labelled_under_their_section():
+    """A field inside a ``section()`` needs its label at the section-qualified path.
+
+    Home Assistant looks a sectioned field's label up under
+    ``step.<id>.sections.<section>.data.<field>``. A label left at the step's own
+    ``data`` is never read: the frontend falls back to the raw key, so the form
+    shows ``area_m2`` and ``flow_rate_lpm`` — in *every* language, translated
+    files included. Fields whose key happens to read like a word (``valve``,
+    ``name``) hide the breakage, which is why it survived a release.
+
+    This is the sectioned-form twin of the selector guard above: the schema is
+    correct, the strings exist, and only the *path* between them is wrong — which
+    no other test and no hassfest check looks at.
+    """
+    membership = _section_membership()
+    assert membership, "no section() found in config_flow.py — this guard would pass vacuously"
+
+    errors: list[str] = []
+    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+        doc = json.loads(path.read_text())
+        for scope in ("config", "options"):
+            for step_id, step in doc.get(scope, {}).get("step", {}).items():
+                declared = step.get("sections")
+                if not declared:
+                    continue
+                step_data = set(step.get("data", {}))
+                for section_key, fields in membership.items():
+                    if section_key not in declared:
+                        continue
+                    labelled = set(declared[section_key].get("data", {}))
+                    missing = fields - labelled
+                    if missing:
+                        errors.append(
+                            f"{path.name} {scope}/{step_id}: section '{section_key}' "
+                            f"missing labels for {sorted(missing)}"
+                        )
+                    stranded = fields & step_data
+                    if stranded:
+                        errors.append(
+                            f"{path.name} {scope}/{step_id}: {sorted(stranded)} labelled at step level "
+                            f"but rendered inside section '{section_key}' — the frontend will not find them"
+                        )
+
+    assert not errors, "Sectioned-form label inconsistencies:\n  " + "\n  ".join(errors)


### PR DESCRIPTION
Grouping the zone form into three collapsible sections moved where Home Assistant looks a field label up: a sectioned field resolves under `step.<id>.sections.<section>.data.<field>`, not under the step own `data`. The strings stayed where they were, so **all 16 sectioned fields fell back to their raw key** — `area_m2`, `flow_rate_lpm`, `plant_family` — in every language, translated files included.

What got reported were the two keys carrying an underscore. The rest were just as broken, hidden by keys that happen to read like words (`valve`, `name`). The Italian form showed the same raw keys, which is what ruled out a missing translation and pointed at the lookup path.

## What changes

No string is added, removed or reworded. The 48 labels per file (16 fields x 3 steps: `config/zone`, `options/add_zone`, `options/edit_zone_detail`) move under the section that renders them, verified by comparing the full set of translated texts against `develop` — identical before and after. `name` is the one field outside a section and stays where it is.

## The guard

hassfest validates the file shape, and every existing test asserts on the schema dict, which was correct all along. Nothing looked at the *path* between a schema key and its string, so a release shipped a form with no labels on it.

The new test derives the field-to-section map from `config_flow.py` with `ast`, then requires the qualified label in all three files and fails if a label is left stranded at step level. It was checked against `develop` first: it reports all 16 fields across the three steps and three files. Same failure mode as the selector guard already in that file — schema right, strings right, lookup path wrong.

## Verification

- Full suite: 1031 passed. `ruff format --check` and `ruff check` clean.
- Still to confirm on a running instance: the empty row above *plant family*, likely an unresolved `data_description` that should fall with the same move.