### PR TITLE
release: bump version to 0.11.1-beta.7

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.6"
+  "version": "0.11.1-beta.7"
 }


### PR DESCRIPTION
Beta of the 0.11.1 line carrying one change, reported twice from the field on the same issue.

## A delivery is bounded by the job, not by a constant ([#173])

The safety timeout used to be combined with the expected duration by taking the **greater** of the two, which made the configured value a floor: a zone with five minutes of work was guarded with the one-hour default, and a flow meter that stopped counting mid-run kept the valve open for the whole hour. That second case is exactly what the reporter hit.

The bound is now the expected duration times a margin, **capped** by the configured timeout — the field means what the manual has always said it means, an upper bound you can tighten but not loosen. The watchdog and the on-device timer scale with it, each spaced above the layer it protects so it catches that layer's failure instead of racing it.

For the reporting zone (5.6 L at 1.2 L/min, 283 s of expected work) the ladder goes from 3600/3600/3600 s to 566 s delivery bound, 708 s watchdog, 885 s on-device timer.

**Unchanged for zones with no guard flow rate**: with no estimate there is nothing to bound with, so the three layers collapse onto the configured value exactly as before. A zone that genuinely needs longer than allowed now says so once instead of quietly stopping short.

## Also in this beta

Documentation only, no behaviour: the retry budget (six attempts, not three) and the scheduled-mode rule (fires at its hour whatever the deficit) now say what the code does, across README, landing page, design note and user manual ([#179]).

## Still open on #173

The **primary** report on that issue — `flow_verify_timeout_s` as a fixed 10 s constant, which blocks a low-flow bed with a 1 L-resolution meter from ever starting a cycle — is **not** addressed here. It needs the verification window derived from meter resolution over flow rate. The issue stays open for it.

Version bump only.

[#173]: https://github.com/never-dry/NeverDry/issues/173
[#179]: https://github.com/never-dry/NeverDry/pull/179