### PR TITLE
release: 0.12.0-beta.2

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.12.0-beta.1"
+  "version": "0.12.0-beta.2"
 }


### PR DESCRIPTION
Version bump only. Second pre-release of the 0.12 line.

Everything beta.1 shipped, plus:

- **#198** — the config flow now says why it refuses a zone, and gives back what you typed. Errors filed against a field inside a collapsed section never reached the frontend, so the form came back blank and silent; the design flow rate is the one most people hit, because it is mandatory in one delivery mode out of three and a form cannot express that. The three ways into a zone — setup, *add zone*, *edit zone* — now answer identically, where the two options steps used to save a broken zone in silence. A zone with no valve is exempt from all of it: it delivers nothing by design.
- **#199** — a water meter that stops answering no longer stops the watering. The zone waters on the estimate, as the code already did for a meter that dies mid-session, and the user is told rather than left with a log line. The estimate now follows the rate real sessions measured, asked of the driver rather than re-derived from the zone's design rate.

## What is worth exercising

- Create a zone leaving the **design flow rate** empty. The form must say why it refuses, at the top, and come back with everything you typed still there. Then do the same from Settings, on *add zone* and on *edit zone*.
- Create a **monitoring zone** — no valve at all — leaving everything about delivery empty. It must save without a word.
- Set the delivery mode to **flow meter** and leave the sensor empty. Refused, with the missing sensor named — not because your hardware lacks a meter, but because you declared one and did not say which.
- Pick **Penman-Monteith** without having declared humidity, wind and radiation. The error was already visible; what is new is that the two sensor pickers stay filled in while you correct the method.
- If you have a **metered zone**, make its meter unavailable and let the zone come up for watering. It waters on the estimate instead of skipping, and says so in a notification.

Pre-release: HACS offers it only to users who have enabled beta versions; everyone else stays on 0.11.1.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4