### PR TITLE
Back-merge the CodeQL bump, and stop dependency updates drifting from develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
+
+# Every update opens against develop, not against the default branch. develop is
+# where work is integrated and verified; main receives it at release time along
+# with everything else. Without target-branch, a bump lands on main on its own,
+# develop drifts behind on the very actions its own CI runs, and each update
+# costs a back-merge — which it did twice before this line existed.
+
 updates:
   # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     # One PR for all action bumps, not one per action path. Without this,
     # actions that must stay on the SAME version get split across PRs and
     # each one lands half the pair: codeql-action/init and /analyze on
@@ -28,6 +36,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "develop"
     commit-message:
       prefix: "deps"
     labels:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:python"


### PR DESCRIPTION
Two commits: the back-merge that was needed, and the reason it was needed.

## The back-merge

`main` got `github/codeql-action` v4.37.6 → v4.37.8 (#187). One file, two lines, pinned by SHA.

## Why it kept happening

Dependabot had no `target-branch`, so it defaulted to the repository's default branch. Every bump therefore landed on `main` alone — `develop` went on running its CI with the *older* action, and re-converging the two cost a back-merge. That happened twice, and the second time left a green, up-to-date, entirely uncontroversial CodeQL bump sitting open for nine days.

`develop` is the integration branch by the model this project already documents: `main` receives work once it has been verified, at release time. A dependency bump is not an exception to that, it is an ordinary instance of it. Applied to both ecosystems.

## The trade-off, stated plainly

`main` now receives dependency updates at release time rather than immediately. For a CI action that is fine — `main` runs CI on pushes and pull requests to `main`, which happen at release time anyway. An urgent security bump needed on `main` sooner would be done by hand, as a hotfix.