### PR TITLE
chore(pages): add the Google Search Console verification token

### DIFF
--- a/docs/gh-pages/google606fb593a72e8644.html
+++ b/docs/gh-pages/google606fb593a72e8644.html
@@ -1,0 +1,1 @@
+google-site-verification: google606fb593a72e8644.html


### PR DESCRIPTION
One file, one line, served from the site root so Search Console can fetch it
and verify ownership of the domain.

Targets `main` because the Pages workflow only deploys from there, on changes
under `docs/gh-pages/**`.

It has to keep existing after verification: Google re-checks the token
periodically, and deleting it silently un-verifies the property.