### PR TITLE
fix: a rejected setup form must speak, and must not empty itself (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ not the argument.
   ([design](docs/design/evidence-and-methodology.md))
 - **The valve picker accepts `valve.*` entities**, not only `switch.*` ([#94]).
   The engine could already drive them; the form would not let you choose one.
+- **A rejected setup form no longer empties itself in silence** ([#196]). Filling in a
+  zone, pressing submit, and watching every field go blank with nothing on screen to
+  say why — the form would not close, and the installation could not be completed.
+  Two faults met there. The zone form is built from collapsible sections, and an error
+  filed against a field *inside* a section never reached the frontend, so no message
+  appeared; the three delivery-mode requirements were filed exactly that way, and the
+  one most people hit is the design flow rate — mandatory, but impossible to mark as
+  such in the form, because it only applies to one delivery mode. On top of that the
+  redraw carried none of the submitted values, so even a visible error cost the user
+  the whole zone. Errors now always reach the top of the form, and a rejected zone
+  comes back filled in. The first step keeps what was typed too: an ET method the
+  declared sensors cannot support used to take the sensor pickers down with it.
 
 ## [0.11.1] - 2026-08-25
 
@@ -133,6 +145,7 @@ For releases prior to 0.11.0, see the [GitHub Releases](https://github.com/never
 [0.11.0]: https://github.com/never-dry/NeverDry/releases/tag/v0.11.0
 [#173]: https://github.com/never-dry/NeverDry/issues/173
 [#94]: https://github.com/never-dry/NeverDry/issues/94
+[#196]: https://github.com/never-dry/NeverDry/issues/196
 [#168]: https://github.com/never-dry/NeverDry/pull/168
 [#165]: https://github.com/never-dry/NeverDry/issues/165
 [#144]: https://github.com/never-dry/NeverDry/issues/144

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ not the argument.
 - **The zone card** shows site exposure, separates what was measured from what was
   derived, acknowledges a press before its outcome, and puts the zone's settings
   one click away.
+- **The three ways into a zone now answer the same** ([#196]). First-run setup, *add
+  zone* and *edit zone* each took a zone in, and each judged it differently: setup
+  refused a delivery mode whose one indispensable input was missing, while the two
+  options steps saved it without a word — or, for a flow meter or volume preset
+  with no entity behind it, quietly swapped the mode for *estimated flow*. A mode
+  you did not choose, needing a design flow rate nobody then checked. All three
+  doors now apply the same rule and say the same thing, so a zone that cannot
+  deliver is refused wherever you try to save it. If you already have such a zone,
+  the next edit will ask you for the missing value before it will save.
 
 ### Fixed
 - **A flow-metered valve no longer times out on a coarse counter** ([#173]). The
@@ -69,6 +78,7 @@ not the argument.
   the whole zone. Errors now always reach the top of the form, and a rejected zone
   comes back filled in. The first step keeps what was typed too: an ET method the
   declared sensors cannot support used to take the sensor pickers down with it.
+  What is refused, and where, is now one rule — see *Changed*.
 
 ## [0.11.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,10 @@ not the argument.
   you did not choose, needing a design flow rate nobody then checked. All three
   doors now apply the same rule and say the same thing, so a zone that cannot
   deliver is refused wherever you try to save it. If you already have such a zone,
-  the next edit will ask you for the missing value before it will save.
+  the next edit will ask you for the missing value before it will save. A zone with
+  **no valve** is exempt from all of it: it delivers nothing by design — it watches
+  the deficit and tells you when to water by hand — so asking it how fast it waters
+  would be asking about something it will never do.
 
 ### Fixed
 - **A flow-metered valve no longer times out on a coarse counter** ([#173]). The

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -731,6 +731,46 @@ def _override_errors(user_input: dict) -> dict[str, str]:
     return errors
 
 
+def _delivery_mode_errors(user_input: dict) -> dict[str, str]:
+    """Reject a delivery mode whose one indispensable input is missing.
+
+    Each mode rests on exactly one value that nothing else can supply: a design
+    flow rate to turn a volume into a duration, a counter to read the volume
+    off, a number entity to hand the target to. Without it the mode is a
+    declaration the zone cannot honour.
+    """
+    errors: dict[str, str] = {}
+    mode = user_input.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
+    if mode == DELIVERY_MODE_ESTIMATED_FLOW and not user_input.get(CONF_ZONE_FLOW_RATE):
+        _add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")
+    elif mode == DELIVERY_MODE_FLOW_METER and not user_input.get(CONF_ZONE_FLOW_METER_SENSOR):
+        _add_field_error(errors, CONF_ZONE_FLOW_METER_SENSOR, "flow_meter_required")
+    elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
+        _add_field_error(errors, CONF_ZONE_VOLUME_ENTITY, "volume_entity_required")
+    return errors
+
+
+def _zone_errors(user_input: dict) -> dict[str, str]:
+    """Everything a submitted zone is refused for, wherever it was submitted.
+
+    The three doors into a zone — first-run setup, *add zone*, *edit zone* —
+    used to answer differently to the same omission: setup refused, the other
+    two saved and said nothing. One function now, so a rule cannot be enforced
+    at one door and forgotten at the next.
+
+    Delivery mode is checked first and keeps "base": a zone that cannot deliver
+    is a worse problem than a preset with an empty box, and "base" is the one
+    key rendered at the top of the form.
+    """
+    errors = _delivery_mode_errors(user_input)
+    for key, code in _override_errors(user_input).items():
+        if key == "base":
+            errors.setdefault("base", code)
+        else:
+            errors[key] = code
+    return errors
+
+
 def _ignored_override_warnings(zone: dict) -> list[str]:
     """Tell the user which values will not be used, and why.
 
@@ -759,17 +799,6 @@ def _ignored_override_warnings(zone: dict) -> list[str]:
             f" — choose 'Custom' to apply it, or clear the field"
         )
     return warnings
-
-
-def _coerce_delivery_mode(user_input: dict) -> dict:
-    """Downgrade delivery_mode to estimated_flow when the required sensor is missing."""
-    dm = user_input.get(CONF_ZONE_DELIVERY_MODE)
-    if (dm == DELIVERY_MODE_FLOW_METER and not user_input.get(CONF_ZONE_FLOW_METER_SENSOR)) or (
-        dm == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY)
-    ):
-        user_input = dict(user_input)
-        user_input[CONF_ZONE_DELIVERY_MODE] = DELIVERY_MODE_ESTIMATED_FLOW
-    return user_input
 
 
 class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -811,19 +840,12 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             user_input = _flatten_sections(user_input)
             name = user_input.get(CONF_ZONE_NAME, "")
-            mode = user_input.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
             if len(name) > MAX_ZONE_NAME_LENGTH:
                 _add_field_error(errors, CONF_ZONE_NAME, "zone_name_too_long")
             elif len(self._zones) >= MAX_ZONES:
                 errors["base"] = "too_many_zones"
-            elif mode == DELIVERY_MODE_ESTIMATED_FLOW and not user_input.get(CONF_ZONE_FLOW_RATE):
-                _add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")
-            elif mode == DELIVERY_MODE_FLOW_METER and not user_input.get(CONF_ZONE_FLOW_METER_SENSOR):
-                _add_field_error(errors, CONF_ZONE_FLOW_METER_SENSOR, "flow_meter_required")
-            elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
-                _add_field_error(errors, CONF_ZONE_VOLUME_ENTITY, "volume_entity_required")
-            elif override_errors := _override_errors(user_input):
-                errors.update(override_errors)
+            elif zone_errors := _zone_errors(user_input):
+                errors.update(zone_errors)
             else:
                 zone_metric = _zone_input_to_metric(user_input, imperial)
                 self._pending_warnings = _unusual_zone_values(zone_metric, imperial) + _ignored_override_warnings(
@@ -968,23 +990,20 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             # typed (L/h read back as L/min).
             submitted = _flatten_sections(user_input)
             user_input = _zone_input_to_metric(submitted, imperial)
-            user_input = _coerce_delivery_mode(user_input)
             new_data = dict(self._config_entry.data)
             zones = list(new_data.get(CONF_ZONES, []))
+            errors = _zone_errors(user_input)
             # Reject duplicate zone names
             new_name = user_input[CONF_ZONE_NAME]
             existing_names = {z[CONF_ZONE_NAME] for z in zones}
             if new_name in existing_names:
+                errors[CONF_ZONE_NAME] = "zone_already_exists"
+                errors["base"] = "zone_already_exists"
+            if errors:
                 return self.async_show_form(
                     step_id="add_zone",
                     data_schema=_zone_schema_initial(imperial, submitted),
-                    errors={"base": "zone_already_exists"},
-                )
-            if override_errors := _override_errors(user_input):
-                return self.async_show_form(
-                    step_id="add_zone",
-                    data_schema=_zone_schema_initial(imperial, submitted),
-                    errors=override_errors,
+                    errors=errors,
                 )
             self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(user_input)
             if self._pending_warnings:
@@ -1051,9 +1070,8 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             user_input = _flatten_sections(user_input)
             user_input = _zone_input_to_metric(user_input, imperial)
-            errors = _override_errors(user_input)
+            errors = _zone_errors(user_input)
             if not errors:
-                user_input = _coerce_delivery_mode(user_input)
                 self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(
                     user_input
                 )

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -222,8 +222,14 @@ def _et_method_error(user_input: dict) -> str | None:
     return None if env.satisfies(model.required_sensors) else "et_method_missing_sensors"
 
 
-def _sensors_schema(is_imperial: bool) -> vol.Schema:
+def _sensors_schema(is_imperial: bool, current: dict | None = None) -> vol.Schema:
     """Sensors + ET parameters form for initial setup, unit-aware.
+
+    ``current`` is a rejected submission being handed back, and every field is
+    seeded from it. An ET method the declared sensors cannot support is the one
+    way out of this step that is not forward, and without the seeding it also
+    emptied the two sensor pickers the user had just filled in — the same trap
+    the zone form had in GH #196, one step earlier.
 
     **No soil probe here.** A probe measures one patch of soil, with one kind of
     planting above it and its own watering history, so a probe declared for the
@@ -242,18 +248,22 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
 
     return vol.Schema(
         {
-            vol.Required(CONF_TEMP_SENSOR): selector.EntitySelector(
+            vol.Required(CONF_TEMP_SENSOR, **_suggest(current, CONF_TEMP_SENSOR)): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", device_class="temperature")
             ),
-            vol.Required(CONF_RAIN_SENSOR): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
-            vol.Optional(CONF_RAIN_SENSOR_TYPE, default=DEFAULT_RAIN_SENSOR_TYPE): selector.SelectSelector(
+            vol.Required(CONF_RAIN_SENSOR, **_suggest(current, CONF_RAIN_SENSOR)): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="sensor")
+            ),
+            vol.Optional(
+                CONF_RAIN_SENSOR_TYPE, default=DEFAULT_RAIN_SENSOR_TYPE, **_suggest(current, CONF_RAIN_SENSOR_TYPE)
+            ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[RAIN_TYPE_EVENT, RAIN_TYPE_DAILY_TOTAL],
                     translation_key="rain_sensor_type",
                     mode="dropdown",
                 )
             ),
-            vol.Optional(CONF_D_MAX, default=d_max_default): selector.NumberSelector(
+            vol.Optional(CONF_D_MAX, default=d_max_default, **_suggest(current, CONF_D_MAX)): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0.5 if is_imperial else 10.0,
                     max=20.0 if is_imperial else 500.0,
@@ -267,8 +277,8 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
             # dropdown within one step, so the only way to express "this box
             # belongs to that choice" is to put it underneath it. The label says
             # which method uses it; the confirm step says so again if it is inert.
-            **_et_method_field(),
-            vol.Optional(CONF_ALPHA, default=DEFAULT_ALPHA): selector.NumberSelector(
+            **_et_method_field(current),
+            vol.Optional(CONF_ALPHA, default=DEFAULT_ALPHA, **_suggest(current, CONF_ALPHA)): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0.05,
                     max=1.0,
@@ -277,7 +287,9 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
                     unit_of_measurement="mm/°C/day",
                 )
             ),
-            vol.Optional(CONF_T_BASE, default=t_base_default): selector.NumberSelector(
+            vol.Optional(
+                CONF_T_BASE, default=t_base_default, **_suggest(current, CONF_T_BASE)
+            ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=23.0 if is_imperial else -5.0,
                     max=68.0 if is_imperial else 20.0,
@@ -286,7 +298,7 @@ def _sensors_schema(is_imperial: bool) -> vol.Schema:
                     unit_of_measurement=t_unit,
                 )
             ),
-            **_extra_sensor_fields(),
+            **_extra_sensor_fields(current),
         }
     )
 
@@ -353,23 +365,50 @@ def _model_params_schema(is_imperial: bool, current: dict) -> vol.Schema:
     )
 
 
-def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
-    """Zone form for initial setup and add_zone options flow (no pre-existing values)."""
+def _suggest(current: dict | None, key: str) -> dict:
+    """Marker keyword arguments that seed one field from a rejected submission.
+
+    ``current is None`` is a first render and the field carries no suggestion
+    at all — an explicit ``suggested_value=None`` there would blank out the
+    ``default=`` the field is supposed to open with.
+
+    A key missing from ``current`` is a box the user left empty, and it has to
+    come back empty: suggesting anything would put back the very value the
+    error is asking for.
+    """
+    if current is None:
+        return {}
+    return {"description": {"suggested_value": current.get(key)}}
+
+
+def _zone_schema_initial(is_imperial: bool, current: dict | None = None) -> vol.Schema:
+    """Zone form for initial setup and add_zone options flow.
+
+    ``current`` is what the user has just submitted, and is present only when
+    the form is being redrawn after an error. Without it every field comes back
+    empty and a rejected zone has to be typed again from scratch, with nothing
+    on screen saying why — the trap reported in GH #196. Seeded as
+    ``suggested_value`` and never as ``default=``: a default cannot be cleared,
+    which is how the override boxes trapped their users in GH #165.
+    """
     area_unit = "ft²" if is_imperial else "m²"
     flow_unit = "gal/h" if is_imperial else "L/h"
     depth_unit = "in" if is_imperial else "mm"
     threshold_default = round(DEFAULT_THRESHOLD * _MM_TO_IN, 2) if is_imperial else DEFAULT_THRESHOLD
+
+    def _sug(key: str) -> dict:
+        return _suggest(current, key)
 
     # Nothing is collapsed here: a zone being created has to be seen once in
     # full. The edit form collapses everything instead — there you already
     # know what you came to change.
     return vol.Schema(
         {
-            vol.Required(CONF_ZONE_NAME): selector.TextSelector(),
+            vol.Required(CONF_ZONE_NAME, **_sug(CONF_ZONE_NAME)): selector.TextSelector(),
             vol.Required(SECTION_GROUND): section(
                 vol.Schema(
                     {
-                        vol.Required(CONF_ZONE_AREA): selector.NumberSelector(
+                        vol.Required(CONF_ZONE_AREA, **_sug(CONF_ZONE_AREA)): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=1.0 if is_imperial else 0.1,
                                 max=107000.0 if is_imperial else 10000.0,
@@ -378,14 +417,14 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                                 unit_of_measurement=area_unit,
                             )
                         ),
-                        vol.Optional(CONF_ZONE_PLANT_FAMILY): selector.SelectSelector(
+                        vol.Optional(CONF_ZONE_PLANT_FAMILY, **_sug(CONF_ZONE_PLANT_FAMILY)): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=list(PLANT_FAMILIES.keys()),
                                 translation_key="plant_family",
                                 mode="dropdown",
                             )
                         ),
-                        vol.Optional(CONF_ZONE_KC): selector.NumberSelector(
+                        vol.Optional(CONF_ZONE_KC, **_sug(CONF_ZONE_KC)): selector.NumberSelector(
                             selector.NumberSelectorConfig(min=0.1, max=2.0, step=0.01, mode="box")
                         ),
                         # The probe belongs here, in the zone, not to the
@@ -394,17 +433,21 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                         # reading from somebody else's patch says nothing about
                         # this one. A zone that declares one stops estimating
                         # and starts measuring.
-                        vol.Optional(CONF_ZONE_VWC_SENSOR): selector.EntitySelector(
+                        vol.Optional(CONF_ZONE_VWC_SENSOR, **_sug(CONF_ZONE_VWC_SENSOR)): selector.EntitySelector(
                             selector.EntitySelectorConfig(domain="sensor", device_class="moisture")
                         ),
-                        vol.Optional(CONF_ZONE_EXPOSURE, default=DEFAULT_EXPOSURE): selector.SelectSelector(
+                        vol.Optional(
+                            CONF_ZONE_EXPOSURE, default=DEFAULT_EXPOSURE, **_sug(CONF_ZONE_EXPOSURE)
+                        ): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=list(EXPOSURES.keys()),
                                 translation_key="exposure",
                                 mode="dropdown",
                             )
                         ),
-                        vol.Optional(CONF_ZONE_MICROCLIMATE_FACTOR): selector.NumberSelector(
+                        vol.Optional(
+                            CONF_ZONE_MICROCLIMATE_FACTOR, **_sug(CONF_ZONE_MICROCLIMATE_FACTOR)
+                        ): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=MICROCLIMATE_FACTOR_MIN,
                                 max=MICROCLIMATE_FACTOR_MAX,
@@ -426,10 +469,12 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                         # controller's own state checks went through that adapter
                         # — offering it earlier would have shown a valve that
                         # saved without error and never opened.
-                        vol.Optional(CONF_ZONE_VALVE): selector.EntitySelector(
+                        vol.Optional(CONF_ZONE_VALVE, **_sug(CONF_ZONE_VALVE)): selector.EntitySelector(
                             selector.EntitySelectorConfig(domain=["switch", "valve"])
                         ),
-                        vol.Optional(CONF_ZONE_DELIVERY_MODE, default=DEFAULT_DELIVERY_MODE): selector.SelectSelector(
+                        vol.Optional(
+                            CONF_ZONE_DELIVERY_MODE, default=DEFAULT_DELIVERY_MODE, **_sug(CONF_ZONE_DELIVERY_MODE)
+                        ): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=[
                                     DELIVERY_MODE_ESTIMATED_FLOW,
@@ -440,7 +485,7 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                                 mode="dropdown",
                             )
                         ),
-                        vol.Optional(CONF_ZONE_FLOW_RATE): selector.NumberSelector(
+                        vol.Optional(CONF_ZONE_FLOW_RATE, **_sug(CONF_ZONE_FLOW_RATE)): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=2.0 if is_imperial else 1.0,
                                 max=3200.0 if is_imperial else 12000.0,
@@ -449,13 +494,13 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                                 unit_of_measurement=flow_unit,
                             )
                         ),
-                        vol.Optional(CONF_ZONE_FLOW_METER_SENSOR): selector.EntitySelector(
-                            selector.EntitySelectorConfig(domain="sensor")
-                        ),
-                        vol.Optional(CONF_ZONE_VOLUME_ENTITY): selector.EntitySelector(
+                        vol.Optional(
+                            CONF_ZONE_FLOW_METER_SENSOR, **_sug(CONF_ZONE_FLOW_METER_SENSOR)
+                        ): selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor")),
+                        vol.Optional(CONF_ZONE_VOLUME_ENTITY, **_sug(CONF_ZONE_VOLUME_ENTITY)): selector.EntitySelector(
                             selector.EntitySelectorConfig(domain="number")
                         ),
-                        vol.Required(CONF_ZONE_SYSTEM_TYPE): selector.SelectSelector(
+                        vol.Required(CONF_ZONE_SYSTEM_TYPE, **_sug(CONF_ZONE_SYSTEM_TYPE)): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=[
                                     SYSTEM_TYPE_DRIP,
@@ -468,7 +513,7 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                                 mode="dropdown",
                             )
                         ),
-                        vol.Optional(CONF_ZONE_EFFICIENCY): selector.NumberSelector(
+                        vol.Optional(CONF_ZONE_EFFICIENCY, **_sug(CONF_ZONE_EFFICIENCY)): selector.NumberSelector(
                             # box, not slider: a slider always submits a value, so an
                             # override set by accident could never be cleared again
                             # (GH #165). step 0.01 so every system-type default is
@@ -477,7 +522,9 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                             selector.NumberSelectorConfig(min=0.1, max=1.0, step=0.01, mode="box")
                         ),
                         vol.Optional(
-                            CONF_ZONE_DELIVERY_TIMEOUT, default=DEFAULT_DELIVERY_TIMEOUT_S
+                            CONF_ZONE_DELIVERY_TIMEOUT,
+                            default=DEFAULT_DELIVERY_TIMEOUT_S,
+                            **_sug(CONF_ZONE_DELIVERY_TIMEOUT),
                         ): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=60, max=7200, step=60, mode="box", unit_of_measurement="s"
@@ -491,7 +538,9 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                 vol.Schema(
                     {
                         vol.Optional(
-                            CONF_ZONE_IRRIGATION_MODE, default=DEFAULT_IRRIGATION_MODE
+                            CONF_ZONE_IRRIGATION_MODE,
+                            default=DEFAULT_IRRIGATION_MODE,
+                            **_sug(CONF_ZONE_IRRIGATION_MODE),
                         ): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=[
@@ -503,10 +552,14 @@ def _zone_schema_initial(is_imperial: bool) -> vol.Schema:
                                 mode="dropdown",
                             )
                         ),
-                        vol.Optional(CONF_ZONE_IRRIGATION_TIME, default=DEFAULT_IRRIGATION_TIME): (
-                            selector.TimeSelector()
-                        ),
-                        vol.Optional(CONF_ZONE_THRESHOLD, default=threshold_default): selector.NumberSelector(
+                        vol.Optional(
+                            CONF_ZONE_IRRIGATION_TIME,
+                            default=DEFAULT_IRRIGATION_TIME,
+                            **_sug(CONF_ZONE_IRRIGATION_TIME),
+                        ): (selector.TimeSelector()),
+                        vol.Optional(
+                            CONF_ZONE_THRESHOLD, default=threshold_default, **_sug(CONF_ZONE_THRESHOLD)
+                        ): selector.NumberSelector(
                             selector.NumberSelectorConfig(
                                 min=0.1 if is_imperial else 1.0,
                                 max=4.0 if is_imperial else 100.0,
@@ -621,13 +674,39 @@ def _flatten_sections(user_input: dict) -> dict:
     return flat
 
 
-# Which section each override box is rendered in, so an error can be pointed
-# at a field the frontend is actually showing.
+# Which section each field is rendered in, so an error can be pointed at a
+# field the frontend is actually showing. Only sectioned fields belong here:
+# a top-level field is found by its own name.
 _SECTION_OF_FIELD = {
     CONF_ZONE_EFFICIENCY: SECTION_VALVE,
     CONF_ZONE_KC: SECTION_GROUND,
     CONF_ZONE_MICROCLIMATE_FACTOR: SECTION_GROUND,
+    CONF_ZONE_FLOW_RATE: SECTION_VALVE,
+    CONF_ZONE_FLOW_METER_SENSOR: SECTION_VALVE,
+    CONF_ZONE_VOLUME_ENTITY: SECTION_VALVE,
 }
+
+
+def _add_field_error(errors: dict[str, str], field: str, code: str) -> None:
+    """File one field error under every key the frontend might look for.
+
+    A field rendered inside a section cannot be reached by its bare name
+    alone, so one problem is filed three times:
+      - the bare name, which is what an unsectioned form matches;
+      - the section-qualified name;
+      - "base", which is rendered at the top of the form no matter what.
+
+    Without that last key the form comes back with nothing on screen to say
+    why it refused — which is how a mandatory design flow rate left users
+    staring at a blank form that would not close (GH #196). A top-level field
+    needs only its own name.
+    """
+    errors[field] = code
+    section_name = _SECTION_OF_FIELD.get(field)
+    if section_name is None:
+        return
+    errors[f"{section_name}.{field}"] = code
+    errors.setdefault("base", code)
 
 
 def _preset_is_custom(table: dict, key: str | None, field: str) -> bool:
@@ -648,16 +727,7 @@ def _override_errors(user_input: dict) -> dict[str, str]:
             continue
         if user_input.get(override_key) is not None:
             continue
-        # Three keys for one problem, because the field lives inside a
-        # collapsed section and the frontend has to be able to find it:
-        #   - the bare name, which is what an unsectioned form matches;
-        #   - the section-qualified name;
-        #   - "base", which is rendered at the top of the form no matter what.
-        # Without the last one the form simply refuses to close with nothing
-        # on screen to say why, which is worse than the bug being fixed.
-        errors[override_key] = error
-        errors[f"{_SECTION_OF_FIELD[override_key]}.{override_key}"] = error
-        errors.setdefault("base", error)
+        _add_field_error(errors, override_key, error)
     return errors
 
 
@@ -725,9 +795,12 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._data = _sensors_input_to_metric(user_input, imperial)
                 return await self.async_step_zone()
 
+        # Same as the zone step: user_input is here only if it was rejected,
+        # and it is still in form units — the conversion to metric happens on
+        # the accepted path.
         return self.async_show_form(
             step_id="user",
-            data_schema=_sensors_schema(imperial),
+            data_schema=_sensors_schema(imperial, user_input),
             errors=errors,
         )
 
@@ -740,15 +813,15 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             name = user_input.get(CONF_ZONE_NAME, "")
             mode = user_input.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
             if len(name) > MAX_ZONE_NAME_LENGTH:
-                errors[CONF_ZONE_NAME] = "zone_name_too_long"
+                _add_field_error(errors, CONF_ZONE_NAME, "zone_name_too_long")
             elif len(self._zones) >= MAX_ZONES:
                 errors["base"] = "too_many_zones"
             elif mode == DELIVERY_MODE_ESTIMATED_FLOW and not user_input.get(CONF_ZONE_FLOW_RATE):
-                errors[CONF_ZONE_FLOW_RATE] = "flow_rate_required"
+                _add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")
             elif mode == DELIVERY_MODE_FLOW_METER and not user_input.get(CONF_ZONE_FLOW_METER_SENSOR):
-                errors[CONF_ZONE_FLOW_METER_SENSOR] = "flow_meter_required"
+                _add_field_error(errors, CONF_ZONE_FLOW_METER_SENSOR, "flow_meter_required")
             elif mode == DELIVERY_MODE_VOLUME_PRESET and not user_input.get(CONF_ZONE_VOLUME_ENTITY):
-                errors[CONF_ZONE_VOLUME_ENTITY] = "volume_entity_required"
+                _add_field_error(errors, CONF_ZONE_VOLUME_ENTITY, "volume_entity_required")
             elif override_errors := _override_errors(user_input):
                 errors.update(override_errors)
             else:
@@ -762,9 +835,12 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._zones.append(zone_metric)
                 return await self.async_step_add_another()
 
+        # user_input survives here only when it was rejected above — it is
+        # still in form units, since the conversion to metric happens on the
+        # accepted path. Passing it back is what keeps the form filled in.
         return self.async_show_form(
             step_id="zone",
-            data_schema=_zone_schema_initial(imperial),
+            data_schema=_zone_schema_initial(imperial, user_input),
             errors=errors,
             description_placeholders={
                 "zone_count": str(len(self._zones)),
@@ -887,8 +963,11 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         """Add a new irrigation zone."""
         imperial = _is_imperial(self.hass)
         if user_input is not None:
-            user_input = _flatten_sections(user_input)
-            user_input = _zone_input_to_metric(user_input, imperial)
+            # Kept in form units for the error redraws below: seeding the
+            # form with metric values would silently rewrite what the user
+            # typed (L/h read back as L/min).
+            submitted = _flatten_sections(user_input)
+            user_input = _zone_input_to_metric(submitted, imperial)
             user_input = _coerce_delivery_mode(user_input)
             new_data = dict(self._config_entry.data)
             zones = list(new_data.get(CONF_ZONES, []))
@@ -898,13 +977,13 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             if new_name in existing_names:
                 return self.async_show_form(
                     step_id="add_zone",
-                    data_schema=_zone_schema_initial(imperial),
+                    data_schema=_zone_schema_initial(imperial, submitted),
                     errors={"base": "zone_already_exists"},
                 )
             if override_errors := _override_errors(user_input):
                 return self.async_show_form(
                     step_id="add_zone",
-                    data_schema=_zone_schema_initial(imperial),
+                    data_schema=_zone_schema_initial(imperial, submitted),
                     errors=override_errors,
                 )
             self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(user_input)

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -738,8 +738,17 @@ def _delivery_mode_errors(user_input: dict) -> dict[str, str]:
     flow rate to turn a volume into a duration, a counter to read the volume
     off, a number entity to hand the target to. Without it the mode is a
     declaration the zone cannot honour.
+
+    None of which applies to a zone with no valve. That zone delivers nothing by
+    design — it watches the deficit and tells you when to water by hand, which
+    is the monitoring mode the controller runs when no valve is configured
+    anywhere. Asking it how fast it waters is asking about something it will
+    never do, and refusing to save it over the answer would lock a supported
+    setup out of the form.
     """
     errors: dict[str, str] = {}
+    if not user_input.get(CONF_ZONE_VALVE):
+        return errors
     mode = user_input.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
     if mode == DELIVERY_MODE_ESTIMATED_FLOW and not user_input.get(CONF_ZONE_FLOW_RATE):
         _add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")

--- a/tests/test_zone_config_guards.py
+++ b/tests/test_zone_config_guards.py
@@ -47,7 +47,7 @@ def _patch_flow_env(monkeypatch):
     monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
     monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
     monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
-    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial, current=None: None)
 
     def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
         return {

--- a/tests/test_zone_exposure.py
+++ b/tests/test_zone_exposure.py
@@ -65,7 +65,7 @@ def _patch_flow_env(monkeypatch):
     monkeypatch.setattr(cf.vol, "UNDEFINED", object(), raising=False)
     monkeypatch.setattr(cf, "selector", MagicMock())
     monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
-    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial, current=None: None)
 
     def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
         return {

--- a/tests/test_zone_form_empty_fields.py
+++ b/tests/test_zone_form_empty_fields.py
@@ -1,0 +1,318 @@
+"""One test per zone-form field left empty, driven from the form itself.
+
+GH #196 was not really about the design flow rate. It was about what happens
+when *any* field is left empty: whether the flow answers, and whether the
+answer costs the user everything else they typed. So the matrix is built by
+reading ``_zone_schema_initial`` with ``ast`` — the same static-parsing trick
+``test_translation_consistency`` uses — rather than by listing fields here.
+A field added to the form and forgotten here fails the coverage test instead
+of quietly going untested.
+
+Two mechanisms protect a field, and each gets the assertion that fits it:
+
+* A ``vol.Required`` field is guarded by the form. Home Assistant validates
+  user input against the schema before the step ever runs, so an empty one
+  cannot reach the handler — the test asserts the field is declared that way,
+  because that declaration *is* the guard.
+* A ``vol.Optional`` field can arrive missing, so the step is actually driven
+  with it dropped. Whatever the flow decides, it must decide out loud: either
+  it accepts the zone, or it refuses with an error the frontend can render —
+  and either way the rest of the submission survives.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from never_dry import config_flow as cf
+from never_dry import const
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_DELIVERY_MODE,
+    CONF_ZONE_DELIVERY_TIMEOUT,
+    CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_EXPOSURE,
+    CONF_ZONE_FLOW_METER_SENSOR,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_IRRIGATION_MODE,
+    CONF_ZONE_IRRIGATION_TIME,
+    CONF_ZONE_KC,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
+    CONF_ZONE_NAME,
+    CONF_ZONE_PLANT_FAMILY,
+    CONF_ZONE_SYSTEM_TYPE,
+    CONF_ZONE_THRESHOLD,
+    CONF_ZONE_VALVE,
+    CONF_ZONE_VOLUME_ENTITY,
+    CONF_ZONE_VWC_SENSOR,
+    DELIVERY_MODE_ESTIMATED_FLOW,
+    EXPOSURE_CUSTOM,
+    IRRIGATION_MODE_SCHEDULED,
+    PLANT_FAMILY_CUSTOM,
+    SYSTEM_TYPE_CUSTOM,
+)
+
+_CONFIG_FLOW = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry" / "config_flow.py"
+
+
+# ── reading the form out of the source ────────────────────────────────
+
+
+def _resolve(name: str) -> str:
+    """A field name written as a constant, resolved to the key it stands for."""
+    for module in (const, cf):
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AssertionError(f"cannot resolve {name}")
+
+
+def _marker(node: ast.AST) -> tuple[str, bool] | None:
+    """``vol.Required(FOO)``/``vol.Optional(FOO)`` -> (field, required)."""
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+        return None
+    if node.func.attr not in ("Required", "Optional") or not node.args:
+        return None
+    first = node.args[0]
+    if not isinstance(first, ast.Name):
+        return None
+    return _resolve(first.id), node.func.attr == "Required"
+
+
+def _dict_of_schema(node: ast.AST) -> ast.Dict | None:
+    """The mapping inside a ``vol.Schema({...})`` call."""
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "Schema"
+        and node.args
+        and isinstance(node.args[0], ast.Dict)
+    ):
+        return node.args[0]
+    return None
+
+
+def _zone_form() -> dict[str, tuple[str | None, bool]]:
+    """Read the zone form: ``{field: (section or None, required)}``."""
+    tree = ast.parse(_CONFIG_FLOW.read_text())
+    fn = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "_zone_schema_initial")
+    returned = next(n.value for n in ast.walk(fn) if isinstance(n, ast.Return))
+    top = _dict_of_schema(returned)
+    assert top is not None, "the zone form is no longer a vol.Schema({...}) literal"
+
+    fields: dict[str, tuple[str | None, bool]] = {}
+    for key, value in zip(top.keys, top.values, strict=True):
+        marked = _marker(key)
+        assert marked is not None, ast.dump(key)
+        name, required = marked
+        # A section() wraps an inner schema; its key is the section name.
+        if isinstance(value, ast.Call) and getattr(value.func, "id", None) == "section":
+            inner = _dict_of_schema(value.args[0])
+            assert inner is not None, f"section {name} no longer wraps a vol.Schema"
+            for k2, _v2 in zip(inner.keys, inner.values, strict=True):
+                m2 = _marker(k2)
+                assert m2 is not None, ast.dump(k2)
+                fields[m2[0]] = (name, m2[1])
+        else:
+            fields[name] = (None, required)
+    return fields
+
+
+ZONE_FORM = _zone_form()
+
+
+# ── a zone with every box filled, and filled coherently ───────────────
+
+# Every preset sits on Custom with its box supplied, so no value in here is
+# dead weight: dropping one is always a real subtraction, never the removal
+# of something that was being ignored anyway.
+FILLED = {
+    CONF_ZONE_NAME: "Prato",
+    CONF_ZONE_AREA: 50.0,
+    CONF_ZONE_PLANT_FAMILY: PLANT_FAMILY_CUSTOM,
+    CONF_ZONE_KC: 0.8,
+    CONF_ZONE_VWC_SENSOR: "sensor.prato_moisture",
+    CONF_ZONE_EXPOSURE: EXPOSURE_CUSTOM,
+    CONF_ZONE_MICROCLIMATE_FACTOR: 1.1,
+    CONF_ZONE_VALVE: "switch.prato",
+    CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_ESTIMATED_FLOW,
+    CONF_ZONE_FLOW_RATE: 600.0,  # L/h — 10 L/min, inside the plausible band
+    CONF_ZONE_FLOW_METER_SENSOR: "sensor.prato_counter",
+    CONF_ZONE_VOLUME_ENTITY: "number.prato_volume",
+    CONF_ZONE_SYSTEM_TYPE: SYSTEM_TYPE_CUSTOM,
+    CONF_ZONE_EFFICIENCY: 0.85,
+    CONF_ZONE_DELIVERY_TIMEOUT: 1800,
+    CONF_ZONE_IRRIGATION_MODE: IRRIGATION_MODE_SCHEDULED,
+    CONF_ZONE_IRRIGATION_TIME: "06:00:00",
+    CONF_ZONE_THRESHOLD: 10.0,
+}
+
+# Dropping these is refused. Each is a value nothing else can supply: a
+# preset sitting on Custom with an empty box means nothing at all, and
+# without a design flow rate a volume never becomes a duration.
+REFUSED_WHEN_EMPTY = {
+    CONF_ZONE_KC: "kc_required",
+    CONF_ZONE_MICROCLIMATE_FACTOR: "microclimate_factor_required",
+    CONF_ZONE_EFFICIENCY: "efficiency_required",
+    CONF_ZONE_FLOW_RATE: "flow_rate_required",
+}
+
+
+def _payload(without: str | None = None) -> dict:
+    """The filled zone as the frontend posts it, optionally minus one field."""
+    body: dict = {}
+    for field, value in FILLED.items():
+        if field == without:
+            continue
+        section = ZONE_FORM[field][0]
+        if section is None:
+            body[field] = value
+        else:
+            body.setdefault(section, {})[field] = value
+    return body
+
+
+@pytest.fixture(autouse=True)
+def _patch_flow_env(monkeypatch):
+    """Fill the gaps in the conftest HA stubs, as the other flow tests do."""
+    monkeypatch.setattr(cf, "_is_imperial", lambda hass: False)
+    monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
+
+    def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {"type": "form", "step_id": step_id, "errors": errors}
+
+    monkeypatch.setattr(cf.NeverDryConfigFlow, "async_show_form", _show_form, raising=False)
+
+
+@pytest.fixture
+def seeded(monkeypatch):
+    """What the redrawn form is asked to offer back."""
+    calls: list[dict | None] = []
+
+    def _schema(is_imperial, current=None):
+        calls.append(current)
+        return None
+
+    monkeypatch.setattr(cf, "_zone_schema_initial", _schema)
+    return calls
+
+
+class TestCoverage:
+    """The matrix has to keep up with the form on its own."""
+
+    def test_every_field_has_a_value_to_drop(self):
+        assert set(ZONE_FORM) == set(FILLED), (
+            "the zone form and this matrix have drifted; give the new field a "
+            "plausible value in FILLED so leaving it empty gets tested"
+        )
+
+    def test_the_form_still_has_its_three_sections(self):
+        assert {s for s, _ in ZONE_FORM.values() if s} == {
+            cf.SECTION_GROUND,
+            cf.SECTION_VALVE,
+            cf.SECTION_SCHEDULING,
+        }
+
+
+class TestFilledZoneIsAccepted:
+    """The baseline the matrix subtracts from must itself go through."""
+
+    @pytest.mark.asyncio
+    async def test_nothing_missing_nothing_refused(self, hass_mock, seeded):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(_payload())
+
+        assert result["step_id"] == "add_another"
+        assert len(flow._zones) == 1
+        assert seeded == []  # never redrawn, so nothing to seed
+
+
+class TestRequiredFieldsAreGuardedByTheForm:
+    """An empty required field cannot reach the step, and that is the point."""
+
+    @pytest.mark.parametrize("field", sorted(f for f, (_, req) in ZONE_FORM.items() if req))
+    def test_declared_required(self, field):
+        # Home Assistant validates against the schema before calling the step,
+        # so this declaration is what stops an empty submission — not a check
+        # inside the handler, which would never run.
+        assert ZONE_FORM[field][1] is True
+
+
+class TestOptionalFieldLeftEmpty:
+    """Every optional field, dropped one at a time, on a zone that was fine."""
+
+    OPTIONAL = sorted(f for f, (_, req) in ZONE_FORM.items() if not req)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", OPTIONAL)
+    async def test_the_answer_is_never_silent(self, hass_mock, seeded, field):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(_payload(without=field))
+
+        if result["step_id"] != "zone":
+            # Accepted, with or without the soft-confirm step in between.
+            assert result["step_id"] in ("add_another", "confirm_zone")
+            return
+        # Refused: the frontend renders "base" whatever section the field is
+        # in, so this is the key that decides whether the user is told at all.
+        assert result["errors"], f"{field}: refused with no error at all"
+        assert "base" in result["errors"], f"{field}: refused without a message the form can show"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", OPTIONAL)
+    async def test_nothing_else_is_lost(self, hass_mock, seeded, field):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        sent = _payload(without=field)
+
+        result = await flow.async_step_zone(sent)
+
+        if result["step_id"] != "zone":
+            return
+        assert seeded, f"{field}: the form was redrawn from nothing"
+        offered = seeded[-1]
+        for kept, value in FILLED.items():
+            if kept == field:
+                assert offered.get(kept) is None, f"{field}: came back filled in behind the user"
+            else:
+                assert offered.get(kept) == value, f"{field}: dropping it also lost {kept}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("field", "code"), sorted(REFUSED_WHEN_EMPTY.items()))
+    async def test_the_refusal_names_the_field(self, hass_mock, seeded, field, code):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(_payload(without=field))
+
+        assert result["step_id"] == "zone"
+        assert result["errors"][field] == code
+        assert result["errors"][f"{ZONE_FORM[field][0]}.{field}"] == code
+        assert result["errors"]["base"] == code
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", OPTIONAL)
+    async def test_only_the_declared_set_is_refused(self, hass_mock, seeded, field):
+        """Anything outside REFUSED_WHEN_EMPTY has to be droppable.
+
+        This is the half that catches a check added later without a thought
+        for whether the user can act on it: a new refusal shows up here as a
+        field that used to be optional in practice and no longer is.
+        """
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(_payload(without=field))
+
+        refused = result["step_id"] == "zone"
+        assert refused is (field in REFUSED_WHEN_EMPTY), (
+            f"{field}: refused={refused}, but REFUSED_WHEN_EMPTY says otherwise"
+        )

--- a/tests/test_zone_form_empty_fields.py
+++ b/tests/test_zone_form_empty_fields.py
@@ -1,4 +1,4 @@
-"""One test per zone-form field left empty, driven from the form itself.
+"""One test per zone-form field left empty, at each of the three doors.
 
 GH #196 was not really about the design flow rate. It was about what happens
 when *any* field is left empty: whether the flow answers, and whether the
@@ -7,6 +7,11 @@ reading ``_zone_schema_initial`` with ``ast`` — the same static-parsing trick
 ``test_translation_consistency`` uses — rather than by listing fields here.
 A field added to the form and forgotten here fails the coverage test instead
 of quietly going untested.
+
+A zone can be submitted from three places — first-run setup, *add zone* and
+*edit zone* in the options — and they used to answer differently to the same
+omission: setup refused, the other two saved and said nothing. Every case here
+runs at all three, and one test asserts directly that the three answers agree.
 
 Two mechanisms protect a field, and each gets the assertion that fits it:
 
@@ -24,6 +29,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from never_dry import config_flow as cf
@@ -47,7 +53,10 @@ from never_dry.const import (
     CONF_ZONE_VALVE,
     CONF_ZONE_VOLUME_ENTITY,
     CONF_ZONE_VWC_SENSOR,
+    CONF_ZONES,
     DELIVERY_MODE_ESTIMATED_FLOW,
+    DELIVERY_MODE_FLOW_METER,
+    DELIVERY_MODE_VOLUME_PRESET,
     EXPOSURE_CUSTOM,
     IRRIGATION_MODE_SCHEDULED,
     PLANT_FAMILY_CUSTOM,
@@ -180,17 +189,26 @@ def _patch_flow_env(monkeypatch):
     monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
     monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
     monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "UNDEFINED", object(), raising=False)
+    # The edit form builds its schema inline, so the selector module has to
+    # answer attribute access rather than be the empty stub conftest installs.
+    monkeypatch.setattr(cf, "selector", MagicMock())
     monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
 
     def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
         return {"type": "form", "step_id": step_id, "errors": errors}
 
-    monkeypatch.setattr(cf.NeverDryConfigFlow, "async_show_form", _show_form, raising=False)
+    def _create_entry(self, *, data=None, title=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    for klass in (cf.NeverDryConfigFlow, cf.NeverDryOptionsFlow):
+        monkeypatch.setattr(klass, "async_show_form", _show_form, raising=False)
+        monkeypatch.setattr(klass, "async_create_entry", _create_entry, raising=False)
 
 
 @pytest.fixture
 def seeded(monkeypatch):
-    """What the redrawn form is asked to offer back."""
+    """What a redrawn ``_zone_schema_initial`` is asked to offer back."""
     calls: list[dict | None] = []
 
     def _schema(is_imperial, current=None):
@@ -199,6 +217,46 @@ def seeded(monkeypatch):
 
     monkeypatch.setattr(cf, "_zone_schema_initial", _schema)
     return calls
+
+
+# ── the three doors a zone can be submitted through ───────────────────
+
+DOORS = ("setup", "add", "edit")
+
+# Each door redraws its own step when it refuses, so this is how "refused"
+# is recognised without asking the flow to tell us.
+_REFUSAL_STEP = {"setup": "zone", "add": "add_zone", "edit": "edit_zone_detail"}
+
+# Only these two build the shared initial schema; the edit form builds its own
+# inline, and its seeding is pinned by test_zone_override_clearing.
+_SEEDS_SHARED_SCHEMA = ("setup", "add")
+
+
+async def _submit(door: str, hass, payload: dict):
+    """Post a zone at one door and hand back (result, flow)."""
+    if door == "setup":
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass
+        return await flow.async_step_zone(payload), flow
+
+    entry = MagicMock()
+    entry.entry_id = "abc"
+    if door == "add":
+        entry.data = {CONF_ZONES: []}
+        flow = cf.NeverDryOptionsFlow(entry)
+        flow.hass = hass
+        return await flow.async_step_add_zone(payload), flow
+
+    # Editing a zone that is already stored, under the name being submitted.
+    entry.data = {CONF_ZONES: [{CONF_ZONE_NAME: FILLED[CONF_ZONE_NAME]}]}
+    flow = cf.NeverDryOptionsFlow(entry)
+    flow.hass = hass
+    flow._edit_zone_name = FILLED[CONF_ZONE_NAME]
+    return await flow.async_step_edit_zone_detail(payload), flow
+
+
+def _was_refused(door: str, result: dict) -> bool:
+    return result.get("step_id") == _REFUSAL_STEP[door]
 
 
 class TestCoverage:
@@ -222,15 +280,11 @@ class TestFilledZoneIsAccepted:
     """The baseline the matrix subtracts from must itself go through."""
 
     @pytest.mark.asyncio
-    async def test_nothing_missing_nothing_refused(self, hass_mock, seeded):
-        flow = cf.NeverDryConfigFlow()
-        flow.hass = hass_mock
+    @pytest.mark.parametrize("door", DOORS)
+    async def test_nothing_missing_nothing_refused(self, hass_mock, seeded, door):
+        result, _flow = await _submit(door, hass_mock, _payload())
 
-        result = await flow.async_step_zone(_payload())
-
-        assert result["step_id"] == "add_another"
-        assert len(flow._zones) == 1
-        assert seeded == []  # never redrawn, so nothing to seed
+        assert not _was_refused(door, result)
 
 
 class TestRequiredFieldsAreGuardedByTheForm:
@@ -245,74 +299,133 @@ class TestRequiredFieldsAreGuardedByTheForm:
 
 
 class TestOptionalFieldLeftEmpty:
-    """Every optional field, dropped one at a time, on a zone that was fine."""
+    """Every optional field, dropped one at a time, at each door."""
 
     OPTIONAL = sorted(f for f, (_, req) in ZONE_FORM.items() if not req)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
     @pytest.mark.parametrize("field", OPTIONAL)
-    async def test_the_answer_is_never_silent(self, hass_mock, seeded, field):
-        flow = cf.NeverDryConfigFlow()
-        flow.hass = hass_mock
+    async def test_the_answer_is_never_silent(self, hass_mock, seeded, door, field):
+        result, _flow = await _submit(door, hass_mock, _payload(without=field))
 
-        result = await flow.async_step_zone(_payload(without=field))
-
-        if result["step_id"] != "zone":
-            # Accepted, with or without the soft-confirm step in between.
-            assert result["step_id"] in ("add_another", "confirm_zone")
+        if not _was_refused(door, result):
             return
-        # Refused: the frontend renders "base" whatever section the field is
-        # in, so this is the key that decides whether the user is told at all.
-        assert result["errors"], f"{field}: refused with no error at all"
-        assert "base" in result["errors"], f"{field}: refused without a message the form can show"
+        # "base" is the one key the frontend renders whatever section the
+        # field sits in, so it decides whether the user is told at all.
+        assert result["errors"], f"{door}/{field}: refused with no error at all"
+        assert "base" in result["errors"], f"{door}/{field}: refused with nothing the form can show"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
     @pytest.mark.parametrize("field", OPTIONAL)
-    async def test_nothing_else_is_lost(self, hass_mock, seeded, field):
-        flow = cf.NeverDryConfigFlow()
-        flow.hass = hass_mock
-        sent = _payload(without=field)
+    async def test_a_refused_zone_is_not_saved(self, hass_mock, seeded, door, field):
+        result, flow = await _submit(door, hass_mock, _payload(without=field))
 
-        result = await flow.async_step_zone(sent)
-
-        if result["step_id"] != "zone":
+        if not _was_refused(door, result):
             return
-        assert seeded, f"{field}: the form was redrawn from nothing"
+        if door == "setup":
+            assert flow._zones == []
+        else:
+            flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", _SEEDS_SHARED_SCHEMA)
+    @pytest.mark.parametrize("field", OPTIONAL)
+    async def test_nothing_else_is_lost(self, hass_mock, seeded, door, field):
+        result, _flow = await _submit(door, hass_mock, _payload(without=field))
+
+        if not _was_refused(door, result):
+            return
+        assert seeded, f"{door}/{field}: the form was redrawn from nothing"
         offered = seeded[-1]
         for kept, value in FILLED.items():
             if kept == field:
-                assert offered.get(kept) is None, f"{field}: came back filled in behind the user"
+                assert offered.get(kept) is None, f"{door}/{field}: came back filled in behind the user"
             else:
-                assert offered.get(kept) == value, f"{field}: dropping it also lost {kept}"
+                assert offered.get(kept) == value, f"{door}/{field}: dropping it also lost {kept}"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
     @pytest.mark.parametrize(("field", "code"), sorted(REFUSED_WHEN_EMPTY.items()))
-    async def test_the_refusal_names_the_field(self, hass_mock, seeded, field, code):
-        flow = cf.NeverDryConfigFlow()
-        flow.hass = hass_mock
+    async def test_the_refusal_names_the_field(self, hass_mock, seeded, door, field, code):
+        result, _flow = await _submit(door, hass_mock, _payload(without=field))
 
-        result = await flow.async_step_zone(_payload(without=field))
-
-        assert result["step_id"] == "zone"
+        assert _was_refused(door, result), f"{door}: {field} was accepted empty"
         assert result["errors"][field] == code
         assert result["errors"][f"{ZONE_FORM[field][0]}.{field}"] == code
         assert result["errors"]["base"] == code
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("field", OPTIONAL)
-    async def test_only_the_declared_set_is_refused(self, hass_mock, seeded, field):
-        """Anything outside REFUSED_WHEN_EMPTY has to be droppable.
+    async def test_the_three_doors_agree(self, hass_mock, seeded, field):
+        """The asymmetry this file exists to keep closed.
 
-        This is the half that catches a check added later without a thought
-        for whether the user can act on it: a new refusal shows up here as a
-        field that used to be optional in practice and no longer is.
+        Setup used to refuse a zone with no design flow rate while *add zone*
+        and *edit zone* saved it and said nothing — the same omission with
+        three different answers, two of them silent. A rule enforced at one
+        door and forgotten at the next fails here.
         """
-        flow = cf.NeverDryConfigFlow()
-        flow.hass = hass_mock
+        answers = {}
+        for door in DOORS:
+            result, _flow = await _submit(door, hass_mock, _payload(without=field))
+            answers[door] = _was_refused(door, result)
 
-        result = await flow.async_step_zone(_payload(without=field))
-
-        refused = result["step_id"] == "zone"
-        assert refused is (field in REFUSED_WHEN_EMPTY), (
-            f"{field}: refused={refused}, but REFUSED_WHEN_EMPTY says otherwise"
+        assert len(set(answers.values())) == 1, f"{field}: the doors disagree — {answers}"
+        assert answers["setup"] is (field in REFUSED_WHEN_EMPTY), (
+            f"{field}: refused={answers['setup']}, but REFUSED_WHEN_EMPTY says otherwise"
         )
+
+
+class TestModeWithoutItsSensor:
+    """The other half of the asymmetry: a mode is refused, not quietly swapped.
+
+    ``_coerce_delivery_mode`` used to downgrade *flow meter* or *volume preset*
+    to *estimated flow* whenever the entity that mode depends on was missing —
+    only in the two options steps, and without a word. Two things were wrong
+    with it. The user picked a mode and got another one; and the mode it landed
+    on needs a design flow rate that nothing then checked, so the downgrade
+    could manufacture the very zone this file is about. Its commit message said
+    it was there for an entity *removed* from Home Assistant, but it only ever
+    ran on form submission — nobody reopens the form when an entity vanishes,
+    so it never did that job either.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
+    @pytest.mark.parametrize(
+        ("mode", "sensor_field", "code"),
+        [
+            (DELIVERY_MODE_FLOW_METER, CONF_ZONE_FLOW_METER_SENSOR, "flow_meter_required"),
+            (DELIVERY_MODE_VOLUME_PRESET, CONF_ZONE_VOLUME_ENTITY, "volume_entity_required"),
+        ],
+    )
+    async def test_refused_at_every_door(self, hass_mock, seeded, door, mode, sensor_field, code):
+        payload = _payload(without=sensor_field)
+        payload[ZONE_FORM[CONF_ZONE_DELIVERY_MODE][0]][CONF_ZONE_DELIVERY_MODE] = mode
+
+        result, _flow = await _submit(door, hass_mock, payload)
+
+        assert _was_refused(door, result), f"{door}: {mode} accepted with no {sensor_field}"
+        assert result["errors"][sensor_field] == code
+        assert result["errors"]["base"] == code
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
+    async def test_the_chosen_mode_is_never_swapped(self, hass_mock, seeded, door):
+        """A complete flow-meter zone keeps the mode it was given."""
+        payload = _payload()
+        payload[ZONE_FORM[CONF_ZONE_DELIVERY_MODE][0]][CONF_ZONE_DELIVERY_MODE] = DELIVERY_MODE_FLOW_METER
+
+        result, flow = await _submit(door, hass_mock, payload)
+
+        assert not _was_refused(door, result)
+        saved = flow._zones[0] if door == "setup" else _saved_zone(flow)
+        assert saved[CONF_ZONE_DELIVERY_MODE] == DELIVERY_MODE_FLOW_METER
+
+
+def _saved_zone(flow) -> dict:
+    """The zone an options step handed to async_update_entry."""
+    call = flow.hass.config_entries.async_update_entry.call_args
+    assert call is not None, "the zone was never saved"
+    return call.kwargs["data"][CONF_ZONES][-1]

--- a/tests/test_zone_form_empty_fields.py
+++ b/tests/test_zone_form_empty_fields.py
@@ -429,3 +429,58 @@ def _saved_zone(flow) -> dict:
     call = flow.hass.config_entries.async_update_entry.call_args
     assert call is not None, "the zone was never saved"
     return call.kwargs["data"][CONF_ZONES][-1]
+
+
+class TestZoneWithNoValve:
+    """A monitoring zone is not asked how fast it waters.
+
+    A zone with no valve delivers nothing by design: it watches the deficit and
+    says when to water by hand, which is the monitoring mode the controller
+    runs when no valve is configured anywhere. Every delivery-mode requirement
+    is about an act it will never perform, so none of them applies — refusing
+    to save it over a design flow rate would lock a supported setup out of the
+    form.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
+    async def test_accepted_with_nothing_about_delivery(self, hass_mock, seeded, door):
+        payload = _payload()
+        valve = payload[ZONE_FORM[CONF_ZONE_VALVE][0]]
+        for field in (CONF_ZONE_VALVE, CONF_ZONE_FLOW_RATE, CONF_ZONE_FLOW_METER_SENSOR, CONF_ZONE_VOLUME_ENTITY):
+            valve.pop(field, None)
+
+        result, _flow = await _submit(door, hass_mock, payload)
+
+        assert not _was_refused(door, result), f"{door}: a monitoring zone was refused"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
+    @pytest.mark.parametrize("mode", [DELIVERY_MODE_FLOW_METER, DELIVERY_MODE_VOLUME_PRESET])
+    async def test_a_stale_mode_does_not_bite_without_a_valve(self, hass_mock, seeded, door, mode):
+        """The dropdown keeps a value even when there is nothing to drive.
+
+        The form cannot hide the delivery mode when the valve field is emptied,
+        so a zone that loses its valve arrives with a mode still selected. It is
+        inert, and it must not be the reason the zone cannot be saved.
+        """
+        payload = _payload()
+        valve = payload[ZONE_FORM[CONF_ZONE_VALVE][0]]
+        for field in (CONF_ZONE_VALVE, CONF_ZONE_FLOW_RATE, CONF_ZONE_FLOW_METER_SENSOR, CONF_ZONE_VOLUME_ENTITY):
+            valve.pop(field, None)
+        valve[CONF_ZONE_DELIVERY_MODE] = mode
+
+        result, _flow = await _submit(door, hass_mock, payload)
+
+        assert not _was_refused(door, result), f"{door}/{mode}: refused a zone that delivers nothing"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("door", DOORS)
+    async def test_a_valve_brings_the_requirement_back(self, hass_mock, seeded, door):
+        """The exemption is the absent valve, not a hole in the rule."""
+        payload = _payload(without=CONF_ZONE_FLOW_RATE)
+
+        result, _flow = await _submit(door, hass_mock, payload)
+
+        assert _was_refused(door, result)
+        assert result["errors"]["base"] == "flow_rate_required"

--- a/tests/test_zone_form_redraw.py
+++ b/tests/test_zone_form_redraw.py
@@ -1,0 +1,261 @@
+"""A rejected zone form must say why, and must not throw away what was typed.
+
+GH #196: filling the zone form in, pressing submit, and watching every field
+empty itself with no message on screen. Two independent faults met there —
+an error filed against a field the frontend could not reach inside its
+collapsed section, and a form redrawn from a schema that carried none of the
+submitted values. Either one alone is survivable; together they make the
+installation impossible to complete, because the one thing missing is never
+named.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from never_dry import config_flow as cf
+from never_dry.const import (
+    CONF_ET_METHOD,
+    CONF_RAIN_SENSOR,
+    CONF_TEMP_SENSOR,
+    CONF_ZONE_AREA,
+    CONF_ZONE_EXPOSURE,
+    CONF_ZONE_FLOW_METER_SENSOR,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_MICROCLIMATE_FACTOR,
+    CONF_ZONE_NAME,
+    CONF_ZONE_VOLUME_ENTITY,
+    CONF_ZONES,
+    DELIVERY_MODE_FLOW_METER,
+    DELIVERY_MODE_VOLUME_PRESET,
+    EXPOSURE_CUSTOM,
+    MAX_ZONE_NAME_LENGTH,
+)
+
+
+@pytest.fixture
+def schema_calls(monkeypatch):
+    """Record what the zone schema is asked to seed the redrawn form with."""
+    calls: list[dict | None] = []
+
+    def _schema(is_imperial, current=None):
+        calls.append(current)
+        return None
+
+    monkeypatch.setattr(cf, "_zone_schema_initial", _schema)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _patch_flow_env(monkeypatch):
+    """Fill the gaps in the conftest HA stubs, as the other flow tests do."""
+    monkeypatch.setattr(cf, "_is_imperial", lambda hass: False)
+    monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
+
+    def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {"type": "form", "step_id": step_id, "errors": errors}
+
+    def _create_entry(self, *, data=None, title=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    for klass in (cf.NeverDryConfigFlow, cf.NeverDryOptionsFlow):
+        monkeypatch.setattr(klass, "async_show_form", _show_form, raising=False)
+        monkeypatch.setattr(klass, "async_create_entry", _create_entry, raising=False)
+
+
+def _sectioned(**valve):
+    """A zone as the frontend posts it: fields nested under their sections."""
+    return {
+        CONF_ZONE_NAME: "Prato",
+        cf.SECTION_GROUND: {CONF_ZONE_AREA: 50.0},
+        cf.SECTION_VALVE: {"valve": "switch.prato", "system_type": "sprinkler", **valve},
+        cf.SECTION_SCHEDULING: {"threshold_mm": 10},
+    }
+
+
+class TestSuggestionRule:
+    """The seeding rule itself, which decides whether a box comes back filled."""
+
+    def test_first_render_carries_no_suggestion(self):
+        # An explicit suggested_value=None here would blank the field's default.
+        assert cf._suggest(None, CONF_ZONE_FLOW_RATE) == {}
+
+    def test_submitted_value_is_offered_back(self):
+        assert cf._suggest({CONF_ZONE_FLOW_RATE: 200.0}, CONF_ZONE_FLOW_RATE) == {
+            "description": {"suggested_value": 200.0}
+        }
+
+    def test_emptied_box_stays_empty(self):
+        # The field the error is about must not be refilled behind the user.
+        assert cf._suggest({CONF_ZONE_NAME: "Prato"}, CONF_ZONE_FLOW_RATE) == {"description": {"suggested_value": None}}
+
+
+class TestErrorsAreVisible:
+    """Every field error reaches a key the frontend actually renders."""
+
+    def test_sectioned_field_error_is_filed_three_ways(self):
+        errors: dict[str, str] = {}
+        cf._add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")
+        assert errors == {
+            CONF_ZONE_FLOW_RATE: "flow_rate_required",
+            f"{cf.SECTION_VALVE}.{CONF_ZONE_FLOW_RATE}": "flow_rate_required",
+            "base": "flow_rate_required",
+        }
+
+    def test_top_level_field_needs_only_its_own_name(self):
+        errors: dict[str, str] = {}
+        cf._add_field_error(errors, CONF_ZONE_NAME, "zone_name_too_long")
+        assert errors == {CONF_ZONE_NAME: "zone_name_too_long"}
+
+    def test_first_error_owns_base(self):
+        errors: dict[str, str] = {}
+        cf._add_field_error(errors, CONF_ZONE_FLOW_RATE, "flow_rate_required")
+        cf._add_field_error(errors, CONF_ZONE_MICROCLIMATE_FACTOR, "microclimate_factor_required")
+        assert errors["base"] == "flow_rate_required"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("valve", "field"),
+        [
+            ({}, CONF_ZONE_FLOW_RATE),
+            ({"delivery_mode": DELIVERY_MODE_FLOW_METER}, CONF_ZONE_FLOW_METER_SENSOR),
+            ({"delivery_mode": DELIVERY_MODE_VOLUME_PRESET}, CONF_ZONE_VOLUME_ENTITY),
+        ],
+    )
+    async def test_every_delivery_mode_rejection_is_announced(self, hass_mock, schema_calls, valve, field):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        result = await flow.async_step_zone(_sectioned(**valve))
+
+        assert result["step_id"] == "zone"
+        # Without "base" the form comes back silent, which is GH #196.
+        assert "base" in result["errors"]
+        assert result["errors"][field] == result["errors"]["base"]
+
+
+class TestRejectedInputSurvives:
+    """A rejected form is redrawn from what was submitted, not from nothing."""
+
+    @pytest.mark.asyncio
+    async def test_zone_step_seeds_the_redraw(self, hass_mock, schema_calls):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        await flow.async_step_zone(_sectioned())  # no flow rate: rejected
+
+        assert schema_calls == [
+            {
+                CONF_ZONE_NAME: "Prato",
+                CONF_ZONE_AREA: 50.0,
+                "valve": "switch.prato",
+                "system_type": "sprinkler",
+                "threshold_mm": 10,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_first_render_seeds_nothing(self, hass_mock, schema_calls):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        await flow.async_step_zone()
+
+        assert schema_calls == [None]
+
+    @pytest.mark.asyncio
+    async def test_overlong_name_keeps_the_rest_of_the_zone(self, hass_mock, schema_calls):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        payload = _sectioned(flow_rate_lpm=200.0)
+        payload[CONF_ZONE_NAME] = "x" * (MAX_ZONE_NAME_LENGTH + 1)
+
+        await flow.async_step_zone(payload)
+
+        assert schema_calls[0][CONF_ZONE_FLOW_RATE] == 200.0
+
+    @pytest.mark.asyncio
+    async def test_options_add_zone_seeds_form_units_not_metric(self, hass_mock, schema_calls):
+        """The redraw must offer back the L/h the user typed, not the stored L/min.
+
+        Seeding from the converted copy would divide the flow rate by 60 every
+        time the form bounced, so a zone would quietly lose an order of
+        magnitude while the user was busy fixing something else.
+        """
+        entry = MagicMock()
+        entry.entry_id = "abc"
+        entry.data = {CONF_ZONES: [{CONF_ZONE_NAME: "Prato"}]}
+        options = cf.NeverDryOptionsFlow(entry)
+        options.hass = hass_mock
+
+        # Duplicate name: rejected, and the form comes back.
+        await options.async_step_add_zone(_sectioned(flow_rate_lpm=600.0))
+
+        assert schema_calls[0][CONF_ZONE_FLOW_RATE] == 600.0
+
+    @pytest.mark.asyncio
+    async def test_options_add_zone_override_error_seeds_the_redraw(self, hass_mock, schema_calls):
+        entry = MagicMock()
+        entry.entry_id = "abc"
+        entry.data = {CONF_ZONES: []}
+        options = cf.NeverDryOptionsFlow(entry)
+        options.hass = hass_mock
+
+        payload = _sectioned(flow_rate_lpm=600.0)
+        payload[cf.SECTION_GROUND][CONF_ZONE_EXPOSURE] = EXPOSURE_CUSTOM
+        payload[cf.SECTION_GROUND][CONF_ZONE_MICROCLIMATE_FACTOR] = None
+
+        result = await options.async_step_add_zone(payload)
+
+        assert result["errors"]["base"] == "microclimate_factor_required"
+        assert schema_calls[0][CONF_ZONE_EXPOSURE] == EXPOSURE_CUSTOM
+
+
+class TestSensorsStepSurvivesRejection:
+    """The step before the zone form loses input the same way, and must not.
+
+    Picking an ET method the declared sensors cannot support is the one way out
+    of the first step that is not forward. The error itself is visible — that
+    form has no sections — but the redraw used to arrive empty, so the two
+    mandatory sensor pickers had to be found again before the method could even
+    be corrected.
+    """
+
+    @pytest.fixture
+    def sensors_schema_calls(self, monkeypatch):
+        calls: list[dict | None] = []
+
+        def _schema(is_imperial, current=None):
+            calls.append(current)
+            return None
+
+        monkeypatch.setattr(cf, "_sensors_schema", _schema)
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_unsupported_method_keeps_the_declared_sensors(self, hass_mock, sensors_schema_calls):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        submitted = {
+            CONF_TEMP_SENSOR: "sensor.outdoor_temp",
+            CONF_RAIN_SENSOR: "sensor.rain",
+            # Penman-Monteith wants humidity, wind and radiation, none declared.
+            CONF_ET_METHOD: "penman_monteith",
+        }
+
+        result = await flow.async_step_user(submitted)
+
+        assert result["step_id"] == "user"
+        assert result["errors"][CONF_ET_METHOD] == "et_method_missing_sensors"
+        assert sensors_schema_calls == [submitted]
+
+    @pytest.mark.asyncio
+    async def test_first_render_seeds_nothing(self, hass_mock, sensors_schema_calls):
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+
+        await flow.async_step_user()
+
+        assert sensors_schema_calls == [None]

--- a/tests/test_zone_override_clearing.py
+++ b/tests/test_zone_override_clearing.py
@@ -84,7 +84,7 @@ def _patch_flow_env(monkeypatch):
     monkeypatch.setattr(cf.vol, "UNDEFINED", object(), raising=False)
     monkeypatch.setattr(cf, "selector", MagicMock())
     monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
-    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial, current=None: None)
 
     def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
         return {"type": "form", "step_id": step_id, "errors": errors}


### PR DESCRIPTION
The 0.12 line's copy of #197. Same fault, same fix; this branch also closes the variant that exists only here.

Fixes #196 on `develop`. The stable-line PR is #197 — both are needed, because a user on 0.11.1 cannot wait for 0.12.0 to be able to install the integration.

## What was wrong

**The error was invisible.** The zone form is built from collapsible sections, and an error filed against a field *inside* a section cannot be reached by the frontend under its bare name. The three delivery-mode requirements were filed exactly that way. `_override_errors` already knew this and worked around it with three keys — bare name, section-qualified name, and `base` — but that knowledge had never been generalised. It is now `_add_field_error`, and every field-level rejection goes through it.

The one most people hit is the **design flow rate**: mandatory, but impossible to mark as such in the form, because it only applies to one delivery mode.

**The form emptied itself.** `_zone_schema_initial` rebuilt the form with no `suggested_value` anywhere. It now seeds every field from the submitted input — as `suggested_value`, never `default=`, because a default cannot be cleared (#165). A key absent from the submission comes back empty on purpose.

**Only on this branch: the first step had the same hole.** An ET method the declared sensors cannot support is the one way out of that step that is not forward, and the redraw took the two mandatory sensor pickers down with it. The error there is visible — no sections — but `_sensors_schema` is now seeded the same way, so the method can be corrected without hunting for the sensors again.

**The three doors disagreed.** Setup refused a delivery mode whose one indispensable input was missing; *add zone* and *edit zone* saved it without a word. `_zone_errors` is now the single answer for all three.

`_coerce_delivery_mode` is removed. It downgraded *flow meter* or *volume preset* to *estimated flow* whenever the entity that mode depends on was missing, silently, in those two options steps. The user picked a mode and got another one — and the one it landed on needs a design flow rate that nothing then checked, so the downgrade could manufacture the very zone this issue is about. Its commit message said it was there for an entity removed from Home Assistant, but it only ever ran on form submission: nobody reopens the form when an entity vanishes.

## Tests

`tests/test_zone_form_empty_fields.py` — one test per zone field left empty, at each of the three doors, with the matrix parsed out of `_zone_schema_initial` by `ast` so it cannot drift from the form. Required fields are asserted to be declared required (the form is the guard); optional fields are dropped for real and must satisfy three invariants — the answer is never silent, nothing else is lost, and the field the error is about does not come back filled in behind the user. One test asserts the three doors agree, and fails against the previous commit with `{'setup': True, 'add': False, 'edit': False}`.

`tests/test_zone_form_redraw.py` covers the seeding rule, the error-key contract, and the first step's redraw.

1609 tests pass, 1 skipped.

## Note for the beta

An installation that already holds a zone saved without its design flow rate — possible until now through *add zone* — will be asked for that value the first time the zone is edited. It is the number that makes the zone work at all. The changelog says so, under *Changed*.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4