### PR TITLE
fix: an error code the options flow raises must be readable there

### DIFF
--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -299,7 +299,13 @@
       "kc_required": "Choose a Kc: the plant family is set to Custom, which takes its value from that field",
       "microclimate_factor_required": "Choose a microclimate factor: the exposure is set to Custom, which takes its value from that field",
       "et_method_missing_sensors": "That method needs sensors this installation has not declared. Pick the sensors it requires, or leave the method on Automatic.",
-      "et_method_unknown": "Unknown evapotranspiration method."
+      "et_method_unknown": "Unknown evapotranspiration method.",
+      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
+      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
+      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "zone_already_exists": "A zone with this name already exists",
+      "too_many_zones": "Maximum number of zones reached (50)",
+      "zone_name_too_long": "Zone name is too long (max 64 characters)"
     },
     "abort": {
       "no_zones": "No zones configured"

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -302,7 +302,13 @@
       "kc_required": "Choose a Kc: the plant family is set to Custom, which takes its value from that field",
       "microclimate_factor_required": "Choose a microclimate factor: the exposure is set to Custom, which takes its value from that field",
       "et_method_missing_sensors": "That method needs sensors this installation has not declared. Pick the sensors it requires, or leave the method on Automatic.",
-      "et_method_unknown": "Unknown evapotranspiration method."
+      "et_method_unknown": "Unknown evapotranspiration method.",
+      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
+      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
+      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "zone_already_exists": "A zone with this name already exists",
+      "too_many_zones": "Maximum number of zones reached (50)",
+      "zone_name_too_long": "Zone name is too long (max 64 characters)"
     },
     "abort": {
       "no_zones": "No zones configured"

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -302,7 +302,13 @@
       "kc_required": "Inserisci un Kc: la famiglia di piante è impostata su Personalizzato, che prende il valore da quel campo",
       "microclimate_factor_required": "Inserisci un fattore microclima: l'esposizione è impostata su Personalizzato, che prende il valore da quel campo",
       "et_method_missing_sensors": "Questo metodo richiede sensori che l'installazione non ha dichiarato. Indica i sensori richiesti, oppure lascia il metodo su Automatico.",
-      "et_method_unknown": "Metodo di evapotraspirazione sconosciuto."
+      "et_method_unknown": "Metodo di evapotraspirazione sconosciuto.",
+      "flow_rate_required": "La portata è richiesta per la modalità di erogazione estimated_flow",
+      "flow_meter_required": "Per la modalità flow_meter serve un sensore di erogazione: un contatore cumulativo o una portata",
+      "volume_entity_required": "L'entità del volume è richiesta per la modalità di erogazione volume_preset",
+      "zone_already_exists": "Esiste già una zona con questo nome",
+      "too_many_zones": "È stato raggiunto il numero massimo di zone (50)",
+      "zone_name_too_long": "Il nome della zona è troppo lungo (massimo 64 caratteri)"
     },
     "abort": {
       "no_zones": "Nessuna zona configurata"

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -345,3 +345,94 @@ def test_every_select_options_argument_is_a_list():
     assert not offenders, "SelectSelectorConfig options must be a list (HA refuses a tuple):\n  " + "\n  ".join(
         offenders
     )
+
+
+# ── Error codes must resolve in the flow that raises them ─────────────
+#
+# An error code is not text: Home Assistant looks it up under
+# ``<root>.error.<code>``, where the root is ``config`` for the setup wizard and
+# ``options`` for the Settings dialogs. A code with no entry there is not a
+# missing translation that falls back to English — the raw code is printed at
+# the user, which is what "flow_rate_required" looked like in the field.
+#
+# The two roots drifted because the delivery-mode checks lived only in the setup
+# step for a long time, so only ``config.error`` ever needed them. The moment
+# the same helper started serving the options steps too (GH #196), every code it
+# can raise had to resolve in both — and nothing was checking.
+
+_STRINGS = _COMPONENT / "strings.json"
+_IT_JSON = _COMPONENT / "translations" / "it.json"
+
+
+def _raised_error_codes() -> set[str]:
+    """Every error code ``config_flow.py`` can hand to a form."""
+    from never_dry import config_flow as cf
+
+    tree = ast.parse(_CONFIG_FLOW.read_text())
+    codes: set[str] = set()
+
+    for node in ast.walk(tree):
+        # _add_field_error(errors, FIELD, "code")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_add_field_error"
+            and len(node.args) == 3
+            and isinstance(node.args[2], ast.Constant)
+        ):
+            codes.add(node.args[2].value)
+        # errors["base"] = "code" / errors[FIELD] = "code"
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "errors"
+                    and isinstance(node.value.value, str)
+                ):
+                    codes.add(node.value.value)
+        # errors={"base": "code"} passed straight to async_show_form
+        if isinstance(node, ast.keyword) and node.arg == "errors" and isinstance(node.value, ast.Dict):
+            for value in node.value.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    codes.add(value.value)
+        # The ET-method validator returns its code.
+        if isinstance(node, ast.FunctionDef) and node.name == "_et_method_error":
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Return) and isinstance(inner.value, ast.Constant) and inner.value.value:
+                    codes.add(inner.value.value)
+
+    # The preset/override codes travel in a table rather than at the call site.
+    codes.update(pair[4] for pair in cf.PRESET_OVERRIDE_PAIRS)
+    return codes
+
+
+def test_every_raised_error_code_resolves_in_both_flows():
+    """A code with no entry is printed raw at the user, not translated late."""
+    codes = _raised_error_codes()
+    assert codes, "no error codes found — the extractor has drifted from the source"
+
+    missing: list[str] = []
+    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+        data = json.loads(path.read_text())
+        for root in ("config", "options"):
+            declared = data.get(root, {}).get("error", {})
+            missing += [f"{path.name}: {root}.error.{code}" for code in sorted(codes) if code not in declared]
+
+    assert not missing, "error codes with no entry to resolve to:\n  " + "\n  ".join(missing)
+
+
+def test_the_two_flows_declare_the_same_error_catalogue():
+    """One set of helpers serves both flows, so one catalogue serves both roots.
+
+    Divergence here is how a code ends up raisable somewhere it cannot be
+    read, which is invisible until a user is standing in front of it.
+    """
+    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+        data = json.loads(path.read_text())
+        config = set(data.get("config", {}).get("error", {}))
+        options = set(data.get("options", {}).get("error", {}))
+        assert config == options, (
+            f"{path.name}: config.error and options.error have drifted — "
+            f"only in config: {sorted(config - options)}; only in options: {sorted(options - config)}"
+        )


### PR DESCRIPTION
Field report on `0.12.0-beta.2`: the form printed **`flow_rate_required`** at the user instead of the sentence.

## Why

An error code is not text. Home Assistant resolves it under `<root>.error.<code>`, where the root is `config` for the setup wizard and `options` for the Settings dialogs. A code with no entry there does **not** fall back to English — the raw code is printed.

The two roots had drifted:

```
config.error:  11 keys
options.error:  5 keys   ← flow_rate_required, flow_meter_required, volume_entity_required, … absent
```

Harmless while the delivery-mode checks lived only in the setup step, because only `config.error` ever needed them. Making the same helper serve *add zone* and *edit zone* (#196) carried those codes into a flow where nothing could read them — and that landed on both lines without being noticed on either.

`zone_already_exists` was already in that state before any of this work: raised by `add_zone`, absent from `options.error`, printed raw. Latent only because nobody had tried to add a zone under a name already taken.

## Tests

Neither of these existed, which is why a user found this and CI did not.

- **`test_every_raised_error_code_resolves_in_both_flows`** extracts every code `config_flow.py` can raise — `_add_field_error` calls, `errors[...]` assignments, `errors={...}` passed to `async_show_form`, `_et_method_error`'s returns, and the preset/override table — and requires each to resolve under both roots in `strings.json`, `en.json` and `it.json`.
- **`test_the_two_flows_declare_the_same_error_catalogue`** asserts the two catalogues are the same set. That is the invariant that actually broke: one set of helpers serves both flows, so one catalogue has to serve both roots.

Against the unfixed translations both tests fail, naming the six missing codes.

1630 tests pass, 1 skipped.

## Also needed on main

`#197` carries the same asymmetry closure and the same gap — worse, `options.error` there has only three keys. It is being fixed the same way, so 0.11.2 does not ship the raw code to stable users.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4