### PR TITLE
docs: state the retry budget and the scheduled-mode rule as the code has them

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ NeverDry tracks how much water your soil has lost to heat and wind, and how much
 
 **And it makes sure the valve always closes.**
 
-If a valve doesn't respond after three attempts, NeverDry blocks that zone and shows a warning on your dashboard. Three independent mechanisms make sure water can't run indefinitely — hardware timeout, software watchdog, and a per-valve state machine that remembers what happened.
+If a valve stops responding, NeverDry keeps trying — six attempts, with a growing pause between them, because a radio hiccup is not a broken valve — and only then blocks that zone and shows a warning on your dashboard. Three independent mechanisms make sure water can't run indefinitely — hardware timeout, software watchdog, and a per-valve state machine that remembers what happened.
 
 ## Features
 
@@ -40,7 +40,7 @@ If a valve doesn't respond after three attempts, NeverDry blocks that zone and s
 - **Knows how much water to deliver** — calculates exactly how many liters each zone needs; if you have a flow meter, it measures delivery directly; otherwise it computes run time from flow rate
 - **Zones are independent** — the rose bed and the lawn dry out at different rates; each zone tracks its own deficit
 - **Skips irrigation after rain** — tracks how much rain actually fell and subtracts it from the deficit
-- **Valve always closes** — if a valve doesn't respond 3 times, NeverDry blocks it, shows the state on the dashboard, and waits for you to check
+- **Valve always closes** — if a valve is still not responding after six tries, NeverDry blocks it, shows the state on the dashboard, and waits for you to check
 - **Two scheduling modes** — water when the deficit crosses a threshold (Mode A) or every night based on current deficit (Mode B)
 - **Works without valves too** — no hardware? NeverDry sends a notification when watering is needed and by how much
 - **Emergency stop** — one button closes all valves immediately

--- a/docs/design/valve-state-machine.md
+++ b/docs/design/valve-state-machine.md
@@ -87,9 +87,15 @@ stateDiagram-v2
 ```
 
 Any failure transition increments the consecutive-failure counter. When
-the counter reaches `max_consecutive_failures` (default **3**) the
-target state is `MAINTENANCE` instead of `IDLE`, and an
-`EnterMaintenance` action is emitted alongside the `NotifyFailure`.
+the counter reaches `max_consecutive_failures` the target state is
+`MAINTENANCE` instead of `IDLE`, and an `EnterMaintenance` action is
+emitted alongside the `NotifyFailure`.
+
+`FsmConfig` defaults that threshold to **3**, but the default is never
+what runs: `ValveOperator` derives it as `max_retries + 1` (**6**), so one
+command owns its entire retry budget and cannot trip `MAINTENANCE`
+half-way through it. A fully-failed command reaches the threshold exactly
+at its definitive failure, never before.
 
 ## Diagram — no flow meter
 
@@ -148,7 +154,7 @@ itself have produced the false `CLOSE_VERIFICATION_FAILED`.
 | `flow_verify_timeout_s` | 10.0 | `OPEN` → `OBS_FLOW_POSITIVE` (flow meter only) |
 | `close_timeout_s` | 10.0 | `REQ_CLOSE` → `OBS_SWITCH_OFF` |
 | `leak_timeout_s` | 10.0 | `CLOSED` → `OBS_FLOW_ZERO` (flow meter only) |
-| `max_consecutive_failures` | 3 | Threshold for entering `MAINTENANCE` |
+| `max_consecutive_failures` | 3 in `FsmConfig`, **6** in production | Threshold for entering `MAINTENANCE`. `ValveOperator` always overrides the FSM default with `max_retries + 1` |
 
 A clean cycle resets the counter:
 - With flow meter: `CLOSED` → `IDLE` via `OBS_FLOW_ZERO`.
@@ -188,8 +194,8 @@ production. One operator per configured valve. It:
 ### Retry policy
 
 The operator retries **transient (communications) failures** with
-exponential backoff up to `max_retries` (default 2, total 3 attempts).
-Physical failures are surfaced immediately:
+exponential backoff up to `max_retries` (default **5**, so **6 attempts**
+in total). Physical failures are surfaced immediately:
 
 | Failure | Retry? | Why |
 |---|---|---|
@@ -198,9 +204,13 @@ Physical failures are surfaced immediately:
 | `ACTUATION_FAILED` | ✗ | Hydraulic / mechanical issue — retry cannot unblock it |
 | `CLOSE_LEAK` | ✗ | Stuck-open valve — retry wastes water during the second close attempt |
 
-Default backoff: `(1.0s, 2.0s, 4.0s)` — exponential, indexed by retry
-number. `flow_zero_threshold` defaults to `0.05` (unit depends on the
-flow sensor; the controller will pass a unit-aware value).
+Default backoff: `(1.0s, 2.0s, 4.0s, 8.0s, 16.0s)` — exponential, indexed
+by retry number, so the six attempts span about 31 s of backoff on top of
+each attempt's own timeout. A notification is withheld while attempts
+remain: on a flaky Zigbee mesh a late confirmation is routine, and
+alerting on every attempt produced spurious criticals (GH #105).
+`flow_zero_threshold` defaults to `0.05` (unit depends on the flow sensor;
+the controller will pass a unit-aware value).
 
 ### Pre-checks
 

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -134,7 +134,7 @@
             <div class="feature-card">
                 <div class="icon">🛡️</div>
                 <h3>The valve always closes</h3>
-                <p>If a valve doesn't respond after three attempts, NeverDry blocks that zone and shows a warning on your dashboard. Three independent safety mechanisms make sure water can't run indefinitely.</p>
+                <p>If a valve stops responding, NeverDry keeps trying &mdash; six attempts, with a growing pause between them &mdash; and only then blocks that zone and shows a warning on your dashboard. Three independent safety mechanisms make sure water can't run indefinitely.</p>
             </div>
             <div class="feature-card">
                 <div class="icon">🌱</div>

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -482,7 +482,7 @@ The per-zone **Irrigate** button calls the `never_dry.irrigate_zone` service. Ne
 Same code path as trigger 2, only the source differs:
 
 - **Mode A (reactive)** — fires when the deficit crosses the threshold. `last_irrigation_source = "reactive"`.
-- **Mode B (scheduled)** — fires at the configured daily time if the deficit is above threshold. `last_irrigation_source = "scheduled"`.
+- **Mode B (scheduled)** — fires at the configured daily time **regardless of the threshold**: a schedule means "top this zone back up at this hour", and gating it on the reactive threshold would silently turn every scheduled run into a reactive one. The dose is whatever deficit has accumulated, so the zone is topped up even when it sits below the threshold; the only zone skipped is one with nothing to refill (deficit ≤ 0). The threshold stays a *reactive*-mode concept. `last_irrigation_source = "scheduled"`.
 - **Custom automation** — your own automation calling `never_dry.irrigate_zone` or `never_dry.irrigate_all`. Source = `"button"` (same as the manual button — the service entry point is shared).
 
 All of them go through `ValveOperator` and `_deliver_water`. Volume tracking, partial irrigation, and the `never_dry_irrigation_complete` event behave identically to trigger 2.


### PR DESCRIPTION
Two user-facing claims had drifted from the code, and each was repeated across more than one document — so a reader checking one against another found them agreeing on the wrong answer.

No behaviour change: documentation only.

## Retry budget — README, landing page, state-machine note

All three said a valve is blocked **after three attempts**. The operator has retried five times — **six attempts** — since the maintenance threshold was derived as `max_retries + 1`, so that one command owns its whole retry budget and cannot trip `MAINTENANCE` half-way through it.

The design note carried two more stale defaults in the same section: the backoff tuple `(1, 2, 4)` instead of `(1, 2, 4, 8, 16)`, and the `FsmConfig` default of 3 presented as if it were what runs. It is now stated as what it is — a dataclass default that `ValveOperator` always overrides — with the reason for the override.

The eight translated landing pages do **not** carry the claim: their safety copy is worded differently and states no number. Verified, not assumed.

## Scheduled mode — user manual

Said Mode B fires "at the configured daily time **if the deficit is above threshold**". It fires at its hour whatever the deficit, skipping only a zone with nothing to refill (deficit ≤ 0). Gating a schedule on the reactive threshold turns every scheduled run into a reactive one, which is the distinction the two modes exist to keep apart.

The README already described this correctly, which is how the divergence stayed invisible.

## Not in scope

Two further stale claims in the same files, deliberately left for a separate pass so this one stays reviewable:

- `developer_manual.md` §2.9 — the resolution orders `explicit value > system_type default` and `manual kc > plant_family`, superseded by the preset/override contract (the dropdown decides).
- `valve-state-machine.md` — two parentheticals describing the notifier as "to be replaced with the unified notifier", which now exists and is wired.