### PR TITLE
fix: declining the soft guard must not undo the edit, and the form must not speak in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ not the argument.
   **no valve** is exempt from all of it: it delivers nothing by design — it watches
   the deficit and tells you when to water by hand — so asking it how fast it waters
   would be asking about something it will never do.
+- **Declining "save anyway" no longer undoes your edit** ([#196]). A zone with
+  unusual values asks for confirmation, and submitting without ticking the box
+  sends you back to the form. That return was drawn from the *saved* zone — the
+  configuration you were in the middle of changing — so a box you had just
+  emptied came back full. The form now comes back holding what you typed,
+  cleared boxes included.
+- **The form stops reading identifiers out loud.** An error said *"required for
+  estimated_flow delivery mode"* while the dropdown beside it said *"Simple
+  on/off"*: the same choice, named twice, once in a language meant for the code.
+  Twelve messages and labels did this. In Italian the design flow rate had its
+  whole explanation pasted into the label slot, so during setup the field
+  announced itself with a 493-character paragraph while every neighbour had a
+  name.
 - **A silent water meter no longer stops the watering.** A zone whose meter was
   already unavailable when its turn came did not water at all, and said so only in
   the log. Mid-session the code had always judged this the other way — a run that

--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -838,7 +838,20 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._data: dict[str, Any] = {}
         self._zones: list[dict[str, Any]] = []
         self._pending_zone: dict[str, Any] | None = None
+        # The same submission in form units, for redrawing the form the user
+        # was standing in. _pending_zone is metric, which is what gets saved.
+        self._pending_form: dict[str, Any] | None = None
         self._pending_warnings: list[str] = []
+
+    def _take_pending_form(self) -> dict[str, Any] | None:
+        """The declined submission, consumed once.
+
+        Declining the soft guard means "let me fix that", not "start again":
+        the form has to come back holding what was typed, including the box
+        that was deliberately emptied.
+        """
+        form, self._pending_form = self._pending_form, None
+        return form
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Step 1: Select sensors and ET model parameters."""
@@ -880,16 +893,19 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if self._pending_warnings:
                     self._pending_zone = zone_metric
+                    self._pending_form = user_input
                     return await self.async_step_confirm_zone()
                 self._zones.append(zone_metric)
                 return await self.async_step_add_another()
 
         # user_input survives here only when it was rejected above — it is
         # still in form units, since the conversion to metric happens on the
-        # accepted path. Passing it back is what keeps the form filled in.
+        # accepted path. With no input at all this may be a return from the
+        # soft guard, which carries the same thing. Either way, passing it back
+        # is what keeps the form filled in.
         return self.async_show_form(
             step_id="zone",
-            data_schema=_zone_schema_initial(imperial, user_input),
+            data_schema=_zone_schema_initial(imperial, user_input or self._take_pending_form()),
             errors=errors,
             description_placeholders={
                 "zone_count": str(len(self._zones)),
@@ -908,10 +924,15 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         if user_input is not None:
             pending = self._pending_zone
-            self._pending_zone = None
             if user_input.get("confirm") and pending is not None:
+                self._pending_zone = None
+                self._pending_form = None
                 self._zones.append(pending)
                 return await self.async_step_add_another()
+            # Declined. The submission is deliberately left standing: the zone
+            # form reads it on the way back, so the values the user was in the
+            # middle of changing survive the round trip.
+            self._pending_zone = None
             return await self.async_step_zone()
 
         return self.async_show_form(
@@ -965,8 +986,36 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         """Initialize options flow."""
         self._config_entry = config_entry
         self._pending_zone: dict[str, Any] | None = None
+        # The same submission in form units, for redrawing the add form.
+        # The edit form seeds from the metric copy, since it converts anyway.
+        self._pending_form: dict[str, Any] | None = None
         self._pending_warnings: list[str] = []
         self._pending_action: str = ""
+
+    def _take_pending_form(self) -> dict[str, Any] | None:
+        """The declined submission in form units, consumed once."""
+        form, self._pending_form = self._pending_form, None
+        return form
+
+    def _take_pending_zone(self) -> dict[str, Any] | None:
+        """The declined submission in metric, consumed once."""
+        zone, self._pending_zone = self._pending_zone, None
+        return zone
+
+    def _edit_zone_seed(self) -> dict[str, Any]:
+        """What the edit form is drawn from when it opens with no input.
+
+        A declined soft guard comes back here, and it must not redraw from the
+        stored zone: that is the configuration the user was in the middle of
+        changing, so a box they had just emptied would come back full and their
+        edit would be undone without a word. The declined submission wins when
+        there is one; otherwise the form opens on what is saved.
+        """
+        declined = self._take_pending_zone()
+        if declined is not None:
+            return declined
+        zones = list(self._config_entry.data.get(CONF_ZONES, []))
+        return next((z for z in zones if z[CONF_ZONE_NAME] == self._edit_zone_name), {})
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Show menu: edit model params or manage zones."""
@@ -1035,13 +1084,16 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(user_input)
             if self._pending_warnings:
                 self._pending_zone = user_input
+                self._pending_form = submitted
                 self._pending_action = "add"
                 return await self.async_step_confirm_zone()
             return self._save_added_zone(user_input)
 
+        # No input here is either a first render or a return from the soft
+        # guard; the second carries the submission that was declined.
         return self.async_show_form(
             step_id="add_zone",
-            data_schema=_zone_schema_initial(imperial),
+            data_schema=_zone_schema_initial(imperial, self._take_pending_form()),
         )
 
     def _save_added_zone(self, zone: dict[str, Any]) -> config_entries.ConfigFlowResult:
@@ -1086,11 +1138,7 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> config_entries.ConfigFlowResult:
         """Edit zone details with current values as defaults."""
-        zones = list(self._config_entry.data.get(CONF_ZONES, []))
-        cur = next(
-            (z for z in zones if z[CONF_ZONE_NAME] == self._edit_zone_name),
-            {},
-        )
+        cur = self._edit_zone_seed()
 
         imperial = _is_imperial(self.hass)
         errors: dict[str, str] = {}
@@ -1396,13 +1444,18 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         """
         if user_input is not None:
             pending = self._pending_zone
-            self._pending_zone = None
             if user_input.get("confirm") and pending is not None:
+                self._pending_zone = None
+                self._pending_form = None
                 if self._pending_action == "edit":
                     return self._save_edited_zone(pending)
                 return self._save_added_zone(pending)
+            # Declined. The submission is left standing for the form to read on
+            # the way back — the edit form takes the metric copy, the add form
+            # the one in display units.
             if self._pending_action == "edit":
                 return await self.async_step_edit_zone_detail()
+            self._pending_zone = None
             return await self.async_step_add_zone()
 
         return self.async_show_form(

--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -66,8 +66,8 @@
               "valve": "Valve switch (optional)",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow_meter mode only)",
-              "volume_entity": "Volume target entity (volume_preset only)",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency (overrides system type default)",
               "delivery_timeout": "Safety timeout"
@@ -76,11 +76,11 @@
               "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
               "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
               "flow_rate_lpm": "The sum of the rated output of everything this zone waters — sprinklers, drippers, micro-sprayers — in liters per hour (gal/h in imperial). Take it from the emitters' rating or your irrigation plan; you do not need to measure it. It is what the zone was built to deliver, and it is required: without it there is no way to turn a volume into a watering duration. What the zone actually delivers is measured separately from real sessions, and the gap between the two is worth watching.",
-              "flow_meter_sensor": "Either kind works, and NeverDry tells them apart by the unit of measurement. A cumulative counter (L, gal, m³) is read before and after the run and the difference is the volume delivered — the more accurate of the two, because it does not depend on reporting frequency. An instantaneous flow rate (L/min, L/h, m³/h, gal/min, gal/h) is integrated over the run instead, so how often your valve reports its flow sets how good the number is. Required for flow_meter mode",
-              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
+              "flow_meter_sensor": "Either kind works, and NeverDry tells them apart by the unit of measurement. A cumulative counter (L, gal, m³) is read before and after the run and the difference is the volume delivered — the more accurate of the two, because it does not depend on reporting frequency. An instantaneous flow rate (L/min, L/h, m³/h, gal/min, gal/h) is integrated over the run instead, so how often your valve reports its flow sets how good the number is. Required when the delivery mode is the one with a flow meter.",
+              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required when the delivery mode leaves the dosing to the valve.",
               "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
               "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-              "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)"
+              "delivery_timeout": "Maximum time to wait for a measured or self-dosed delivery before forcing the valve closed (safety limit)."
             }
           },
           "scheduling": {
@@ -116,9 +116,9 @@
     "error": {
       "zone_name_too_long": "Zone name is too long (max 64 characters)",
       "too_many_zones": "Maximum number of zones reached (50)",
-      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
-      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
-      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "flow_rate_required": "The design flow rate is needed: the delivery mode you chose works the watering duration out from it.",
+      "flow_meter_required": "A delivery measurement sensor is needed — a cumulative counter or a flow rate: the delivery mode you chose closes the valve at the measured volume.",
+      "volume_entity_required": "A volume target entity is needed: the delivery mode you chose leaves the dosing to the valve itself.",
       "zone_already_exists": "A zone with this name already exists",
       "efficiency_required": "Choose an efficiency: the system type is set to Custom, which takes its value from that field",
       "kc_required": "Choose a Kc: the plant family is set to Custom, which takes its value from that field",
@@ -194,8 +194,8 @@
               "valve": "Valve switch (optional)",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor (counter or flow rate)",
-              "volume_entity": "Volume target entity",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency",
               "delivery_timeout": "Safety timeout"
@@ -261,8 +261,8 @@
               "valve": "Valve switch",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor (counter or flow rate)",
-              "volume_entity": "Volume target entity",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency",
               "delivery_timeout": "Safety timeout"
@@ -300,9 +300,9 @@
       "microclimate_factor_required": "Choose a microclimate factor: the exposure is set to Custom, which takes its value from that field",
       "et_method_missing_sensors": "That method needs sensors this installation has not declared. Pick the sensors it requires, or leave the method on Automatic.",
       "et_method_unknown": "Unknown evapotranspiration method.",
-      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
-      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
-      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "flow_rate_required": "The design flow rate is needed: the delivery mode you chose works the watering duration out from it.",
+      "flow_meter_required": "A delivery measurement sensor is needed — a cumulative counter or a flow rate: the delivery mode you chose closes the valve at the measured volume.",
+      "volume_entity_required": "A volume target entity is needed: the delivery mode you chose leaves the dosing to the valve itself.",
       "zone_already_exists": "A zone with this name already exists",
       "too_many_zones": "Maximum number of zones reached (50)",
       "zone_name_too_long": "Zone name is too long (max 64 characters)"

--- a/custom_components/never_dry/translations/en.json
+++ b/custom_components/never_dry/translations/en.json
@@ -66,8 +66,8 @@
               "valve": "Valve switch (optional)",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow_meter mode only)",
-              "volume_entity": "Volume target entity (volume_preset only)",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency (overrides system type default)",
               "delivery_timeout": "Safety timeout"
@@ -76,11 +76,11 @@
               "valve": "The switch entity that controls this zone's irrigation valve. Leave empty for monitoring mode (no valve)",
               "delivery_mode": "How your valve delivers water. Estimated flow: simple on/off valve, duration calculated from flow rate. Flow meter: valve with a flow sensor, closes at target volume. Volume preset: smart valve that accepts a volume target and closes itself.",
               "flow_rate_lpm": "The sum of the rated output of everything this zone waters — sprinklers, drippers, micro-sprayers — in liters per hour (gal/h in imperial). Take it from the emitters' rating or your irrigation plan; you do not need to measure it. It is what the zone was built to deliver, and it is required: without it there is no way to turn a volume into a watering duration. What the zone actually delivers is measured separately from real sessions, and the gap between the two is worth watching.",
-              "flow_meter_sensor": "Either kind works, and NeverDry tells them apart by the unit of measurement. A cumulative counter (L, gal, m³) is read before and after the run and the difference is the volume delivered — the more accurate of the two, because it does not depend on reporting frequency. An instantaneous flow rate (L/min, L/h, m³/h, gal/min, gal/h) is integrated over the run instead, so how often your valve reports its flow sets how good the number is. Required for flow_meter mode",
-              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required for volume_preset mode",
+              "flow_meter_sensor": "Either kind works, and NeverDry tells them apart by the unit of measurement. A cumulative counter (L, gal, m³) is read before and after the run and the difference is the volume delivered — the more accurate of the two, because it does not depend on reporting frequency. An instantaneous flow rate (L/min, L/h, m³/h, gal/min, gal/h) is integrated over the run instead, so how often your valve reports its flow sets how good the number is. Required when the delivery mode is the one with a flow meter.",
+              "volume_entity": "Number entity on the smart valve that accepts a volume target in liters. Required when the delivery mode leaves the dosing to the valve.",
               "system_type": "Sets the zone's efficiency (drip 0.92, micro-sprinklers 0.80, pop-up 0.68, manual 0.55). Pick Custom to enter your own below.",
               "efficiency": "Used only when the system type is Custom. With any other type this field is ignored and the form will tell you so.",
-              "delivery_timeout": "Maximum time to wait for flow_meter or volume_preset delivery before forcing valve close (safety limit)"
+              "delivery_timeout": "Maximum time to wait for a measured or self-dosed delivery before forcing the valve closed (safety limit)."
             }
           },
           "scheduling": {
@@ -116,9 +116,9 @@
     "error": {
       "zone_name_too_long": "Zone name is too long (max 64 characters)",
       "too_many_zones": "Maximum number of zones reached (50)",
-      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
-      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
-      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "flow_rate_required": "The design flow rate is needed: the delivery mode you chose works the watering duration out from it.",
+      "flow_meter_required": "A delivery measurement sensor is needed — a cumulative counter or a flow rate: the delivery mode you chose closes the valve at the measured volume.",
+      "volume_entity_required": "A volume target entity is needed: the delivery mode you chose leaves the dosing to the valve itself.",
       "zone_already_exists": "A zone with this name already exists",
       "efficiency_required": "Choose an efficiency: the system type is set to Custom, which takes its value from that field",
       "kc_required": "Choose a Kc: the plant family is set to Custom, which takes its value from that field",
@@ -197,8 +197,8 @@
               "valve": "Valve switch (optional)",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor (counter or flow rate)",
-              "volume_entity": "Volume target entity",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency",
               "delivery_timeout": "Safety timeout"
@@ -264,8 +264,8 @@
               "valve": "Valve switch",
               "delivery_mode": "Water delivery mode",
               "flow_rate_lpm": "Design flow rate",
-              "flow_meter_sensor": "Delivery measurement sensor (counter or flow rate)",
-              "volume_entity": "Volume target entity",
+              "flow_meter_sensor": "Delivery measurement sensor — counter or flow rate (flow meter mode only)",
+              "volume_entity": "Volume target entity (volume dosing mode only)",
               "system_type": "Irrigation system type",
               "efficiency": "Custom efficiency",
               "delivery_timeout": "Safety timeout"
@@ -303,9 +303,9 @@
       "microclimate_factor_required": "Choose a microclimate factor: the exposure is set to Custom, which takes its value from that field",
       "et_method_missing_sensors": "That method needs sensors this installation has not declared. Pick the sensors it requires, or leave the method on Automatic.",
       "et_method_unknown": "Unknown evapotranspiration method.",
-      "flow_rate_required": "Flow rate is required for estimated_flow delivery mode",
-      "flow_meter_required": "A delivery measurement sensor — a cumulative counter or a flow rate — is required for flow_meter delivery mode",
-      "volume_entity_required": "Volume entity is required for volume_preset delivery mode",
+      "flow_rate_required": "The design flow rate is needed: the delivery mode you chose works the watering duration out from it.",
+      "flow_meter_required": "A delivery measurement sensor is needed — a cumulative counter or a flow rate: the delivery mode you chose closes the valve at the measured volume.",
+      "volume_entity_required": "A volume target entity is needed: the delivery mode you chose leaves the dosing to the valve itself.",
       "zone_already_exists": "A zone with this name already exists",
       "too_many_zones": "Maximum number of zones reached (50)",
       "zone_name_too_long": "Zone name is too long (max 64 characters)"

--- a/custom_components/never_dry/translations/it.json
+++ b/custom_components/never_dry/translations/it.json
@@ -65,9 +65,9 @@
             "data": {
               "valve": "Interruttore della valvola (opzionale)",
               "delivery_mode": "Modalità di erogazione dell'acqua",
-              "flow_rate_lpm": "La somma delle portate nominali di tutto ciò che irriga questa zona — irrigatori, gocciolatoi, nebulizzatori — in litri all'ora (gal/h in imperiale). Prendila dalla scheda degli erogatori o dal progetto dell'impianto: non serve misurarla. È ciò che la zona è stata costruita per erogare, ed è obbligatoria: senza non è possibile tradurre un volume in una durata di irrigazione. Quanto la zona eroga davvero viene misurato a parte dalle sessioni reali, e lo scarto fra le due merita attenzione.",
-              "flow_meter_sensor": "Sensore di erogazione — contatore o portata (solo per flow_meter)",
-              "volume_entity": "Entità target del volume (solo per volume_preset)",
+              "flow_rate_lpm": "Portata di progetto",
+              "flow_meter_sensor": "Sensore di erogazione — contatore o portata (solo con valvola a flussometro)",
+              "volume_entity": "Entità target del volume (solo con dosaggio a volume)",
               "system_type": "Tipo di impianto di irrigazione",
               "efficiency": "Efficienza personalizzata (sovrascrive il valore predefinito del tipo di impianto)",
               "delivery_timeout": "Timeout di sicurezza"
@@ -76,11 +76,11 @@
               "valve": "L'entità interruttore (switch) che controlla la valvola di irrigazione di questa zona. Lascia vuoto per la modalità di solo monitoraggio (nessuna valvola)",
               "delivery_mode": "Modalità di erogazione dell'acqua della valvola. Portata stimata (estimated flow): semplice valvola on/off, durata calcolata in base alla portata. Flussometro (flow meter): valvola con sensore di flusso, si chiude al raggiungimento del volume target. Volume preimpostato (volume preset): valvola intelligente che accetta un volume target e si chiude autonomamente.",
               "flow_rate_lpm": "La somma delle portate nominali di tutto ciò che irriga questa zona — irrigatori, gocciolatoi, nebulizzatori — in litri all'ora (gal/h in imperiale). Prendila dalla scheda degli erogatori o dal progetto dell'impianto: non serve misurarla. È ciò che la zona è stata costruita per erogare, ed è obbligatoria: senza non è possibile tradurre un volume in una durata di irrigazione. Quanto la zona eroga davvero viene misurato a parte dalle sessioni reali, e lo scarto fra le due merita attenzione.",
-              "flow_meter_sensor": "Vanno bene entrambi, e NeverDry li distingue dall'unità di misura. Un contatore cumulativo (L, gal, m³) viene letto prima e dopo la corsa e la differenza è il volume erogato: è il più accurato dei due, perché non dipende da quanto spesso la valvola parla. Una portata istantanea (L/min, L/h, m³/h, gal/min, gal/h) viene invece integrata nel tempo, quindi la frequenza con cui la valvola riporta il flusso decide quanto è buono il numero. Richiesto per la modalità flow_meter",
-              "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto per la modalità volume_preset",
+              "flow_meter_sensor": "Vanno bene entrambi, e NeverDry li distingue dall'unità di misura. Un contatore cumulativo (L, gal, m³) viene letto prima e dopo la corsa e la differenza è il volume erogato: è il più accurato dei due, perché non dipende da quanto spesso la valvola parla. Una portata istantanea (L/min, L/h, m³/h, gal/min, gal/h) viene invece integrata nel tempo, quindi la frequenza con cui la valvola riporta il flusso decide quanto è buono il numero. Richiesto quando la modalità di erogazione è quella con flussometro.",
+              "volume_entity": "Entità numerica sulla valvola intelligente che accetta un target di volume in litri. Richiesto quando la modalità di erogazione affida il dosaggio alla valvola.",
               "system_type": "Imposta l'efficienza della zona (goccia 0.92, micro-irrigatori 0.80, pop-up 0.68, manuale 0.55). Scegli Personalizzato per inserire la tua qui sotto.",
               "efficiency": "Usato solo quando il tipo di impianto è Personalizzato. Con qualsiasi altro tipo questo campo viene ignorato e il form te lo segnala.",
-              "delivery_timeout": "Tempo massimo di attesa per l'erogazione con flow_meter o volume_preset prima di forzare la chiusura della valvola (limite di sicurezza)"
+              "delivery_timeout": "Tempo massimo di attesa per un'erogazione misurata o dosata dalla valvola prima di forzarne la chiusura (limite di sicurezza)."
             }
           },
           "scheduling": {
@@ -116,9 +116,9 @@
     "error": {
       "zone_name_too_long": "Il nome della zona è troppo lungo (massimo 64 caratteri)",
       "too_many_zones": "È stato raggiunto il numero massimo di zone (50)",
-      "flow_rate_required": "La portata è richiesta per la modalità di erogazione estimated_flow",
-      "flow_meter_required": "Per la modalità flow_meter serve un sensore di erogazione: un contatore cumulativo o una portata",
-      "volume_entity_required": "L'entità del volume è richiesta per la modalità di erogazione volume_preset",
+      "flow_rate_required": "Serve la portata di progetto: la modalità di erogazione scelta ricava da quella la durata dell'irrigazione.",
+      "flow_meter_required": "Serve il sensore di erogazione — un contatore cumulativo o una portata: la modalità scelta chiude la valvola al volume misurato.",
+      "volume_entity_required": "Serve l'entità target del volume: la modalità scelta affida il dosaggio alla valvola stessa.",
       "zone_already_exists": "Esiste già una zona con questo nome",
       "efficiency_required": "Inserisci un'efficienza: il tipo di impianto è impostato su Personalizzato, che prende il valore da quel campo",
       "kc_required": "Inserisci un Kc: la famiglia di piante è impostata su Personalizzato, che prende il valore da quel campo",
@@ -197,8 +197,8 @@
               "valve": "Interruttore della valvola (opzionale)",
               "delivery_mode": "Modalità di erogazione dell'acqua",
               "flow_rate_lpm": "Portata di progetto",
-              "flow_meter_sensor": "Sensore di erogazione (contatore o portata)",
-              "volume_entity": "Entità target del volume",
+              "flow_meter_sensor": "Sensore di erogazione — contatore o portata (solo con valvola a flussometro)",
+              "volume_entity": "Entità target del volume (solo con dosaggio a volume)",
               "system_type": "Tipo di impianto di irrigazione",
               "efficiency": "Efficienza personalizzata",
               "delivery_timeout": "Timeout di sicurezza"
@@ -264,8 +264,8 @@
               "valve": "Interruttore della valvola",
               "delivery_mode": "Modalità di erogazione dell'acqua",
               "flow_rate_lpm": "Portata di progetto",
-              "flow_meter_sensor": "Sensore di erogazione (contatore o portata)",
-              "volume_entity": "Entità target del volume",
+              "flow_meter_sensor": "Sensore di erogazione — contatore o portata (solo con valvola a flussometro)",
+              "volume_entity": "Entità target del volume (solo con dosaggio a volume)",
               "system_type": "Tipo di impianto di irrigazione",
               "efficiency": "Efficienza personalizzata",
               "delivery_timeout": "Timeout di sicurezza"
@@ -303,9 +303,9 @@
       "microclimate_factor_required": "Inserisci un fattore microclima: l'esposizione è impostata su Personalizzato, che prende il valore da quel campo",
       "et_method_missing_sensors": "Questo metodo richiede sensori che l'installazione non ha dichiarato. Indica i sensori richiesti, oppure lascia il metodo su Automatico.",
       "et_method_unknown": "Metodo di evapotraspirazione sconosciuto.",
-      "flow_rate_required": "La portata è richiesta per la modalità di erogazione estimated_flow",
-      "flow_meter_required": "Per la modalità flow_meter serve un sensore di erogazione: un contatore cumulativo o una portata",
-      "volume_entity_required": "L'entità del volume è richiesta per la modalità di erogazione volume_preset",
+      "flow_rate_required": "Serve la portata di progetto: la modalità di erogazione scelta ricava da quella la durata dell'irrigazione.",
+      "flow_meter_required": "Serve il sensore di erogazione — un contatore cumulativo o una portata: la modalità scelta chiude la valvola al volume misurato.",
+      "volume_entity_required": "Serve l'entità target del volume: la modalità scelta affida il dosaggio alla valvola stessa.",
       "zone_already_exists": "Esiste già una zona con questo nome",
       "too_many_zones": "È stato raggiunto il numero massimo di zone (50)",
       "zone_name_too_long": "Il nome della zona è troppo lungo (massimo 64 caratteri)"

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -436,3 +436,74 @@ def test_the_two_flows_declare_the_same_error_catalogue():
             f"{path.name}: config.error and options.error have drifted — "
             f"only in config: {sorted(config - options)}; only in options: {sorted(options - config)}"
         )
+
+
+# ── Internal vocabulary must not reach the user ───────────────────────
+#
+# A value like ``estimated_flow`` is an identifier. It has a translated label
+# precisely because the user is not supposed to see the key — and then the
+# error text said "required for estimated_flow delivery mode", naming in the
+# message the very thing the dropdown had just spelt out in words. A tester
+# read it back on 0.12.0-beta.3 and asked why the form spoke two languages.
+#
+# The rule is derived rather than listed: every option that has a label under
+# ``selector.<key>.options`` is by construction an internal identifier, so its
+# raw form must not appear in any label, description or error.
+
+
+def _internal_option_keys(data: dict) -> set[str]:
+    """Option values that have a translated label, so are identifiers.
+
+    Only the ones carrying an underscore. A key like ``custom`` or ``auto`` is
+    an ordinary English word, and banning it would flag "Pick Custom to enter
+    your own" — the label doing its job.
+    """
+    keys: set[str] = set()
+    for group in data.get("selector", {}).values():
+        keys |= {k for k in group.get("options", {}) if "_" in k}
+    return keys
+
+
+def _user_facing_strings(data: dict):
+    """Every string the form puts in front of a person, with where it lives."""
+    for root in ("config", "options"):
+        section = data.get(root, {})
+        for code, text in section.get("error", {}).items():
+            yield f"{root}.error.{code}", text
+        for step_name, step in section.get("step", {}).items():
+            blocks = [("", step)] + [(f"{s}.", body) for s, body in step.get("sections", {}).items()]
+            for prefix, block in blocks:
+                for kind in ("data", "data_description"):
+                    for field, text in block.get(kind, {}).items():
+                        yield f"{root}.{step_name}.{prefix}{kind}.{field}", text
+
+
+def test_no_user_facing_string_names_an_internal_key():
+    offenders: list[str] = []
+    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+        data = json.loads(path.read_text())
+        keys = _internal_option_keys(data)
+        assert keys, f"{path.name}: no translated options found — the extractor has drifted"
+        for where, text in _user_facing_strings(data):
+            for key in sorted(keys):
+                if key in text:
+                    offenders.append(f"{path.name}: {where} says '{key}'")
+    assert not offenders, "these read an identifier out loud; use the label the user already sees:\n  " + "\n  ".join(
+        offenders
+    )
+
+
+def test_a_label_is_a_name_not_a_paragraph():
+    """A label names the field; the explanation belongs in data_description.
+
+    The Italian file had the whole design-flow-rate description pasted into the
+    label slot — 493 characters where the form expects two words — so the
+    field announced itself with a paragraph while every neighbour had a name.
+    """
+    offenders: list[str] = []
+    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+        data = json.loads(path.read_text())
+        for where, text in _user_facing_strings(data):
+            if ".data." in where and len(text) > 90:
+                offenders.append(f"{path.name}: {where} is {len(text)} characters")
+    assert not offenders, "labels that are paragraphs:\n  " + "\n  ".join(offenders)

--- a/tests/test_zone_form_redraw.py
+++ b/tests/test_zone_form_redraw.py
@@ -18,6 +18,7 @@ from never_dry.const import (
     CONF_RAIN_SENSOR,
     CONF_TEMP_SENSOR,
     CONF_ZONE_AREA,
+    CONF_ZONE_DELIVERY_MODE,
     CONF_ZONE_EXPOSURE,
     CONF_ZONE_FLOW_METER_SENSOR,
     CONF_ZONE_FLOW_RATE,
@@ -52,6 +53,10 @@ def _patch_flow_env(monkeypatch):
     monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
     monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
     monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "UNDEFINED", object(), raising=False)
+    # The edit form builds its schema inline, so the selector module has to
+    # answer attribute access rather than be the empty stub conftest installs.
+    monkeypatch.setattr(cf, "selector", MagicMock())
     monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
 
     def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
@@ -259,3 +264,101 @@ class TestSensorsStepSurvivesRejection:
         await flow.async_step_user()
 
         assert sensors_schema_calls == [None]
+
+
+_STORED_ZONE = {
+    CONF_ZONE_NAME: "Prato",
+    CONF_ZONE_AREA: 50.0,
+    CONF_ZONE_FLOW_RATE: 10.0,  # metric, L/min
+    CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+    CONF_ZONE_FLOW_METER_SENSOR: "sensor.prato_counter",
+}
+
+
+class TestDecliningTheSoftGuard:
+    """Declining means "let me fix that", not "start again".
+
+    A zone with unusual values routes through a confirmation step, and
+    submitting it without ticking the box sends the user back to the form.
+    That return redrew from the *stored* configuration — the very
+    configuration the user was in the middle of changing — so a box they had
+    deliberately emptied came back full and the edit was undone without a
+    word. Reported from the field on 0.12.0-beta.3, on the design flow rate.
+
+    Reported *after* the fix that made a cleared field survive a refusal, and
+    it is worth saying why that fix did not cover this: a refusal redraws the
+    same step with the input in hand, while declining leaves the step and
+    comes back with nothing. Two paths back into one form.
+    """
+
+    def _options(self, hass):
+        entry = MagicMock()
+        entry.entry_id = "abc"
+        entry.data = {CONF_ZONES: [dict(_STORED_ZONE)]}
+        options = cf.NeverDryOptionsFlow(entry)
+        options.hass = hass
+        options._edit_zone_name = "Prato"
+        return options
+
+    def test_the_form_opens_on_what_is_saved(self, hass_mock):
+        options = self._options(hass_mock)
+
+        assert options._edit_zone_seed() == _STORED_ZONE
+
+    def test_a_declined_submission_wins_over_what_is_saved(self, hass_mock):
+        options = self._options(hass_mock)
+        # The rate is gone from the submission; the stored zone still has it.
+        options._pending_zone = {CONF_ZONE_NAME: "Prato", CONF_ZONE_AREA: 50.0}
+
+        seed = options._edit_zone_seed()
+
+        assert CONF_ZONE_FLOW_RATE not in seed
+        assert seed[CONF_ZONE_AREA] == 50.0
+
+    def test_the_declined_submission_is_consumed_once(self, hass_mock):
+        """It seeds the form it was declined from, and then it is gone."""
+        options = self._options(hass_mock)
+        options._pending_zone = {CONF_ZONE_NAME: "Prato"}
+
+        options._edit_zone_seed()
+
+        assert options._edit_zone_seed() == _STORED_ZONE
+
+    @pytest.mark.asyncio
+    async def test_declining_carries_the_submission_back(self, hass_mock):
+        options = self._options(hass_mock)
+        submitted = {
+            CONF_ZONE_NAME: "Prato",
+            cf.SECTION_GROUND: {CONF_ZONE_AREA: 50.0},
+            cf.SECTION_VALVE: {
+                "valve": "switch.prato",
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.prato_counter",
+                "system_type": "sprinkler",
+            },
+            cf.SECTION_SCHEDULING: {},
+        }
+        # The meter is declared, so a missing design rate is a warning here,
+        # not a refusal — which is the path that leads to the guard at all.
+        result = await options.async_step_edit_zone_detail(submitted)
+        assert result["step_id"] == "confirm_zone"
+
+        options._pending_action = "edit"
+        await options.async_step_confirm_zone({"confirm": False})
+
+        # Consumed by the redraw on the way back, and the rate stayed gone.
+        assert options._pending_zone is None
+
+    @pytest.mark.asyncio
+    async def test_confirming_saves_and_forgets(self, hass_mock):
+        """A kept submission must not leak into the next visit to the form."""
+        options = self._options(hass_mock)
+        options._pending_zone = {CONF_ZONE_NAME: "Prato"}
+        options._pending_form = {CONF_ZONE_NAME: "Prato"}
+        options._pending_action = "edit"
+
+        await options.async_step_confirm_zone({"confirm": True})
+
+        assert options._pending_zone is None
+        assert options._pending_form is None
+        assert options._edit_zone_seed() == _STORED_ZONE


### PR DESCRIPTION
Three faults reported from the field on `0.12.0-beta.3`, all found by using the form rather than reading it.

## Declining "save anyway" undid the edit

A zone with unusual values asks for confirmation. Submitting without ticking the box sends you back to the form — and that return was drawn from the **stored** zone, the configuration you were in the middle of changing. A box you had just emptied came back full.

The earlier fix did not cover this, and the reason is worth stating: the two paths back into the form are different. A **refusal** redraws the same step with the input in hand. **Declining** leaves the step and re-enters it with nothing.

The declined submission now stays standing and the form reads it on the way back — the edit form takes the metric copy, the add form the one in display units — and it is consumed once, so it cannot leak into the next visit. What seeds the edit form is now `_edit_zone_seed`, which makes the decision testable instead of buried inside a step.

## The form read identifiers out loud

The error said *"required for estimated_flow delivery mode"* while the dropdown beside it said *"Simple on/off"*. The same choice, named twice, once in a language meant for the code.

An option that has a translated label is **by construction** an identifier — that is what the label is for. Twelve messages, labels and descriptions were naming one.

| before | after |
|---|---|
| Flow rate is required for estimated_flow delivery mode | The design flow rate is needed: the delivery mode you chose works the watering duration out from it. |
| Volume target entity (volume_preset only) | Volume target entity (volume dosing mode only) |
| Maximum time to wait for flow_meter or volume_preset delivery… | Maximum time to wait for a measured or self-dosed delivery… |

## An Italian label that was a paragraph

`translations/it.json` had the design flow rate's whole explanation pasted into its **label** slot: 493 characters where the form expects a name. During setup the field announced itself with a paragraph while every neighbour had two words. The edit form was unaffected, which is why nobody had seen it — the tester was editing, not creating.

## Tests

- `test_no_user_facing_string_names_an_internal_key` derives the forbidden vocabulary from the file itself rather than from a list that would go stale: anything with a label under `selector.*.options` is an identifier. It skips keys without an underscore, so `custom` can still appear as the word it is in "Pick Custom to enter your own".
- `test_a_label_is_a_name_not_a_paragraph` holds a label to being a name.
- Five tests on the decline path; four of them fail against the previous commit.

1639 tests pass, 1 skipped.

The same fixes go to `main` on #197, as every commit in this series has.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4