### PR TITLE
release: 0.12.0-beta.4

### DIFF
--- a/custom_components/never_dry/manifest.json
+++ b/custom_components/never_dry/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/never-dry/NeverDry/issues",
   "requirements": [],
-  "version": "0.12.0-beta.3"
+  "version": "0.12.0-beta.4"
 }


### PR DESCRIPTION
Version bump only. Fourth pre-release of the 0.12 line, cut because a tester met three faults on `beta.3` — all in the config flow, all found by using it rather than reading it.

- **Declining "save anyway" undid the edit** ([#204]). A zone with unusual values asks for confirmation; submitting without ticking the box sent you back to a form drawn from the **saved** zone, so a box you had just emptied came back full. The fix before this one covered a *refusal*, which redraws the same step with the input in hand — declining leaves the step and comes back with nothing, and that is a different path.
- **The form read identifiers out loud.** An error said *"required for estimated_flow delivery mode"* while the dropdown beside it said *"Simple on/off"*: the same choice, named twice, once in a language meant for the code. Twelve messages, labels and descriptions did it.
- **An Italian label that was a paragraph.** The design flow rate's whole explanation sat in its label slot, so during setup the field announced itself with 493 characters while every neighbour had a name. Editing was unaffected, which is why it had gone unseen.

## Worth exercising

- Clear the **design flow rate** on a metered zone and submit. The confirmation appears — submit it **without ticking the box**. The form must come back with the rate still empty, not refilled behind you.
- Do the same on an **estimated-flow** zone: a refusal, in a sentence, and the sentence must not contain the word `estimated_flow`.
- **Create** a zone from scratch in Italian and look at the design flow rate's label. Three words, not a paragraph.

Home Assistant caches translations, so restart after updating.

Pre-release: HACS offers it only to users who have enabled beta versions.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4