### PR TITLE
release: 0.12.0-beta.3

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.12.0-beta.2"
+  "version": "0.12.0-beta.3"
 }


### PR DESCRIPTION
Version bump only. Third pre-release of the 0.12 line, cut because a tester met two faults on `beta.2` — both in the config flow, both found by using it rather than by reading it.

- **#201** — the form printed `flow_rate_required` at the user instead of the sentence. An error code is resolved under `<root>.error.<code>`, and the two roots had drifted: `options.error` carried five codes against `config`'s eleven. Harmless while those checks lived only in the setup step; making the same helper serve *add zone* and *edit zone* carried them into a flow where nothing could read them.
- **#202** — a field cleared in the edit form came back filled, with no error. The design flow rate was declared with a default carrying the stored value, and voluptuous re-injects a default whenever the key is missing, so the flow never saw an empty field and the refusal could not fire. That is #165 again, fixed then on three boxes and never turned into a rule. It is a rule now: **a default may carry a constant, a stored value may only be suggested.** Thirteen declarations broke it.

Both now have a test that closes the class rather than the case: every code the flow can raise must resolve under both roots, and no `default=` may read the stored configuration — checked on identifiers, following local assignments, so a value cannot be laundered through a variable.

## Worth re-exercising

- Clear the **design flow rate** of an existing zone and save. It must refuse, in a sentence, and leave the box empty.
- The same in **Settings**, on *add zone* and on *edit zone*: the message must read as a sentence there too, not as a code.
- A **monitoring zone** — no valve — with nothing filled in about delivery. Saves without a word.
- **Flow meter** selected with no sensor named. Refused, sensor named.
- A **metered zone** whose meter you make unavailable. Waters on the estimate and notifies, instead of skipping in silence.

Home Assistant caches translations, so restart after updating or the old text will still be on screen.

Pre-release: HACS offers it only to users who have enabled beta versions.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4