### PR TITLE
fix(safety): bound a delivery by the job, not by a constant (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **A delivery is now bounded by the job, not by a constant** ([#173]). The safety timeout used to be combined with the expected duration by taking the *greater* of the two, which made the configured value a floor: a zone with five minutes of work was guarded with the one-hour default, and a flow meter that stopped counting mid-run kept the valve open for the whole hour. The bound is now the expected duration (`volume / flow rate`) times a safety margin, capped by the configured timeout — the field goes back to meaning what the manual has always said it means, an upper bound you can tighten but not loosen. If a zone genuinely needs longer than you allow, it now says so once instead of quietly stopping short. Zones with no guard flow rate configured are unaffected: with no estimate there is nothing to bound with, and the configured timeout is still all there is.
+
 ### Added
 - System-wide reset buttons on the NeverDry hub device ([#142]):
   - **Reset yearly rain** — clears the shared year-to-date rain total (behind every zone's *Rain Yearly [L]*) without waiting for 1 January. The total is a saved value that survives a restart and a plain reinstall, so this button is the way to clear a wrong figure — e.g. after switching rain sensor type.
@@ -58,6 +61,7 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/never
 
 [Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.0
+[#173]: https://github.com/never-dry/NeverDry/issues/173
 [#170]: https://github.com/never-dry/NeverDry/issues/170
 [#146]: https://github.com/never-dry/NeverDry/issues/146
 [#142]: https://github.com/never-dry/NeverDry/pull/142

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -157,8 +157,16 @@ DELIVERY_MODES = {
     DELIVERY_MODE_VOLUME_PRESET: "Smart valve with volume dosing",
 }
 
-DEFAULT_DELIVERY_TIMEOUT_S = 3600  # 1 hour safety timeout
+DEFAULT_DELIVERY_TIMEOUT_S = 3600  # 1 hour safety timeout — the ceiling, not the job
 FLOW_METER_POLL_INTERVAL_S = 2
+
+# How far past the expected job duration a delivery may run before the safety
+# timeout cuts it. The job duration comes from the *declared* guard flow rate,
+# which is an approximation — real flow moves with pressure, emitter fouling and
+# water temperature — so the margin has to absorb an honest shortfall without
+# cutting a healthy run short. 2.0 tolerates a real flow half the declared one.
+# Tighten this only once the flow rate is measured rather than declared.
+DELIVERY_DURATION_MARGIN = 2.0
 
 # ── Services ─────────────────────────────────────────────
 SERVICE_RESET = "reset"

--- a/custom_components/never_dry/const.py
+++ b/custom_components/never_dry/const.py
@@ -168,6 +168,14 @@ FLOW_METER_POLL_INTERVAL_S = 2
 # Tighten this only once the flow rate is measured rather than declared.
 DELIVERY_DURATION_MARGIN = 2.0
 
+# Spacing between the three safety layers. Each one exists to catch the failure
+# of the one before it — the delivery loop stops a normal run, the watchdog
+# stops a loop that is stuck or gone, the on-device timer stops a valve when
+# Home Assistant itself is gone — so each must fire *after* the one it protects,
+# or it steals the ending instead of catching a failure. A quarter more each
+# step: delivery bound → x1.25 watchdog → x1.25 hardware timer.
+SAFETY_LAYER_SPREAD = 1.25
+
 # ── Services ─────────────────────────────────────────────
 SERVICE_RESET = "reset"
 SERVICE_RESET_YEARLY_RAIN = "reset_yearly_rain"

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -58,6 +58,7 @@ from .const import (
     DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
     FLOW_METER_POLL_INTERVAL_S,
+    SAFETY_LAYER_SPREAD,
 )
 from .valve_fsm import (
     CancelAllTimers,
@@ -814,7 +815,13 @@ class Driver(abc.ABC):
         if not has_entity and not has_topic:
             return
         self._hw_duration_set = True
-        value = round(self._current_max_open_duration() * self._hw_max_duration_multiplier, 1)
+        # Outermost layer: it must outlast the watchdog, which must outlast the
+        # delivery bound. The multiplier is the entity's unit conversion; the
+        # spread is what keeps the ladder ordered.
+        value = round(
+            self._watchdog_duration_s() * SAFETY_LAYER_SPREAD * self._hw_max_duration_multiplier,
+            1,
+        )
 
         if has_entity:
             try:
@@ -862,9 +869,21 @@ class Driver(abc.ABC):
                     exc,
                 )
 
+    def _watchdog_duration_s(self) -> float:
+        """How long the watchdog waits — deliberately longer than the caller's bound.
+
+        The caller closes at its own delivery bound; this timer is for the case
+        where that caller is stuck, cancelled or gone, so it must fire *after*
+        it. One shared number would make the watchdog trip on every run that
+        legitimately reaches its bound — and trip first, since it is armed at
+        open while the delivery loop only starts counting once open is
+        confirmed. See ``SAFETY_LAYER_SPREAD``.
+        """
+        return self._current_max_open_duration() * SAFETY_LAYER_SPREAD
+
     async def _watchdog(self) -> None:
         """Absolute safety timer: force-close the actuator if it stays open too long."""
-        max_open_s = self._current_max_open_duration()
+        max_open_s = self._watchdog_duration_s()
         try:
             await asyncio.sleep(max_open_s)
         except asyncio.CancelledError:

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -1012,7 +1012,18 @@ class ZoneDriver(Driver):
         auto_open_grace_s: float = AUTO_OPEN_GRACE_S,
         **base_kwargs,
     ) -> None:
-        """Configure a zone actuator; ``base_kwargs`` flow to :class:`Driver`."""
+        """Configure a zone actuator; ``base_kwargs`` flow to :class:`Driver`.
+
+        ``delivery_timeout_s`` is a **ceiling on the job**, not an absolute
+        constant: the caller derives it from the expected duration (volume over
+        the declared flow rate) times a margin, capped by the user's configured
+        safety timeout — see ``IrrigationZoneSensor.delivery_timeout``. Passing
+        a bare constant here is what let a stalled meter keep a valve open for
+        an hour on a five-minute job (GH #173), because the only exit from the
+        loops below is the meter reaching target or this timeout expiring. Take
+        it once, before opening: the deficit shrinks as water arrives, so a
+        bound recomputed mid-session follows the session it should bound.
+        """
         super().__init__(hass, entity_id, flow_sensor_entity_id=flow_meter_sensor, **base_kwargs)
         self._delivery_mode = DeliveryMode(delivery_mode)
         self._flow_rate_lpm = flow_rate_lpm

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -58,7 +58,6 @@ from .const import (
     DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
     FLOW_METER_POLL_INTERVAL_S,
-    SAFETY_LAYER_SPREAD,
 )
 from .valve_fsm import (
     CancelAllTimers,
@@ -289,6 +288,7 @@ class Driver(abc.ABC):
         flow_zero_threshold: float = 0.05,
         notifier: ValveNotifier | None = None,
         max_open_duration_s: float | Callable[[], float] = 3600.0,
+        hw_max_duration_s: float | Callable[[], float] | None = None,
         hw_max_duration_entity: str | None = None,
         hw_max_duration_multiplier: float = 1.0,
         hw_max_duration_topic: str | None = None,
@@ -316,6 +316,10 @@ class Driver(abc.ABC):
         # Static float or zero-arg callable re-evaluated at every open, so the
         # watchdog and hardware timer track the current deficit, not a snapshot.
         self._max_open_duration_s = max_open_duration_s
+        # Outermost safety layer, supplied by the caller: it must outlast the
+        # watchdog above. ``None`` means "same as the watchdog" — the flat
+        # ladder, which is all a zone without a flow-rate estimate can offer.
+        self._hw_max_duration_s = hw_max_duration_s
         self._hw_max_duration_entity = hw_max_duration_entity
         self._hw_max_duration_multiplier = hw_max_duration_multiplier
         self._hw_max_duration_topic = hw_max_duration_topic
@@ -384,6 +388,13 @@ class Driver(abc.ABC):
     def latency_diagnostics(self) -> dict:
         """Return latency statistics for this actuator (open and close windows)."""
         return self._latency.as_dict()
+
+    def _current_hw_max_duration(self) -> float:
+        """Resolve the on-device timer value, falling back to the watchdog's."""
+        provider = self._hw_max_duration_s
+        if provider is None:
+            return self._current_max_open_duration()
+        return float(provider() if callable(provider) else provider)
 
     def _current_max_open_duration(self) -> float:
         """Resolve the max-open duration, evaluating the provider if callable."""
@@ -815,13 +826,11 @@ class Driver(abc.ABC):
         if not has_entity and not has_topic:
             return
         self._hw_duration_set = True
-        # Outermost layer: it must outlast the watchdog, which must outlast the
-        # delivery bound. The multiplier is the entity's unit conversion; the
-        # spread is what keeps the ladder ordered.
-        value = round(
-            self._watchdog_duration_s() * SAFETY_LAYER_SPREAD * self._hw_max_duration_multiplier,
-            1,
-        )
+        # Outermost layer. The value is supplied by the caller, which owns the
+        # whole ladder (delivery bound < watchdog < hardware, all under the
+        # user's configured ceiling); the multiplier is only the entity's unit
+        # conversion. An actuator must not invent its own safety margins.
+        value = round(self._current_hw_max_duration() * self._hw_max_duration_multiplier, 1)
 
         if has_entity:
             try:
@@ -869,21 +878,9 @@ class Driver(abc.ABC):
                     exc,
                 )
 
-    def _watchdog_duration_s(self) -> float:
-        """How long the watchdog waits — deliberately longer than the caller's bound.
-
-        The caller closes at its own delivery bound; this timer is for the case
-        where that caller is stuck, cancelled or gone, so it must fire *after*
-        it. One shared number would make the watchdog trip on every run that
-        legitimately reaches its bound — and trip first, since it is armed at
-        open while the delivery loop only starts counting once open is
-        confirmed. See ``SAFETY_LAYER_SPREAD``.
-        """
-        return self._current_max_open_duration() * SAFETY_LAYER_SPREAD
-
     async def _watchdog(self) -> None:
         """Absolute safety timer: force-close the actuator if it stays open too long."""
-        max_open_s = self._watchdog_duration_s()
+        max_open_s = self._current_max_open_duration()
         try:
             await asyncio.sleep(max_open_s)
         except asyncio.CancelledError:

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -100,6 +100,7 @@ from .const import (
     MICROCLIMATE_FACTOR_MIN,
     PLANT_FAMILIES,
     RAIN_TYPE_EVENT,
+    SAFETY_LAYER_SPREAD,
     SYSTEM_TYPES,
     UNUSUAL_FLOW_MAX_LPM,
 )
@@ -523,7 +524,8 @@ def _setup_controller(
             notifier=notifier,
             # Callable, not snapshot: re-evaluated at every valve open so the
             # watchdog and hardware timer scale with the current deficit.
-            max_open_duration_s=lambda zs=zs: zs.delivery_timeout,
+            max_open_duration_s=lambda zs=zs: zs.watchdog_timeout,
+            hw_max_duration_s=lambda zs=zs: zs.hw_max_duration_s,
             hw_max_duration_entity=hw_entity,
             hw_max_duration_multiplier=hw_mult,
             hw_max_duration_topic=zs.hw_max_duration_topic,
@@ -1556,6 +1558,32 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                 self._delivery_timeout,
             )
         return min(self._delivery_timeout, bound_s)
+
+    @property
+    def watchdog_timeout(self) -> int:
+        """Second safety layer: fires when the delivery loop itself is stuck or gone.
+
+        A spread above :attr:`delivery_timeout` so it catches that layer's
+        failure instead of racing it — the watchdog is armed at valve open while
+        the loop only starts counting once the open is confirmed, so equal
+        values would make the watchdog trip *first* and report a fault where
+        the loop was about to close in good order.
+
+        Capped by the configured timeout like every other layer: the user's
+        value means "never run longer than this", so no layer may sit above it.
+        Without a guard flow rate there is no room under the cap and all three
+        collapse onto it — the same flat ladder as before, which is what the
+        configuration deserves when it gives us nothing to derive one from.
+        """
+        return min(self._delivery_timeout, round(self.delivery_timeout * SAFETY_LAYER_SPREAD))
+
+    @property
+    def hw_max_duration_s(self) -> int:
+        """Outermost layer, written to the device so it survives Home Assistant.
+
+        A spread above :attr:`watchdog_timeout`, under the same cap.
+        """
+        return min(self._delivery_timeout, round(self.watchdog_timeout * SAFETY_LAYER_SPREAD))
 
     @property
     def hw_max_duration_topic(self) -> str | None:

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -87,6 +87,7 @@ from .const import (
     DEFAULT_ROOT_DEPTH,
     DEFAULT_T_BASE,
     DEFAULT_THRESHOLD,
+    DELIVERY_DURATION_MARGIN,
     DELIVERY_MODE_ESTIMATED_FLOW,
     DELIVERY_MODE_FLOW_METER,
     DOMAIN,
@@ -1178,6 +1179,7 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._hw_max_duration_payload: str = zone_config.get(CONF_ZONE_HW_MAX_DURATION_PAYLOAD, "{value}")
         self._irrigating = False
         self._no_guard_flow_warned = False
+        self._timeout_caps_job_warned = False
         self._session_listeners: list[Callable] = []
         self._operator = None  # set by _setup_controller after operator creation
 
@@ -1510,13 +1512,50 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
     def delivery_timeout(self) -> int:
         """Safety timeout in seconds for flow_meter and volume_preset modes.
 
-        Returns the greater of the configured floor and the guard-flow
-        duration estimate, so large deficits never hit the timeout before
-        completion. Deliberately based on the guard flow only — never the
-        live meter rate — so the watchdog cannot tighten on a momentary
-        high reading.
+        Two different questions used to share this number. *How long should
+        the job take* is a prediction about the work — volume over flow rate.
+        *How long do we tolerate before something is wrong* is a bound on
+        failure. Combining them with ``max()`` made the configured value a
+        floor, so the estimate could only ever loosen the bound: a zone with
+        five minutes of work to do was guarded with the one-hour default, and
+        a meter that stopped counting kept the valve open for the whole hour
+        (GH #173). The user manual has always described this field as an upper
+        bound; this restores that.
+
+        So: when the expected duration is known, the timeout is that duration
+        plus :data:`DELIVERY_DURATION_MARGIN`, and the configured value caps it
+        from above — the user can always tighten, never loosen. With no guard
+        flow configured there is no prediction to bound anything with, and the
+        configured value is all we have.
+
+        Deliberately based on the guard flow only — never the live meter rate.
+        It would be absurd to calibrate the protection *against* a meter using
+        that same meter, and a momentary high reading must not be able to
+        tighten the watchdog. For the same reason the caller reads this once,
+        before opening: the deficit shrinks as water arrives, so a bound
+        re-read mid-session would follow the session it is meant to bound.
         """
-        return max(self._delivery_timeout, round(self._guard_duration_s * 1.1))
+        expected_s = self._guard_duration_s
+        if expected_s <= 0:
+            return self._delivery_timeout
+        bound_s = round(expected_s * DELIVERY_DURATION_MARGIN)
+        if bound_s > self._delivery_timeout and not self._timeout_caps_job_warned:
+            # The cap bites: the zone needs more time than the user allows, so
+            # it will stop short. Silence here would under-water the zone every
+            # cycle with nothing to show for it — the failure this whole bound
+            # exists to avoid, only in the other direction.
+            self._timeout_caps_job_warned = True
+            _LOGGER.warning(
+                "Zone '%s' needs about %ds to deliver %.1fL at %.2f L/min, but its safety"
+                " timeout is %ds — irrigation will stop short. Raise the safety timeout, or"
+                " check that the configured flow rate matches the real one",
+                self._zone_name,
+                expected_s,
+                self.volume_liters,
+                self._flow_rate,
+                self._delivery_timeout,
+            )
+        return min(self._delivery_timeout, bound_s)
 
     @property
     def hw_max_duration_topic(self) -> str | None:

--- a/custom_components/never_dry/valve_operator.py
+++ b/custom_components/never_dry/valve_operator.py
@@ -27,7 +27,6 @@ from typing import ClassVar
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .const import SAFETY_LAYER_SPREAD
 from .valve_fsm import (
     CancelAllTimers,
     CancelTimer,
@@ -122,6 +121,7 @@ class ValveOperator:
         flow_zero_threshold: float = 0.05,
         notifier: ValveNotifier | None = None,
         max_open_duration_s: float | Callable[[], float] = 3600.0,
+        hw_max_duration_s: float | Callable[[], float] | None = None,
         hw_max_duration_entity: str | None = None,
         hw_max_duration_multiplier: float = 1.0,
         hw_max_duration_topic: str | None = None,
@@ -149,6 +149,10 @@ class ValveOperator:
         # open, so the watchdog and the hardware timer track the current
         # deficit instead of a setup-time snapshot.
         self._max_open_duration_s = max_open_duration_s
+        # Outermost safety layer, supplied by the caller: it must outlast the
+        # watchdog above. ``None`` means "same as the watchdog" — the flat
+        # ladder, which is all a zone without a flow-rate estimate can offer.
+        self._hw_max_duration_s = hw_max_duration_s
         self._hw_max_duration_entity = hw_max_duration_entity
         self._hw_max_duration_multiplier = hw_max_duration_multiplier
         self._hw_max_duration_topic = hw_max_duration_topic
@@ -193,6 +197,13 @@ class ValveOperator:
     def latency_diagnostics(self) -> dict:
         """Return latency statistics for this valve (open and close windows)."""
         return self._latency.as_dict()
+
+    def _current_hw_max_duration(self) -> float:
+        """Resolve the on-device timer value, falling back to the watchdog's."""
+        provider = self._hw_max_duration_s
+        if provider is None:
+            return self._current_max_open_duration()
+        return float(provider() if callable(provider) else provider)
 
     def _current_max_open_duration(self) -> float:
         """Resolve the max-open duration, evaluating the provider if callable."""
@@ -591,13 +602,11 @@ class ValveOperator:
         if not has_entity and not has_topic:
             return
         self._hw_duration_set = True
-        # Outermost layer: it must outlast the watchdog, which must outlast the
-        # delivery bound. The multiplier is the entity's unit conversion; the
-        # spread is what keeps the ladder ordered.
-        value = round(
-            self._watchdog_duration_s() * SAFETY_LAYER_SPREAD * self._hw_max_duration_multiplier,
-            1,
-        )
+        # Outermost layer. The value is supplied by the caller, which owns the
+        # whole ladder (delivery bound < watchdog < hardware, all under the
+        # user's configured ceiling); the multiplier is only the entity's unit
+        # conversion. An actuator must not invent its own safety margins.
+        value = round(self._current_hw_max_duration() * self._hw_max_duration_multiplier, 1)
 
         if has_entity:
             try:
@@ -646,22 +655,9 @@ class ValveOperator:
                     exc,
                 )
 
-    def _watchdog_duration_s(self) -> float:
-        """How long the watchdog waits — deliberately longer than the caller's bound.
-
-        The caller (the delivery loop) closes the valve at its own bound. This
-        timer exists for the case where that loop is stuck, cancelled or gone,
-        so it has to fire *after* it. Sharing one number would make the watchdog
-        trip on every run that reaches its bound legitimately, reporting a
-        critical fault where the loop was about to close in good order — and it
-        would trip *first*, since the watchdog is armed at valve open while the
-        loop only starts counting once the open is confirmed.
-        """
-        return self._current_max_open_duration() * SAFETY_LAYER_SPREAD
-
     async def _watchdog(self) -> None:
         """Absolute safety timer: force-close the valve if it stays open too long."""
-        max_open_s = self._watchdog_duration_s()
+        max_open_s = self._current_max_open_duration()
         try:
             await asyncio.sleep(max_open_s)
         except asyncio.CancelledError:

--- a/custom_components/never_dry/valve_operator.py
+++ b/custom_components/never_dry/valve_operator.py
@@ -27,6 +27,7 @@ from typing import ClassVar
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 
+from .const import SAFETY_LAYER_SPREAD
 from .valve_fsm import (
     CancelAllTimers,
     CancelTimer,
@@ -590,7 +591,13 @@ class ValveOperator:
         if not has_entity and not has_topic:
             return
         self._hw_duration_set = True
-        value = round(self._current_max_open_duration() * self._hw_max_duration_multiplier, 1)
+        # Outermost layer: it must outlast the watchdog, which must outlast the
+        # delivery bound. The multiplier is the entity's unit conversion; the
+        # spread is what keeps the ladder ordered.
+        value = round(
+            self._watchdog_duration_s() * SAFETY_LAYER_SPREAD * self._hw_max_duration_multiplier,
+            1,
+        )
 
         if has_entity:
             try:
@@ -639,9 +646,22 @@ class ValveOperator:
                     exc,
                 )
 
+    def _watchdog_duration_s(self) -> float:
+        """How long the watchdog waits — deliberately longer than the caller's bound.
+
+        The caller (the delivery loop) closes the valve at its own bound. This
+        timer exists for the case where that loop is stuck, cancelled or gone,
+        so it has to fire *after* it. Sharing one number would make the watchdog
+        trip on every run that reaches its bound legitimately, reporting a
+        critical fault where the loop was about to close in good order — and it
+        would trip *first*, since the watchdog is armed at valve open while the
+        loop only starts counting once the open is confirmed.
+        """
+        return self._current_max_open_duration() * SAFETY_LAYER_SPREAD
+
     async def _watchdog(self) -> None:
         """Absolute safety timer: force-close the valve if it stays open too long."""
-        max_open_s = self._current_max_open_duration()
+        max_open_s = self._watchdog_duration_s()
         try:
             await asyncio.sleep(max_open_s)
         except asyncio.CancelledError:

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -216,15 +216,33 @@ every delivery mode:
 2. **Configured guard flow rate** (`flow_rate_lpm`) — `flow_meter` at
    rest or with a cumulative-volume meter, `volume_preset`, and
    `estimated_flow`.
-3. **0** — no source available; only the `delivery_timeout` floor guards
-   the valve (a once-per-zone warning is logged).
+3. **0** — no source available; there is nothing to derive a bound from,
+   so the configured `delivery_timeout` is all that guards the valve
+   (a once-per-zone warning is logged).
 
-The related safety timeout is `delivery_timeout = max(configured floor,
-1.1 × guard-flow duration)`. It deliberately uses the guard-flow estimate
-only — never the live rate — so a momentary high meter reading cannot
-tighten the `ValveOperator` watchdog. The operator receives the timeout
-as a callable re-evaluated at every valve open (watchdog sleep and
-hardware max-duration write), not as a setup-time snapshot.
+The related safety timeout is `delivery_timeout = min(configured ceiling,
+DELIVERY_DURATION_MARGIN × guard-flow duration)`. Two different questions
+used to share this number — *how long should the job take* is a prediction
+about the work, *how long before something is wrong* is a bound on failure
+— and combining them with `max()` made the configured value a floor: a
+zone with five minutes of work was guarded with the one-hour default, and
+a meter that stopped counting kept the valve open for the whole hour
+(GH #173). The configured value is now a cap, which the user can tighten
+but never loosen; when it bites, the zone logs one warning instead of
+quietly stopping short.
+
+Two derived layers sit above it, each `SAFETY_LAYER_SPREAD` (×1.25) above
+the previous one and each capped by the same configured value:
+`watchdog_timeout` (`ValveOperator._watchdog`) and `hw_max_duration_s`
+(the on-device timer). The spacing is what lets a layer catch the failure
+of the one below it rather than race it. Without a guard flow there is no
+room under the cap and all three collapse onto the configured value.
+
+All three deliberately use the guard-flow estimate only — never the live
+rate — so a momentary high meter reading cannot tighten the watchdog. The
+operator receives the value as a callable re-evaluated at every valve open
+(watchdog sleep and hardware max-duration write), not as a setup-time
+snapshot.
 
 ### 2.9 Resolution orders
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -162,7 +162,7 @@ For each zone, the wizard asks:
 | **Custom Kc** | For *Custom* | One fixed Kc (0.1–2.0). Used **only** when the plant family is *Custom*, and required in that case. |
 | **Site exposure** | No | How much sun and wind this zone gets compared to an open site. Multiplies the Kc. Default *Full sun, open* (×1.00) changes nothing. See table below. |
 | **Custom microclimate factor** | For *Custom* | Your own exposure factor (0.1–1.5). Used **only** when site exposure is *Custom*, and required in that case. |
-| **Guard flow rate (L/min)** | For `estimated_flow` | Measured valve flow rate. Required for `estimated_flow`; strongly recommended for `flow_meter` and `volume_preset` too — it drives the expected-duration estimate and lets the safety timeout scale with large deficits (it will become required in a future release). Measure with a bucket and stopwatch. |
+| **Guard flow rate (L/min)** | For `estimated_flow` | Measured valve flow rate. Required for `estimated_flow`; strongly recommended for `flow_meter` and `volume_preset` too — it drives the expected-duration estimate, and that estimate is what bounds a delivery — without it the only bound is the safety timeout, an hour by default, regardless of how long the zone was ever going to take (it will become required in a future release). Measure with a bucket and stopwatch. |
 | **Threshold (mm)** | No | Deficit threshold for Mode A triggering (default: 20.0 mm) |
 
 **System type defaults:**
@@ -461,7 +461,7 @@ What happens:
 3. A baseline is recorded for the flow meter (current cumulative reading, or open timestamp for rate sensors).
 4. An **auto-close monitor** starts in the background. It will close the valve via `switch.turn_off` at the **minimum** of:
    - **Volume needed** — if the zone has a flow meter, the monitor polls it and closes as soon as the delivered volume covers the current deficit-driven target (`volume_liters`). Without a flow meter but with a configured `flow_rate`, the monitor sleeps for the estimated duration `volume / flow_rate`.
-   - **Safety timeout** (`delivery_timeout`, default 1 hour) — always honoured as the upper bound, so a forgotten-open valve cannot run indefinitely. When the zone has a guard flow rate configured, the timeout automatically grows to `1.1 ×` the guard-flow duration estimate, so a large deficit is never cut short by the default floor.
+   - **Safety timeout** (`delivery_timeout`, default 1 hour) — the upper bound, so a forgotten-open valve cannot run indefinitely. When the zone has a guard flow rate configured, the effective bound is the *expected duration* (`volume / flow_rate`) times a safety margin, capped by this field: a zone with five minutes of work is guarded at its own scale rather than at the default hour. You can always tighten this field, never loosen it — if the work genuinely needs longer than you allow, the zone warns that it will stop short instead of quietly under-watering.
 5. When the switch goes `on → off` (either because the user closed it, or because the monitor closed it):
    - `is_irrigating` flips back to `False`.
    - `last_irrigated` is stamped with the current time.

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -723,3 +723,109 @@ class TestZeroFlowTimeoutFallback:
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
 
         assert ctrl._fallback_volume_estimate(zone, 3600, 42.0) == 42.0
+
+
+class TestStalledFlowMeter:
+    """GH #173, second report: the meter counts once, then stops.
+
+    The reporter's meter registered 1 L about a minute in — enough for the run
+    to start — and never incremented again. The valve stayed open until its
+    *hardware* auto-shutoff fired. His words: on a valve without one, "that
+    could be very bad".
+
+    These tests characterise what NeverDry does today. Both will need updating
+    when the failsafe lands: the expected duration is computed, logged, and
+    then discarded, so nothing bounds the run except a timeout that defaults to
+    an hour regardless of how long the zone was ever going to take.
+    """
+
+    # The reporter's zone: 18.9 gal/h ≈ 1.19 L/min, 5.6 L target.
+    FLOW_LPM = 1.19
+    VOLUME_L = 5.6
+    AREA_M2 = 20.0
+    EFFICIENCY = 0.9
+
+    def _zone(self, hass_mock, di_sensor):
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_AREA: self.AREA_M2,
+                CONF_ZONE_EFFICIENCY: self.EFFICIENCY,
+                CONF_ZONE_FLOW_RATE: self.FLOW_LPM,
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+            },
+        )
+        # deficit chosen so the target volume is the reporter's 5.6 L
+        zone._zone_deficit = self.VOLUME_L * self.EFFICIENCY / self.AREA_M2
+        return zone
+
+    @staticmethod
+    def _one_litre_then_stall(zone, meter_entity):
+        """states.get: a totalizer that counts a single litre, then freezes.
+
+        The single litre lands about a minute in, as reported — a minute is
+        ~30 polls at the 2 s interval — and the reading never grows again.
+        Counting reads rather than scripting them keeps the fake honest: the
+        controller reads the meter twice before the loop even starts (once to
+        detect the sensor type, once for the baseline).
+        """
+        reads = {"n": 0}
+
+        def get_state(entity_id):
+            if entity_id == meter_entity:
+                reads["n"] += 1
+                s = MagicMock()
+                s.state = "100.0" if reads["n"] <= 30 else "101.0"
+                s.attributes = {"unit_of_measurement": "L"}
+                return s
+            if entity_id == zone.valve:
+                s = MagicMock()
+                s.state = "on"
+                return s
+            return None
+
+        return get_state
+
+    def test_the_expected_duration_is_computed_and_then_discarded(self, hass_mock, di_sensor):
+        """The two numbers sit on the same log line; only the larger is used.
+
+        `delivery_timeout` takes the *greater* of the configured floor and the
+        guard-flow estimate, so it can only ever loosen. With the default floor
+        of one hour, a zone that was going to take five minutes is guarded at
+        twelve times its own expected duration.
+        """
+        zone = self._zone(hass_mock, di_sensor)
+        hass_mock.states.get = MagicMock(return_value=None)  # no live rate → guard flow
+
+        expected_s = round(self.VOLUME_L / self.FLOW_LPM * 60)
+
+        assert zone.volume_liters == pytest.approx(self.VOLUME_L, abs=0.05)
+        assert zone.duration_s == expected_s  # ≈ 282 s: we know the right answer
+        assert zone.delivery_timeout == 3600  # ...and guard with an hour anyway
+        assert zone.delivery_timeout > 12 * expected_s
+
+    @pytest.mark.asyncio
+    async def test_stalled_meter_keeps_the_valve_open_for_the_whole_timeout(self, hass_mock, di_sensor, monkeypatch):
+        """One litre in, then nothing: the run continues for the full hour.
+
+        `asyncio.sleep` is neutralised so the loop's simulated clock advances
+        without the test waiting for it — elapsed time is read back from the
+        number of polls, which is exactly how the controller counts it.
+        """
+        zone = self._zone(hass_mock, di_sensor)
+        hass_mock.states.get = MagicMock(
+            side_effect=self._one_litre_then_stall(zone, "sensor.flow_meter"),
+        )
+        sleep = AsyncMock()
+        monkeypatch.setattr("never_dry.controller.asyncio.sleep", sleep)
+
+        expected_s = zone.duration_s
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        delivered = await ctrl._deliver_flow_meter(zone)
+
+        elapsed_s = sleep.await_count * FLOW_METER_POLL_INTERVAL_S
+        assert delivered == pytest.approx(1.0)  # 1 L of the 5.6 L target
+        assert elapsed_s == 3600  # ran the full timeout...
+        assert elapsed_s > 12 * expected_s  # ...for a zone needing ~282 s

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -14,6 +14,8 @@ from never_dry.const import (
     CONF_ZONE_SYSTEM_TYPE,
     CONF_ZONE_VALVE,
     CONF_ZONE_VOLUME_ENTITY,
+    DEFAULT_DELIVERY_TIMEOUT_S,
+    DELIVERY_DURATION_MARGIN,
     DELIVERY_MODE_ESTIMATED_FLOW,
     DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
@@ -730,13 +732,11 @@ class TestStalledFlowMeter:
 
     The reporter's meter registered 1 L about a minute in — enough for the run
     to start — and never incremented again. The valve stayed open until its
-    *hardware* auto-shutoff fired. His words: on a valve without one, "that
-    could be very bad".
+    *hardware* auto-shutoff fired, an hour later, on a zone with five minutes
+    of work to do. His words: on a valve without one, "that could be very bad".
 
-    These tests characterise what NeverDry does today. Both will need updating
-    when the failsafe lands: the expected duration is computed, logged, and
-    then discarded, so nothing bounds the run except a timeout that defaults to
-    an hour regardless of how long the zone was ever going to take.
+    The bound now comes from the job (volume over the declared flow rate, times
+    a margin) instead of a constant that could only ever loosen it.
     """
 
     # The reporter's zone: 18.9 gal/h ≈ 1.19 L/min, 5.6 L target.
@@ -788,13 +788,12 @@ class TestStalledFlowMeter:
 
         return get_state
 
-    def test_the_expected_duration_is_computed_and_then_discarded(self, hass_mock, di_sensor):
-        """The two numbers sit on the same log line; only the larger is used.
+    def test_the_bound_follows_the_job(self, hass_mock, di_sensor):
+        """The two numbers used to sit on the same log line; only one was used.
 
-        `delivery_timeout` takes the *greater* of the configured floor and the
-        guard-flow estimate, so it can only ever loosen. With the default floor
-        of one hour, a zone that was going to take five minutes is guarded at
-        twelve times its own expected duration.
+        `duration_s` said 282 s and `delivery_timeout` said 3600, because the
+        timeout took the *greater* of the configured floor and the estimate.
+        The zone is now guarded at its own scale.
         """
         zone = self._zone(hass_mock, di_sensor)
         hass_mock.states.get = MagicMock(return_value=None)  # no live rate → guard flow
@@ -802,13 +801,13 @@ class TestStalledFlowMeter:
         expected_s = round(self.VOLUME_L / self.FLOW_LPM * 60)
 
         assert zone.volume_liters == pytest.approx(self.VOLUME_L, abs=0.05)
-        assert zone.duration_s == expected_s  # ≈ 282 s: we know the right answer
-        assert zone.delivery_timeout == 3600  # ...and guard with an hour anyway
-        assert zone.delivery_timeout > 12 * expected_s
+        assert zone.duration_s == expected_s  # ≈ 282 s
+        assert zone.delivery_timeout == round(expected_s * DELIVERY_DURATION_MARGIN)
+        assert zone.delivery_timeout < DEFAULT_DELIVERY_TIMEOUT_S
 
     @pytest.mark.asyncio
-    async def test_stalled_meter_keeps_the_valve_open_for_the_whole_timeout(self, hass_mock, di_sensor, monkeypatch):
-        """One litre in, then nothing: the run continues for the full hour.
+    async def test_stalled_meter_no_longer_runs_for_the_whole_hour(self, hass_mock, di_sensor, monkeypatch):
+        """One litre in, then nothing: the run ends at the job's own bound.
 
         `asyncio.sleep` is neutralised so the loop's simulated clock advances
         without the test waiting for it — elapsed time is read back from the
@@ -822,10 +821,12 @@ class TestStalledFlowMeter:
         monkeypatch.setattr("never_dry.controller.asyncio.sleep", sleep)
 
         expected_s = zone.duration_s
+        bound_s = zone.delivery_timeout
         ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
         delivered = await ctrl._deliver_flow_meter(zone)
 
         elapsed_s = sleep.await_count * FLOW_METER_POLL_INTERVAL_S
-        assert delivered == pytest.approx(1.0)  # 1 L of the 5.6 L target
-        assert elapsed_s == 3600  # ran the full timeout...
-        assert elapsed_s > 12 * expected_s  # ...for a zone needing ~282 s
+        assert delivered == pytest.approx(1.0)  # still only 1 L of the 5.6 L target
+        assert elapsed_s == bound_s  # stopped at the job's bound...
+        assert elapsed_s <= 2 * expected_s  # ...roughly ten minutes, not an hour
+        assert elapsed_s < DEFAULT_DELIVERY_TIMEOUT_S / 6

--- a/tests/test_expected_duration.py
+++ b/tests/test_expected_duration.py
@@ -25,6 +25,7 @@ from never_dry.const import (
     CONF_ZONE_SYSTEM_TYPE,
     CONF_ZONE_VALVE,
     CONF_ZONE_VOLUME_ENTITY,
+    DELIVERY_DURATION_MARGIN,
     DELIVERY_MODE_ESTIMATED_FLOW,
     DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
@@ -224,29 +225,54 @@ class TestEstimatedFlowRegression:
 
 
 class TestDeliveryTimeoutScaling:
-    """delivery_timeout = max(floor, 1.1 x guard-flow duration)."""
+    """delivery_timeout = min(configured ceiling, expected duration x margin).
 
-    def test_floor_when_duration_small(self, di_sensor):
+    The configured value is an upper bound, as the manual has always said. It
+    used to be combined with ``max()``, which turned it into a floor: the
+    estimate could only ever loosen the bound, so a five-minute job was guarded
+    with the one-hour default and a stalled meter ran the whole hour (GH #173).
+    """
+
+    def test_short_job_gets_a_short_timeout(self, di_sensor):
+        """The bound follows the work, instead of the work being lost to the default."""
         hass = _hass_with_meter(0.0, "L")
         zone = _make_zone(di_sensor, hass, flow_rate=10.0, timeout=3600)
         zone._zone_deficit = 1.0  # small deficit → short duration
-        assert zone.delivery_timeout == 3600
+        guard_s = round(zone.volume_liters / 10.0 * 60)
 
-    def test_scales_with_large_deficit(self, di_sensor):
+        assert zone.delivery_timeout == round(guard_s * DELIVERY_DURATION_MARGIN)
+        assert zone.delivery_timeout < 3600
+
+    def test_configured_value_caps_a_long_job(self, di_sensor, caplog):
+        """A job longer than the ceiling is capped — and says so.
+
+        Capping silently would under-water the zone on every cycle with nothing
+        to show for it, which is the same silent failure in the other
+        direction, so the zone warns once when the cap bites.
+        """
         hass = _hass_with_meter(0.0, "L")
         zone = _make_zone(di_sensor, hass, flow_rate=2.0, timeout=3600)
         zone._zone_deficit = 50.0
         guard_s = round(zone.volume_liters / 2.0 * 60)
-        assert guard_s > 3600
-        assert zone.delivery_timeout == max(3600, round(guard_s * 1.1))
+        assert guard_s > 3600  # the work genuinely exceeds the ceiling
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.never_dry.sensor"):
+            assert zone.delivery_timeout == 3600
+            zone.delivery_timeout  # noqa: B018 — second read must stay quiet
+
+        assert sum("will stop short" in r.message for r in caplog.records) == 1
 
     def test_ignores_live_rate(self, di_sensor):
-        """A momentary high meter reading must not shrink the timeout."""
+        """A momentary high meter reading must not move the bound.
+
+        Calibrating the protection *against* a meter with that same meter would
+        let one optimistic reading shrink the watchdog mid-session.
+        """
         hass = _hass_with_meter(100.0, "L/min")
         zone = _make_zone(di_sensor, hass, flow_rate=2.0, timeout=3600)
         zone._zone_deficit = 50.0
-        guard_s = round(zone.volume_liters / 2.0 * 60)
-        assert zone.delivery_timeout == max(3600, round(guard_s * 1.1))
+
+        assert zone.delivery_timeout == 3600  # capped by the ceiling, not by the live rate
 
     def test_no_guard_flow_stays_at_floor(self, di_sensor):
         hass = _hass_with_meter(0.0, "L")

--- a/tests/test_valve_operator.py
+++ b/tests/test_valve_operator.py
@@ -7,6 +7,7 @@ import contextlib
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from never_dry.const import SAFETY_LAYER_SPREAD
 from never_dry.valve_fsm import FailureKind, FsmConfig, ValveState
 from never_dry.valve_operator import OperationResult, OperationStatus, ValveOperator
 
@@ -925,7 +926,10 @@ async def test_hw_max_duration_called_on_open(hass):
     set_value_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("number", "set_value")]
     assert len(set_value_calls) == 1
     assert set_value_calls[0].args[2]["entity_id"] == "number.hw_timer"
-    assert set_value_calls[0].args[2]["value"] == pytest.approx(120.0)
+    # Outermost of the three layers: the delivery bound is 120 s, the watchdog
+    # sits a spread above it and the on-device timer a spread above that, so
+    # each net can catch the failure of the one before instead of racing it.
+    assert set_value_calls[0].args[2]["value"] == pytest.approx(120.0 * SAFETY_LAYER_SPREAD**2)
 
 
 async def test_hw_max_duration_not_called_on_failed_open(hass):
@@ -1007,7 +1011,7 @@ async def test_hw_max_duration_called_once_per_open(hass):
 
 
 async def test_hw_max_duration_with_minute_multiplier(hass):
-    """Multiplier is applied: 120s * (1/60) = 2.0 minutes written to entity."""
+    """Multiplier is a unit conversion, applied on top of the layer spread."""
     op = ValveOperator(
         hass=hass,
         switch_entity_id="switch.valve",
@@ -1031,7 +1035,8 @@ async def test_hw_max_duration_with_minute_multiplier(hass):
 
     set_value_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("number", "set_value")]
     assert len(set_value_calls) == 1
-    assert set_value_calls[0].args[2]["value"] == pytest.approx(2.0, rel=1e-3)
+    # The written value is rounded to one decimal, as the entity expects.
+    assert set_value_calls[0].args[2]["value"] == round(2.0 * SAFETY_LAYER_SPREAD**2, 1)
 
 
 async def test_hw_max_duration_mqtt_fallback_when_no_entity(hass):
@@ -1061,7 +1066,8 @@ async def test_hw_max_duration_mqtt_fallback_when_no_entity(hass):
     mqtt_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("mqtt", "publish")]
     assert len(mqtt_calls) == 1
     assert mqtt_calls[0].args[2]["topic"] == "zigbee2mqtt/valve/set"
-    assert mqtt_calls[0].args[2]["payload"] == '{"irrigation_duration": 60.0}'
+    expected = round(60.0 * SAFETY_LAYER_SPREAD**2, 1)
+    assert mqtt_calls[0].args[2]["payload"] == f'{{"irrigation_duration": {expected}}}'
 
 
 async def test_hw_max_duration_entity_tried_before_mqtt(hass):
@@ -1104,7 +1110,7 @@ async def test_hw_max_duration_entity_tried_before_mqtt(hass):
 
     assert entity_attempted, "entity path was never tried"
     assert len(mqtt_calls) == 1
-    assert mqtt_calls[0]["payload"] == "30.0"
+    assert mqtt_calls[0]["payload"] == str(round(30.0 * SAFETY_LAYER_SPREAD**2, 1))
 
 
 async def test_hw_max_duration_exception_is_swallowed(hass, caplog):

--- a/tests/test_valve_operator.py
+++ b/tests/test_valve_operator.py
@@ -7,7 +7,6 @@ import contextlib
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from never_dry.const import SAFETY_LAYER_SPREAD
 from never_dry.valve_fsm import FailureKind, FsmConfig, ValveState
 from never_dry.valve_operator import OperationResult, OperationStatus, ValveOperator
 
@@ -926,10 +925,9 @@ async def test_hw_max_duration_called_on_open(hass):
     set_value_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("number", "set_value")]
     assert len(set_value_calls) == 1
     assert set_value_calls[0].args[2]["entity_id"] == "number.hw_timer"
-    # Outermost of the three layers: the delivery bound is 120 s, the watchdog
-    # sits a spread above it and the on-device timer a spread above that, so
-    # each net can catch the failure of the one before instead of racing it.
-    assert set_value_calls[0].args[2]["value"] == pytest.approx(120.0 * SAFETY_LAYER_SPREAD**2)
+    # No hw provider passed: the on-device timer mirrors the watchdog value.
+    # The ladder itself is the zone's business, not the operator's.
+    assert set_value_calls[0].args[2]["value"] == pytest.approx(120.0)
 
 
 async def test_hw_max_duration_not_called_on_failed_open(hass):
@@ -1011,7 +1009,7 @@ async def test_hw_max_duration_called_once_per_open(hass):
 
 
 async def test_hw_max_duration_with_minute_multiplier(hass):
-    """Multiplier is a unit conversion, applied on top of the layer spread."""
+    """Multiplier is applied: 120s * (1/60) = 2.0 minutes written to entity."""
     op = ValveOperator(
         hass=hass,
         switch_entity_id="switch.valve",
@@ -1035,8 +1033,7 @@ async def test_hw_max_duration_with_minute_multiplier(hass):
 
     set_value_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("number", "set_value")]
     assert len(set_value_calls) == 1
-    # The written value is rounded to one decimal, as the entity expects.
-    assert set_value_calls[0].args[2]["value"] == round(2.0 * SAFETY_LAYER_SPREAD**2, 1)
+    assert set_value_calls[0].args[2]["value"] == pytest.approx(2.0, rel=1e-3)
 
 
 async def test_hw_max_duration_mqtt_fallback_when_no_entity(hass):
@@ -1066,8 +1063,7 @@ async def test_hw_max_duration_mqtt_fallback_when_no_entity(hass):
     mqtt_calls = [c for c in hass.services.async_call.call_args_list if c.args[:2] == ("mqtt", "publish")]
     assert len(mqtt_calls) == 1
     assert mqtt_calls[0].args[2]["topic"] == "zigbee2mqtt/valve/set"
-    expected = round(60.0 * SAFETY_LAYER_SPREAD**2, 1)
-    assert mqtt_calls[0].args[2]["payload"] == f'{{"irrigation_duration": {expected}}}'
+    assert mqtt_calls[0].args[2]["payload"] == '{"irrigation_duration": 60.0}'
 
 
 async def test_hw_max_duration_entity_tried_before_mqtt(hass):
@@ -1110,7 +1106,7 @@ async def test_hw_max_duration_entity_tried_before_mqtt(hass):
 
     assert entity_attempted, "entity path was never tried"
     assert len(mqtt_calls) == 1
-    assert mqtt_calls[0]["payload"] == str(round(30.0 * SAFETY_LAYER_SPREAD**2, 1))
+    assert mqtt_calls[0]["payload"] == "30.0"
 
 
 async def test_hw_max_duration_exception_is_swallowed(hass, caplog):


### PR DESCRIPTION
## What

The safety timeout used to be combined with the expected duration by taking the **greater** of the two:

```python
return max(self._delivery_timeout, round(self._guard_duration_s * 1.1))
```

That made the configured value a *floor*. Two different questions were sharing one number — *how long should the job take* is a prediction about the work, *how long before something is wrong* is a bound on failure — and `max()` meant the estimate could only ever loosen the bound. A zone with five minutes of work was guarded with the one-hour default, and a flow meter that stopped counting kept the valve open for the whole hour.

The bound is now the expected duration times a margin, **capped** by the configured value:

```python
return min(self._delivery_timeout, round(expected_s * DELIVERY_DURATION_MARGIN))
```

The field goes back to meaning what the user manual has always said it means: an upper bound you can tighten but not loosen.

## Three layers, spaced

Each safety layer exists to catch the failure of the one before it — the delivery loop ends a normal run, the watchdog catches a loop that is stuck or gone, the on-device timer catches a valve when Home Assistant itself is gone. Equal values made them race instead: the watchdog is armed at valve open while the loop only starts counting once the open is confirmed, so it would trip *first* and report a fault where the loop was about to close in good order.

Each layer now sits `SAFETY_LAYER_SPREAD` (x1.25) above the previous one, and every one of them is capped by the configured timeout — the user's value means "never longer than this", so no layer may sit above it.

## Behaviour that does not change

Zones with **no guard flow rate** configured. With no estimate there is nothing to bound with, so the configured timeout is still all there is and the three layers collapse onto it — the same flat ladder as before, which is what the configuration deserves when it gives us nothing to derive one from.

## When the cap bites

If a zone genuinely needs longer than the user allows, it now logs one warning naming the numbers instead of quietly stopping short every cycle. Under-watering in silence is the same failure this bound exists to prevent, only in the other direction.

## Scope

Closes the second report on #173 (stalled flow meter). The **first** report on that issue — the flow verification window, AI-257 — is not touched by this work, so #173 stays open.

## Tests

1056 passing, ruff check and ruff format clean. New coverage:
- `tests/test_delivery_modes.py` — reproduces the stalled meter: a delivery whose meter freezes now ends at the job's scale rather than at the hour.
- `tests/test_expected_duration.py` — the ladder: cap bites, cap does not bite, no guard flow collapses all three.