### PR TITLE
Bring the contributors list onto main, so the bot has something to work on

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,95 @@
+{
+  "projectName": "NeverDry",
+  "projectOwner": "never-dry",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "skipCi": true,
+  "contributors": [
+    {
+      "login": "drake69",
+      "name": "Luigi Corsaro",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5324491?v=4",
+      "profile": "https://github.com/drake69",
+      "contributions": [
+        "code",
+        "doc",
+        "ideas",
+        "maintenance"
+      ]
+    },
+    {
+      "login": "philipgiuliani",
+      "name": "Philip Giuliani",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5446019?v=4",
+      "profile": "https://github.com/philipgiuliani",
+      "contributions": [
+        "code",
+        "ideas"
+      ]
+    },
+    {
+      "login": "evlas",
+      "name": "Vito Ammirata",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1157933?v=4",
+      "profile": "https://github.com/evlas",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "rpatel3001",
+      "name": "Rajan Patel",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6333479?v=4",
+      "profile": "https://github.com/rpatel3001",
+      "contributions": [
+        "bug",
+        "userTesting"
+      ]
+    },
+    {
+      "login": "dietklein",
+      "name": "dietklein",
+      "avatar_url": "https://avatars.githubusercontent.com/u/155997718?v=4",
+      "profile": "https://github.com/dietklein",
+      "contributions": [
+        "bug",
+        "userTesting"
+      ]
+    },
+    {
+      "login": "MetheLittle",
+      "name": "MetheLittle",
+      "avatar_url": "https://avatars.githubusercontent.com/u/155000385?v=4",
+      "profile": "https://github.com/MetheLittle",
+      "contributions": [
+        "bug",
+        "userTesting"
+      ]
+    },
+    {
+      "login": "fpytloun",
+      "name": "Filip Pytloun",
+      "avatar_url": "https://avatars.githubusercontent.com/u/948799?v=4",
+      "profile": "https://github.com/fpytloun",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "MrEcosse",
+      "name": "MrEcosse",
+      "avatar_url": "https://avatars.githubusercontent.com/u/62436640?v=4",
+      "profile": "https://github.com/MrEcosse",
+      "contributions": [
+        "ideas"
+      ]
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,18 @@ build a hierarchy, and none of them is a claim on your time.
 pre-release, or shaped a design note. This is not granted and there is nothing to
 apply for: if you have done any of that, you already are one.
 
+Contributors are listed in the README, with what they contributed: code,
+documentation, ideas, bug reports, testing on a real garden. The list is
+maintained with [all-contributors](https://allcontributors.org), and it exists
+because GitHub's own contributor graph counts commits and nothing else — which
+would credit the dependency-update bot above every person who has run this on
+their own irrigation system and told us what broke.
+
+Being added is not automatic, and deliberately so: a list that grows with every
+comment measures volume rather than contribution, which is the opposite of what
+it is for. If you are missing, say so on any issue — that is not a favour to ask
+for, it is a correction.
+
 **Triage** — an invited role (GitHub's `triage` permission). It allows labelling,
 assigning, closing and reopening issues, and being formally requested as a
 reviewer. It carries **no write access**: you cannot push or merge anything. It is

--- a/README.md
+++ b/README.md
@@ -296,6 +296,43 @@ Site exposure contributed by [philipgiuliani](https://github.com/philipgiuliani)
 
 ---
 
+## Contributors
+
+NeverDry is shaped by people who never pushed a commit as much as by people who
+did. A field report that explains *why* a valve times out is worth more than the
+patch it leads to, and this list counts it that way — code, ideas, bug reports and
+testing on real gardens all appear.
+
+If you have reported a bug, tested a pre-release or shaped a design note, you
+belong here. If you are missing, say so on any issue and it will be fixed.
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/drake69"><img src="https://avatars.githubusercontent.com/u/5324491?v=4?s=100" width="100px;" alt="Luigi Corsaro"/><br /><sub><b>Luigi Corsaro</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/commits?author=drake69" title="Code">💻</a> <a href="https://github.com/never-dry/NeverDry/commits?author=drake69" title="Documentation">📖</a> <a href="#ideas-drake69" title="Ideas, Planning, & Feedback">🤔</a> <a href="#maintenance-drake69" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/philipgiuliani"><img src="https://avatars.githubusercontent.com/u/5446019?v=4?s=100" width="100px;" alt="Philip Giuliani"/><br /><sub><b>Philip Giuliani</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/commits?author=philipgiuliani" title="Code">💻</a> <a href="#ideas-philipgiuliani" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/evlas"><img src="https://avatars.githubusercontent.com/u/1157933?v=4?s=100" width="100px;" alt="Vito Ammirata"/><br /><sub><b>Vito Ammirata</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/commits?author=evlas" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/rpatel3001"><img src="https://avatars.githubusercontent.com/u/6333479?v=4?s=100" width="100px;" alt="Rajan Patel"/><br /><sub><b>Rajan Patel</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/issues?q=author%3Arpatel3001" title="Bug reports">🐛</a> <a href="#userTesting-rpatel3001" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/dietklein"><img src="https://avatars.githubusercontent.com/u/155997718?v=4?s=100" width="100px;" alt="dietklein"/><br /><sub><b>dietklein</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/issues?q=author%3Adietklein" title="Bug reports">🐛</a> <a href="#userTesting-dietklein" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/MetheLittle"><img src="https://avatars.githubusercontent.com/u/155000385?v=4?s=100" width="100px;" alt="MetheLittle"/><br /><sub><b>MetheLittle</b></sub></a><br /><a href="https://github.com/never-dry/NeverDry/issues?q=author%3AMetheLittle" title="Bug reports">🐛</a> <a href="#userTesting-MetheLittle" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/fpytloun"><img src="https://avatars.githubusercontent.com/u/948799?v=4?s=100" width="100px;" alt="Filip Pytloun"/><br /><sub><b>Filip Pytloun</b></sub></a><br /><a href="#ideas-fpytloun" title="Ideas, Planning, & Feedback">🤔</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/MrEcosse"><img src="https://avatars.githubusercontent.com/u/62436640?v=4?s=100" width="100px;" alt="MrEcosse"/><br /><sub><b>MrEcosse</b></sub></a><br /><a href="#ideas-MrEcosse" title="Ideas, Planning, & Feedback">🤔</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+---
+
 ## Scientific References
 
 NeverDry is based on established agronomic science. The key references are:


### PR DESCRIPTION
Cherry-pick of the contributors work from `develop` (#193) onto `main`, and nothing else — three files, 144 insertions, none of the 0.12 work.

## Why it cannot wait for the release

The all-contributors bot operates on the repository's **default branch**, which is `main`. Installing it while the markers and `.all-contributorsrc` live only on `develop` would give it a README with nothing to update.

There is a second reason: `main` is what anyone browsing the repository sees. That currently includes the two people who have just been invited to triage, who would find a README that does not mention contributors at all.

## What lands

- `.all-contributorsrc` — eight people, `dependabot` excluded
- the README contributors section and the generated table, byte-identical to `develop`
- the CONTRIBUTING paragraph explaining that being listed is how the **Contributor** role becomes visible, and why the list is not fully automatic

The rest of `develop` stays where it is. `CONTRIBUTING.md` on `main` remains without the sections that arrived with the 0.12 branch; they travel at release time with everything else.