### PR TITLE
release: bump version to 0.12.0-beta.1

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.11.1"
+  "version": "0.12.0-beta.1"
 }


### PR DESCRIPTION
First pre-release of the 0.12 line, and the first in which the domain model runs the integration rather than sitting beside it.

A minor rather than a patch: the water balance moves into the model and the site chooses which one, the soil probe moves from the installation to the zone, and one "flow rate" becomes three named quantities. The `[Unreleased]` section of the changelog carries the summary and links the design notes.

Pre-release, so HACS offers it only to users who have enabled beta versions; everyone else stays on 0.11.1.

Worth exercising, for anyone testing:

- the water-balance method, and whether *Automatic* picks what your sensors actually support
- a supervised valve test on a zone with a water meter, especially a coarse one
- a zone with its own soil probe alongside a zone without one
- a flow-metered delivery that used to time out