### PR TITLE
release: bump version to 0.11.1-beta.8

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1-beta.7"
+  "version": "0.11.1-beta.8"
 }


### PR DESCRIPTION
Packages what develop already carries but no pre-release has ever shipped.

Two fixes landed after the beta.7 bump and have been sitting untagged since:

- **#181** `fix(lifecycle)` — release every subscription when a config entry is unloaded.
- **#182** — warn when a valve is not answering, instead of letting the zone look inert.

That is 5 files and 179 lines of `custom_components/` diverging from the
`v0.11.1-beta.7` tag, so a HACS tester installing "the latest beta" today does
not have either of them. #182 in particular is the one reported on #173 as
shipped, which makes the gap worth closing before any stable release is cut
from this branch.

Version bump only — no code changes in this PR.