### PR TITLE
Release notes from the changelog, and docs that match what 0.11.1 shipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,36 @@ jobs:
           cd custom_components/never_dry
           zip -r ../../never_dry.zip . -x '*__pycache__*'
 
+      - name: Compose release notes from the changelog
+        id: notes
+        run: |
+          # A stable release is described by its CHANGELOG section, in the words
+          # a user needs. Asking GitHub to generate the notes instead produces
+          # the raw list of merged pull requests — back-merges, version bumps
+          # and CI bumps included — which is internal churn served to people who
+          # install the integration.
+          #
+          # A missing section FAILS the release rather than falling back: the
+          # thing being guarded against is shipping a version nobody wrote down,
+          # and a silent fallback is exactly how that goes unnoticed.
+          #
+          # Pre-releases have no changelog section by convention, so they keep
+          # the generated notes: their audience is testers, who are the people
+          # the pull request list is actually useful to.
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            echo "Pre-release ${{ github.ref_name }}: keeping the generated notes."
+            echo "from_changelog=false" >> "$GITHUB_OUTPUT"
+          else
+            python3 scripts/release_notes.py "${{ steps.version.outputs.version }}" \
+              --out release_notes.md
+            echo "from_changelog=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.from_changelog == 'true' && 'release_notes.md' || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.from_changelog != 'true' }}
           files: never_dry.zip
           # Tags with a prerelease suffix (v0.11.0-beta.1) must be marked as
           # pre-release: HACS only offers them to users who enabled beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-25
+
+A patch stable for the 0.11 line. Theme: **stop failing quietly**. Almost everything here was a fault that produced no error — a valve that looked inert, a probe pinned at zero, a reload leaving two copies running, an override that came back on its own, a yearly rain total that stayed at zero while it rained.
+
+Nothing in the water-balance engine changes: the domain model classes and the Hargreaves and Penman-Monteith ET tiers are present in the code but inert, with no caller in production. Wiring them is the next minor and goes through a pre-release first.
+
+**Upgrading.** Update through HACS and restart Home Assistant. There is nothing to configure by hand and no entity is renamed or removed — but two things are worth knowing.
+
+Your zone settings are migrated for you: a zone holding a custom efficiency or a manual Kc gets that value marked as *Custom* in the matching dropdown, so it goes on watering exactly as it did. Without that step the number would be ignored at the next start and the zone would fall back to its preset — a drip zone set to 0.55 would jump to 0.92 and water less, with nobody having touched it. Site exposure is deliberately left alone: there the dropdown already decided, so switching a leftover factor on would *change* the watering rather than preserve it. The config flow points those leftovers out the next time you save the zone.
+
+Going back to 0.11.0 is not supported once 0.11.1 has started: the migration marks your configuration as a newer schema, and 0.11.0 refuses to load a configuration it does not understand. If you want a way back, take a backup before updating.
+
 ### Changed
 - **A delivery is now bounded by the job, not by a constant** ([#173]). The safety timeout used to be combined with the expected duration by taking the *greater* of the two, which made the configured value a floor: a zone with five minutes of work was guarded with the one-hour default, and a flow meter that stopped counting mid-run kept the valve open for the whole hour. The bound is now the expected duration (`volume / flow rate`) times a safety margin, capped by the configured timeout — the field goes back to meaning what the manual has always said it means, an upper bound you can tighten but not loosen. If a zone genuinely needs longer than you allow, it now says so once instead of quietly stopping short. Zones with no guard flow rate configured are unaffected: with no estimate there is nothing to bound with, and the configured timeout is still all there is.
+- **One rule for the three preset/override pairs** ([#168]). System type, plant family and site exposure each pair a dropdown with a box for a custom value, and each behaved differently. The rule is now the same everywhere and stated once: **the dropdown decides, and the box is read only when the dropdown says *Custom***. A number typed in the box while a preset is selected no longer takes effect silently. The step on the three dimensionless factors goes from 0.05 to 0.01, because the preset values are not multiples of 0.05 — drip is 0.92 and pop-up sprinklers 0.68, so dialling one back by hand used to be impossible.
 
 ### Added
 - **The zone card says when a valve is not answering.** An amber warning appears as soon as a command goes unanswered, instead of the press appearing to do nothing. A valve that drops off the radio mesh periodically keeps reporting a perfectly ordinary "off", so it never shows as unavailable: the only symptom used to be a button that seemed inert for the better part of a minute, followed by a blocked zone. The warning distinguishes *did not answer* — a radio problem: check the link, check the batteries — from *answered and delivered no water*, which is hydraulic and needs a different look. It clears itself as soon as the valve replies, and it stays quiet for the first few minutes after a restart, when Zigbee entities are not loaded yet and every zone would otherwise cry wolf. New `valve_reachable` and `valve_last_failure` attributes carry it. See the user manual, *When a valve stops answering*.
@@ -16,10 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Reset yearly rain** — clears the shared year-to-date rain total (behind every zone's *Rain Yearly [L]*) without waiting for 1 January. The total is a saved value that survives a restart and a plain reinstall, so this button is the way to clear a wrong figure — e.g. after switching rain sensor type.
   - **Reset yearly water** — clears *Irrigated Yearly [L]* for every zone at once; each zone's lifetime total is preserved.
   - Both are state-only: recorder long-term statistics (Energy dashboard) are left untouched.
-- Per-zone **site exposure**: a microclimate factor (`k_mc`) that multiplies the crop coefficient, so a shaded, windy or paving-adjacent zone keeps its seasonal Kc curve instead of being frozen at one value by a constant Kc override ([#146]). Presets from the landscape coefficient method (0.60 deep shade … 1.20 reflected heat), plus an *Advanced (custom factor)* entry (0.1–1.5). Default *Full sun, open* (×1.00) leaves existing zones unchanged.
+- Per-zone **site exposure**: a microclimate factor (`k_mc`) that multiplies the crop coefficient, so a shaded, windy or paving-adjacent zone keeps its seasonal Kc curve instead of being frozen at one value by a constant Kc override ([#146], contributed by @philipgiuliani — the first outside code change NeverDry has shipped). Presets from the landscape coefficient method (0.60 deep shade … 1.20 reflected heat), plus an *Advanced (custom factor)* entry (0.1–1.5). Default *Full sun, open* (×1.00) leaves existing zones unchanged.
 - Zone Kc sensor attributes `kc_base`, `exposure` and `microclimate_factor`, so an effective Kc can be traced back to the curve and the factor it came from.
 
 ### Fixed
+- **Yearly rain stayed at zero for anyone using a soil-moisture probe** ([#144]). Rain is a system-wide quantity — one sky over the whole garden — but the credit lived inside the ET branch of the calculation, and a VWC setup bypasses that branch entirely. Every zone's *Rain Yearly [L]* therefore read 0 forever, with the rain sensor tracked, firing and correct. The credit now runs in both modes. ET behaviour is unchanged, and rain is still not subtracted from a VWC deficit — the probe already reflects it, because the water landed on the soil the probe is in.
+- **An override set by accident could not be cleared** ([#165]). Emptying a zone's efficiency, manual Kc, exposure, microclimate factor, delivery timeout or irrigation time silently restored the previous value: the form re-injected its own default whenever a field came back empty. Efficiency had a second, separate reason — it was a slider, and a slider always submits a number, so it had no empty state to send at all. It is a box now, like the Kc field beside it. Fields that must always hold a value keep their default.
+- **A partial delivery on 1 January no longer adds to last year's total.** *Irrigated Yearly [L]* is reset when the calendar year turns, but only the full-delivery path did so: a session that stopped short of its target — a stop, a timeout, a valve that closed early — carried the previous year's figure forward instead. The counter feeds long-term statistics, so the jump reached the Energy dashboard too. Both settle paths now share one answer.
 - **Reloading no longer leaves the previous setup running underneath the new one.** Saving anything in the options flow reloads the integration, and until now the reload left the old copy subscribed: the retired hub kept waking on every temperature reading and advancing a second water balance, and each valve gained another operator — each with its own watchdog, able to force a valve closed under the one legitimately driving it. The count grew with every edit. Nothing was visibly broken, which is why it lasted: the symptoms are drifting deficits and valves that close early for no reason the log explains. Every listener is now released when the entity or the controller goes away.
 - Soil-moisture probes reporting a **percentage** no longer stop a zone from watering ([#170]). A reading of 45 rather than 0.45 made `(field_capacity − vwc)` negative for every possible value — including a bone-dry 15 % — and the clamp that keeps a deficit from going negative pinned it at exactly zero, silently and forever. Readings are now normalised at the input boundary: above 1 is read as a percentage, exactly 1.0 as a saturated fraction. Consumer probes (Ecowitt, most Zigbee models) work without a template-sensor helper.
 - A moisture reading that is not a water content on either scale — a raw ADC count, a negative, a NaN — is now refused instead of being clamped to "saturated": the last good deficit is held and one warning is logged, naming the sensor.
@@ -61,9 +77,13 @@ First stable of the 0.11 line. Theme: **trust your water balance**.
 
 For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/never-dry/NeverDry/releases) page.
 
-[Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.1
 [0.11.0]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.0
 [#173]: https://github.com/never-dry/NeverDry/issues/173
+[#168]: https://github.com/never-dry/NeverDry/pull/168
+[#165]: https://github.com/never-dry/NeverDry/issues/165
+[#144]: https://github.com/never-dry/NeverDry/issues/144
 [#170]: https://github.com/never-dry/NeverDry/issues/170
 [#146]: https://github.com/never-dry/NeverDry/issues/146
 [#142]: https://github.com/never-dry/NeverDry/pull/142

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If a valve stops responding, NeverDry keeps trying — six attempts, with a grow
 - **Knows how much water to deliver** — calculates exactly how many liters each zone needs; if you have a flow meter, it measures delivery directly; otherwise it computes run time from flow rate
 - **Zones are independent** — the rose bed and the lawn dry out at different rates; each zone tracks its own deficit
 - **Skips irrigation after rain** — tracks how much rain actually fell and subtracts it from the deficit
+- **Tells you when a valve goes quiet** — a flat battery valve keeps reporting a perfectly ordinary "off", so nothing looks wrong while the zone dries out; NeverDry warns on the card as soon as a command goes unanswered, and tells a radio problem apart from a valve that answers and delivers no water
 - **Valve always closes** — if a valve is still not responding after six tries, NeverDry blocks it, shows the state on the dashboard, and waits for you to check
 - **Two scheduling modes** — water when the deficit crosses a threshold (Mode A) or every night based on current deficit (Mode B)
 - **Works without valves too** — no hardware? NeverDry sends a notification when watering is needed and by how much

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -302,6 +302,8 @@ Shows the volume of water needed for this specific zone in liters.
 | `flow_rate_lpm` | Valve flow rate |
 | `threshold_mm` | Mode A trigger threshold |
 | `irrigating` | `true` if this zone is currently being irrigated |
+| `valve_reachable` | `true` when the valve is answering, `false` when it is not, and absent when there is no evidence either way — a zone with no valve, or one not heard from yet. Absence is never a fault. |
+| `valve_last_failure` | Why the last command failed, when one did. It separates a valve that never answered from one that answered and moved no water. |
 
 ### Water totals: Rain Yearly and Irrigated Yearly
 
@@ -704,6 +706,15 @@ If you have a soil moisture sensor that reports volumetric water content (VWC), 
 - Default field capacity: 0.30 (30%)
 - Default root depth: 0.30 m
 
+**Either scale works — no template sensor needed.** A probe may report water
+content as a fraction (`0.25`) or as a percentage (`25`), and NeverDry reads
+both: a value above 1 is taken as a percentage, and exactly `1.0` as a saturated
+fraction. Consumer probes — Ecowitt, most Zigbee models — report percentages and
+work as they come, without a helper to divide by 100. A reading that is not a
+water content on either scale (a raw ADC count, a negative, a `NaN`) is refused
+rather than believed: the zone holds its last good deficit and one warning is
+logged naming the sensor.
+
 This gives the most accurate deficit estimate, especially in variable soil conditions.
 
 ### Seasonal adjustments
@@ -828,6 +839,29 @@ concurrent cycle is logged, or `Reactive irrigation triggered:` to confirm it fi
 - Verify the source sensors are online and reporting values
 - Check the Home Assistant logs: **Settings → System → Logs** → filter for `never_dry`
 
+### When a valve stops answering
+
+The zone card shows an **amber warning** — *"Valve not responding"* — as soon as a valve stops answering NeverDry.
+
+**Why this exists.** A battery valve that runs flat mid-season is close to invisible. The switch goes on showing a perfectly ordinary *off*, the battery sensor goes on showing whatever it last managed to report, and a Zigbee coordinator will not call the device missing for hours, because a valve that sleeps is *supposed* to be quiet. Meanwhile the zone's deficit climbs and looks exactly like a dry spell. Before this warning existed the only symptom was a button that seemed inert for the better part of a minute, followed by a blocked zone.
+
+**What it means, and what it does not.** It means the valve is not *answering*: a radio problem, or a flat battery. It does **not** mean the valve is broken or that no water came out. A valve that answers normally and delivers nothing — supply turned off, clogged filter — is a different fault and deliberately does not raise this warning, because it would send you to look in the wrong place. The two are told apart by `valve_last_failure` (see §6).
+
+**How NeverDry decides.** Two kinds of evidence, and they are not equally strong:
+
+- **A command went unanswered.** NeverDry asked and got nothing back. That is proof, and it counts immediately — this is also the case that actually bites, because a flaky valve keeps reporting a level and so never looks unavailable.
+- **The valve simply has not spoken** — its entity is missing or `unavailable`. Nobody asked, so this is weaker: right after a restart it is the normal state of every Zigbee entity for a minute or two. During that grace period the card says nothing rather than crying wolf. The grace ends early as soon as the valve is seen alive even once, so a valve that comes up and then drops out is reported straight away.
+
+**What to check**, in the order that usually pays:
+
+1. **Batteries.** The most common cause by far, and the one the valve cannot report — a device with no power cannot tell you it has no power.
+2. **Radio range.** A valve at the edge of the mesh drops out in wet weather and returns in dry. If it recovers on its own and the warning comes back days later, add a mains-powered Zigbee device between the coordinator and the valve to act as a router.
+3. **The coordinator.** If *every* zone warns at once, the problem is upstream — the gateway, not the valves.
+
+**It clears itself.** As soon as the valve answers again the warning disappears. You never have to dismiss it.
+
+**When you are told, and when you are not.** NeverDry notifies you when a watering was actually **attempted** and the valve did not answer — whether you pressed the button or the schedule did. It does **not** go looking for a dead valve between waterings: nothing polls the valves on a timer, so a battery that dies on Monday is reported at the next watering, not the moment it dies. Until then the amber warning on the card is the only sign, which is why it is worth having the card somewhere you actually look. Proactive checking is planned but not in this release.
+
 ### Deficit never increases
 
 - Is your temperature sensor reporting values above `t_base` (default 9°C)?
@@ -888,7 +922,7 @@ A: You can add new zones via **Settings → Devices & Services → NeverDry → 
 A: D_max (default 100 mm) is the maximum value the deficit can reach. It prevents the deficit from growing indefinitely during extended dry periods or sensor outages. In practice, values above 100 mm rarely occur in residential settings.
 
 **Q: What is the VWC sensor option?**
-A: If you have a soil moisture sensor that reports volumetric water content (as a fraction, e.g., 0.25 for 25%), the integration can calculate the deficit directly from that measurement instead of using the temperature-based ET model. This is more accurate but requires a suitable sensor.
+A: If you have a soil moisture sensor that reports volumetric water content, the integration can calculate the deficit directly from that measurement instead of using the temperature-based ET model. This is more accurate but requires a suitable sensor. Either scale is accepted — a fraction (`0.25`) or a percentage (`25`) — so the consumer probes that report percentages need no conversion helper.
 
 **Q: How accurate is the ET estimate?**
 A: With temperature only, the model explains 40–60% of the real ET variance in temperate climates. It's sufficient for residential use but not for professional agriculture. Adding T_max/T_min sensors (Hargreaves-Samani) improves accuracy to ~1 mm/day.

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""release_notes.py — Turn a CHANGELOG section into a GitHub release body.
+
+Usage:
+    python3 scripts/release_notes.py <version> [--changelog PATH] [--out PATH]
+
+Why this exists: the release workflow used to ask GitHub to generate the notes,
+which produces the raw list of merged pull requests — back-merges, version
+bumps and CI bumps included. That is the project's internal churn served to
+people who install the integration. The changelog already says what changed in
+the words a user needs, so the release body is taken from there instead.
+
+A release body has no link-reference section at the bottom, so the ``[#123]``
+references are resolved into absolute URLs on the way out.
+
+For a stable version the section is REQUIRED: a missing one fails the release
+rather than falling back, because the failure this guards against is shipping a
+version nobody wrote down. Pre-releases have no changelog section by
+convention, and the workflow does not call this for them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# "## [0.11.1] - 2026-08-25" — the date is required: an entry still sitting
+# under [Unreleased] has not been released, and must not be published as if it
+# had been.
+_HEADING = re.compile(r"^## \[(?P<version>[^\]]+)\] - (?P<date>\d{4}-\d{2}-\d{2})\s*$")
+_ANY_HEADING = re.compile(r"^## \[")
+_REF_DEF = re.compile(r"^\[(?P<label>#\d+)\]: (?P<url>\S+)\s*$", re.MULTILINE)
+_REF_USE = re.compile(r"\[(?P<label>#\d+)\]")
+
+COMPARE_URL = "https://github.com/never-dry/NeverDry/compare/v{previous}...v{version}"
+
+
+class SectionNotFound(Exception):
+    """The changelog has no released section for the requested version."""
+
+
+def _split_sections(text: str) -> list[tuple[str, int, int]]:
+    """Return (version, start_line, end_line) for every released section."""
+    lines = text.splitlines()
+    starts: list[tuple[str, int]] = []
+    for number, line in enumerate(lines):
+        match = _HEADING.match(line)
+        if match:
+            starts.append((match.group("version"), number))
+
+    sections = []
+    for version, start in starts:
+        end = len(lines)
+        # A section ends at the next "## [" heading of any kind, which includes
+        # [Unreleased] — so a section is never allowed to swallow the one below.
+        for number in range(start + 1, len(lines)):
+            if _ANY_HEADING.match(lines[number]):
+                end = number
+                break
+        sections.append((version, start, end))
+    return sections
+
+
+def _previous_version(sections: list[tuple[str, int, int]], version: str) -> str | None:
+    """The version released before ``version``, by changelog order."""
+    versions = [name for name, _, _ in sections]
+    try:
+        index = versions.index(version)
+    except ValueError:
+        return None
+    return versions[index + 1] if index + 1 < len(versions) else None
+
+
+def _resolve_references(body: str, definitions: dict[str, str]) -> str:
+    """Rewrite ``[#123]`` as ``[#123](url)``.
+
+    A reference with no definition is left alone rather than dropped: it still
+    reads as the issue number it is, and losing it silently would be worse than
+    leaving it unlinked.
+    """
+
+    def replace(match: re.Match[str]) -> str:
+        label = match.group("label")
+        url = definitions.get(label)
+        return f"[{label}]({url})" if url else label
+
+    # Only bare references — anything already followed by "(" is an inline link.
+    return re.sub(_REF_USE.pattern + r"(?!\()", replace, body)
+
+
+def build(text: str, version: str) -> str:
+    """Extract the release body for ``version`` from changelog ``text``."""
+    sections = _split_sections(text)
+    match = next((s for s in sections if s[0] == version), None)
+    if match is None:
+        released = ", ".join(name for name, _, _ in sections) or "none"
+        raise SectionNotFound(
+            f"CHANGELOG.md has no released section '## [{version}] - <date>'.\n"
+            f"Released sections found: {released}.\n"
+            "Write the entry (or promote [Unreleased] and date it) before tagging."
+        )
+
+    lines = text.splitlines()
+    _, start, end = match
+    body = "\n".join(lines[start + 1 : end]).strip()
+    if not body:
+        raise SectionNotFound(f"The section for {version} is empty — nothing to publish.")
+
+    body = _resolve_references(body, dict(_REF_DEF.findall(text)))
+
+    previous = _previous_version(sections, version)
+    if previous:
+        url = COMPARE_URL.format(previous=previous, version=version)
+        body += f"\n\n**Full changelog:** {url}\n"
+    return body + "\n" if not body.endswith("\n") else body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Version to publish, without the leading v")
+    parser.add_argument("--changelog", default="CHANGELOG.md", type=Path)
+    parser.add_argument("--out", type=Path, help="Write here instead of stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        body = build(args.changelog.read_text(encoding="utf-8"), args.version)
+    except SectionNotFound as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    if args.out:
+        args.out.write_text(body, encoding="utf-8")
+        print(f"Release notes for {args.version} written to {args.out}")
+    else:
+        print(body, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/release_notes.py — the changelog section that becomes the
+GitHub release body.
+
+The failure this guards against is silent: an extractor that returns an empty
+body, or the wrong section, still publishes a release. Nobody reads a release
+body before it is public, so the check has to happen here.
+
+Includes one test against the real CHANGELOG.md, because a fixture proves the
+parser works on the shape the parser expects — not on the file it will actually
+be handed.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_spec = importlib.util.spec_from_file_location("release_notes", REPO_ROOT / "scripts" / "release_notes.py")
+release_notes = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(release_notes)
+
+
+CHANGELOG = """# Changelog
+
+Preamble that must never appear in a release body.
+
+## [Unreleased]
+
+### Added
+- Something not released yet.
+
+## [0.11.1] - 2026-08-25
+
+Theme line.
+
+### Fixed
+- A probe reporting percentages no longer silences a zone ([#170]).
+- Something with no reference at all.
+
+## [0.11.0] - 2026-07-26
+
+### Added
+- The first stable ([#116]).
+
+[Unreleased]: https://github.com/never-dry/NeverDry/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.1
+[#170]: https://github.com/never-dry/NeverDry/issues/170
+[#116]: https://github.com/never-dry/NeverDry/issues/116
+"""
+
+
+def test_extracts_only_the_requested_section():
+    body = release_notes.build(CHANGELOG, "0.11.1")
+
+    assert "Theme line." in body
+    assert "A probe reporting percentages" in body
+    # The neighbours on both sides must stay out.
+    assert "Something not released yet" not in body
+    assert "The first stable" not in body
+    assert "Preamble" not in body
+
+
+def test_drops_its_own_version_heading():
+    body = release_notes.build(CHANGELOG, "0.11.1")
+
+    # The release is already titled by its tag; repeating it reads as a typo.
+    assert not body.startswith("## [0.11.1]")
+    assert "## [0.11.1]" not in body
+
+
+def test_resolves_references_to_absolute_links():
+    body = release_notes.build(CHANGELOG, "0.11.1")
+
+    # A release body has no link-reference section, so a bare [#170] would
+    # render as literal brackets.
+    assert "[#170](https://github.com/never-dry/NeverDry/issues/170)" in body
+    assert "[#170]." not in body
+
+
+def test_keeps_an_undefined_reference_readable():
+    changelog = CHANGELOG.replace("[#170]: https://github.com/never-dry/NeverDry/issues/170\n", "")
+
+    body = release_notes.build(changelog, "0.11.1")
+
+    # Unlinked but still legible, rather than silently dropped.
+    assert "#170" in body
+    assert "[#170]" not in body
+
+
+def test_appends_the_comparison_against_the_previous_release():
+    body = release_notes.build(CHANGELOG, "0.11.1")
+
+    assert "**Full changelog:** https://github.com/never-dry/NeverDry/compare/v0.11.0...v0.11.1" in body
+
+
+def test_no_comparison_for_the_oldest_release():
+    body = release_notes.build(CHANGELOG, "0.11.0")
+
+    assert "Full changelog" not in body
+
+
+def test_unreleased_is_not_publishable():
+    # [Unreleased] carries no date, so it is not a released section and must not
+    # be shipped as one.
+    with pytest.raises(release_notes.SectionNotFound):
+        release_notes.build(CHANGELOG, "Unreleased")
+
+
+def test_missing_section_fails_loudly_and_says_what_exists():
+    with pytest.raises(release_notes.SectionNotFound) as error:
+        release_notes.build(CHANGELOG, "0.12.0")
+
+    message = str(error.value)
+    assert "0.12.0" in message
+    assert "0.11.1" in message  # names what it did find, so the fix is obvious
+
+
+def test_empty_section_is_refused():
+    changelog = CHANGELOG.replace(
+        "Theme line.\n\n### Fixed\n"
+        "- A probe reporting percentages no longer silences a zone ([#170]).\n"
+        "- Something with no reference at all.\n",
+        "",
+    )
+
+    with pytest.raises(release_notes.SectionNotFound):
+        release_notes.build(changelog, "0.11.1")
+
+
+def test_the_real_changelog_yields_notes_for_the_shipped_version():
+    text = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    version = release_notes._split_sections(text)[0][0]
+
+    body = release_notes.build(text, version)
+
+    assert len(body) > 200
+    assert "## [" not in body  # no version heading leaked in
+    assert "]: https://" not in body  # no link-reference block leaked in


### PR DESCRIPTION
Follow-up to the 0.11.1 release (#188), which went out with two problems this fixes.

## The release notes were the pull request list

`release.yml` asked GitHub to generate the notes, so v0.11.1 was published with the raw list of forty merged pull requests — back-merges, beta version bumps and CodeQL bumps included. That is internal churn served to the people who install the integration, and it buries the handful of lines that concern them.

A stable release now publishes its `CHANGELOG.md` section, which is already written in the words a user needs. `scripts/release_notes.py` extracts it and resolves `[#123]` references into absolute URLs, because a release body has no link-reference block to define them.

**A missing section fails the release** rather than falling back. The failure being guarded against is shipping a version nobody wrote down, and a silent fallback is precisely how that goes unnoticed — as it just did. The error names the sections it did find, so the fix is obvious from the log. Pre-releases keep the generated notes: they have no changelog section by convention, and their audience is testers, who are the people a pull request list is genuinely useful to.

Ten tests, one of them against the real `CHANGELOG.md` rather than a fixture.

## The changelog and the docs did not match the release

- `[Unreleased]` is promoted to `[0.11.1]` and dated. Two shipped changes had never reached the file at all: yearly rain staying at zero on VWC setups, and an override that could not be cleared.
- The section now also carries what upgrading involves, which could not be read anywhere: the configuration is migrated so a custom efficiency or manual Kc keeps watering the zone as before, and **0.11.0 will not load a configuration 0.11.1 has migrated**.
- The published notes told readers to see the user manual, *When a valve stops answering*. That section exists only on the branch that wires the domain model, so the pointer led nowhere. It is written now — against the released behaviour, not ported: the branch version describes an active probe comparing valves with each other and needing three zones, none of which shipped.
- The manual states the real limit plainly: nothing polls the valves between waterings (`start_liveness_probe` has no caller), so a battery that dies on Monday is reported at the next watering attempt. Documenting the passive notification would promise a watch that is not being kept.
- `valve_reachable` and `valve_last_failure` shipped as attributes and were documented nowhere.
- The VWC guidance was **wrong**, not merely thin: two passages said the probe must report a fraction, "0.25 for 25%". Since this release either scale is read — which was the entire point, since consumer probes report percentages. The old text sent people to build a template helper they no longer need.

## Verification

1098 tests pass; `ruff check` and `ruff format --check` clean. The workflow YAML parses and both branches of the pre-release condition were exercised.