### PR TITLE
release: bump version to 0.11.1-beta.6

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.5"
+  "version": "0.11.1-beta.6"
 }


### PR DESCRIPTION
Version bump only — `manifest.json` from `0.11.1-beta.5` to `0.11.1-beta.6`.

Carries two fixes a tester meets in the first minute:

- **#170** — a soil-moisture probe reporting a percentage no longer stops a zone from watering. The deficit was pinned at zero silently and forever; readings are now normalised where they enter, and a reading that is not a water content on either scale is refused rather than clamped to "saturated".
- **#175** — the zone form shows its labels again. Sections moved where Home Assistant resolves a label, so every sectioned field fell back to its raw key in all languages. No string changed, and a new guard derives the field-to-section map from the schema so it cannot regress unseen.