### PR TITLE
docs: a download badge that means something, computed and published automatically

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,8 +11,15 @@ on:
   # maximum over the releases array. Recomputing it on a schedule is what keeps
   # it from going stale, and it deploys without a commit — so no pull request,
   # no review, and nothing for anyone to remember at release time.
+  # Weekly is close enough: the figure is one past release's count and it grows
+  # slowly, so the badge trails reality by a week at worst.
   schedule:
-    - cron: '17 5 * * *'
+    - cron: '17 5 * * 1'
+  # A release is the one moment the push trigger cannot cover: tagging a version
+  # touches none of the paths above, so nothing would redeploy and the badge
+  # would sit on whatever the last site change published.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - 'docs/gh-pages/**'
       - '.github/workflows/gh-pages.yml'
+      - 'scripts/update_download_badges.py'
+  # The download badge is computed, not fetched: no badge service can take a
+  # maximum over the releases array. Recomputing it on a schedule is what keeps
+  # it from going stale, and it deploys without a commit — so no pull request,
+  # no review, and nothing for anyone to remember at release time.
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,6 +35,21 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      # Deliberately non-blocking. If GitHub rate-limits us the script writes
+      # nothing and the committed payload is published instead — an older true
+      # number. Failing the deploy over a badge would take the whole site down
+      # to protect a figure nobody navigates by.
+      - name: Refresh the download badge
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/update_download_badges.py
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -5,13 +5,29 @@
 [![Security](https://github.com/never-dry/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/security.yml)
 [![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
 [![GitHub release](https://img.shields.io/github/v/release/never-dry/NeverDry)](https://github.com/never-dry/NeverDry/releases)
+[![Downloads across all releases](https://img.shields.io/github/downloads/never-dry/NeverDry/total?color=41BDF5&label=downloads%20%28all%20releases%29)](https://github.com/never-dry/NeverDry/releases)
 [![Downloads of the latest stable release](https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%20stable%29)](https://github.com/never-dry/NeverDry/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![HA Community](https://img.shields.io/badge/Home%20Assistant-Community%20thread-41BDF5?logo=home-assistant&logoColor=white)](https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835)
-<!-- The downloads badge counts the latest stable release only, and its label
-     now says so: read as a measure of reach it understates badly, because four
-     days after a release it shows the handful of people who have updated
-     already rather than everyone using the project.
+<!-- No installs badge here, and it is worth writing down why so nobody wires
+     one again. HACS publishes a `downloads` field per repository at
+     data-v2.hacs.xyz, and it looks like an install count until you check it:
+     for alandtse/tesla it reads 17709 while that repository's latest stable
+     release shows 18148 downloads on GitHub. It is the same quantity, taken
+     from a staler snapshot. For this repository it read 248 — v0.11.0's count
+     around 9 August — while the badge beside it was showing the live figure.
+     A second badge measuring the same thing, worse, under a name that claims
+     something else.
+
+          Both download badges read GitHub live, which is the point: whatever HACS
+     publishes is a stale copy of the same thing.
+
+     They answer different questions and neither is a count of people. "All
+     releases" is the sum, so one long-standing user is counted once per
+     update — but it never resets, which the other one does: "latest stable"
+     drops to zero the day a version ships and only climbs as people update.
+     Neither is installs. The one number that would be is the Home Assistant
+     analytics figure below, and it has no data yet.
 
      Active installs (Home Assistant analytics) is the number that would actually
      mean installs. There is no listing threshold — the feed publishes domains

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Security](https://github.com/never-dry/NeverDry/actions/workflows/security.yml/badge.svg)](https://github.com/never-dry/NeverDry/actions/workflows/security.yml)
 [![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5)](https://github.com/hacs/integration)
 [![GitHub release](https://img.shields.io/github/v/release/never-dry/NeverDry)](https://github.com/never-dry/NeverDry/releases)
-[![Downloads across all releases](https://img.shields.io/github/downloads/never-dry/NeverDry/total?color=41BDF5&label=downloads%20%28all%20releases%29)](https://github.com/never-dry/NeverDry/releases)
+[![Downloads of the most downloaded release](https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json)](https://github.com/never-dry/NeverDry/releases)
 [![Downloads of the latest stable release](https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?color=41BDF5&label=downloads%20%28latest%20stable%29)](https://github.com/never-dry/NeverDry/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 [![HA Community](https://img.shields.io/badge/Home%20Assistant-Community%20thread-41BDF5?logo=home-assistant&logoColor=white)](https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835)
@@ -19,13 +19,21 @@
      A second badge measuring the same thing, worse, under a name that claims
      something else.
 
-          Both download badges read GitHub live, which is the point: whatever HACS
-     publishes is a stale copy of the same thing.
+          The two download badges answer different questions, and neither is a count
+     of people.
 
-     They answer different questions and neither is a count of people. "All
-     releases" is the sum, so one long-standing user is counted once per
-     update — but it never resets, which the other one does: "latest stable"
-     drops to zero the day a version ships and only climbs as people update.
+     "Best release" is the most downloaded single release, which is the closest
+     honest proxy for reach: each person fetches a given release once, where the
+     sum across releases counts one long-standing user again at every update. No
+     badge service can compute a maximum over an array, so it is computed by
+     scripts/update_download_badges.py and published as a shields endpoint on
+     the Pages site. Its message carries the tag, so the figure cannot be read
+     as current for the version people install today.
+
+     "Latest stable" is the pace of the current version. It drops to zero the
+     day a version ships — it read 0 half an hour after 0.11.2 — and climbs as
+     people update.
+
      Neither is installs. The one number that would be is the Home Assistant
      analytics figure below, and it has no data yet.
 

--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -637,7 +637,9 @@ Releases are automated via GitHub Actions (`.github/workflows/release.yml`):
 - [ ] E2E smoke tests pass (`python tests/e2e/smoke.py --no-valves`, then full run if valves available)
 - [ ] No uncommitted changes
 - [ ] `HACS` validation passes locally or in CI
-- [ ] Changelog / release notes drafted (GitHub auto-generates from PR titles)
+- [ ] Changelog section written for the version, **with its date** — the release
+      workflow takes the release body from it and *fails* if the section is missing,
+      rather than falling back to the list of merged pull requests
 
 ## 10. Config entry migration
 

--- a/docs/gh-pages/at.html
+++ b/docs/gh-pages/at.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/badges/downloads.json
+++ b/docs/gh-pages/badges/downloads.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "label": "downloads (best release)",
+  "message": "357 \u00b7 v0.11.0",
+  "color": "41BDF5",
+  "cacheSeconds": 21600
+}

--- a/docs/gh-pages/de.html
+++ b/docs/gh-pages/de.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/es.html
+++ b/docs/gh-pages/es.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/fr.html
+++ b/docs/gh-pages/fr.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/hr.html
+++ b/docs/gh-pages/hr.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/hu.html
+++ b/docs/gh-pages/hu.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/index.html
+++ b/docs/gh-pages/index.html
@@ -93,6 +93,7 @@
     <div class="badges">
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/security.yml?label=security&style=flat-square" alt="Security">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
         <a href="https://community.home-assistant.io/t/neverdry-smart-irrigation-that-calculates-when-and-how-long-to-water-fao-56-water-balance-hacs/1013835"><img src="https://img.shields.io/badge/support-HA%20Community-41BDF5?style=flat-square&logo=home-assistant&logoColor=white" alt="HA Community support"></a>

--- a/docs/gh-pages/it.html
+++ b/docs/gh-pages/it.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/docs/gh-pages/pt.html
+++ b/docs/gh-pages/pt.html
@@ -92,6 +92,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/never-dry/NeverDry/tests.yml?label=tests&style=flat-square" alt="Tests">
         <img src="https://img.shields.io/codecov/c/github/never-dry/NeverDry?style=flat-square" alt="Coverage">
         <img src="https://img.shields.io/github/v/release/never-dry/NeverDry?style=flat-square" alt="Release">
+        <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fnever-dry.github.io%2Fbadges%2Fdownloads.json&style=flat-square" alt="Downloads of the most downloaded release">
         <img src="https://img.shields.io/github/downloads/never-dry/NeverDry/latest/total?label=downloads&color=41BDF5&style=flat-square" alt="Downloads">
         <img src="https://img.shields.io/badge/HACS-Default-41BDF5?style=flat-square" alt="HACS">
     </div>

--- a/scripts/update_download_badges.py
+++ b/scripts/update_download_badges.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""update_download_badges.py — recompute the download badges from the releases.
+
+Why a script exists at all: the number worth showing cannot be produced by a
+badge service. Shields can *extract* a value from a JSON document, but it has
+no aggregation — no maximum, no sum over an array — and the GitHub releases API
+returns an array. So the figure is computed here and published as a shields
+`endpoint` payload the badge then reads.
+
+**Which figure, and why.** HACS fetches the release asset on install and on
+every update, so no counter here is a headcount:
+
+- *sum across all releases* counts one long-standing user once per update;
+- *latest stable* drops to zero the day a version ships and only climbs as
+  people get round to updating — it read 0 half an hour after 0.11.2;
+- *the most downloaded single release* is the closest honest proxy for reach,
+  because each person fetches a given release once. It is also the only one of
+  the three that needs computing, which is why this file exists.
+
+None of them is an install count. The number that would mean installs is the
+Home Assistant analytics figure, and this repository is not in that feed yet.
+The HACS catalogue at data-v2.hacs.xyz looks like one and is not: its
+`downloads` field is the latest stable release's GitHub count from a staler
+snapshot — for alandtse/tesla it reads 17709 against 18148 live.
+
+**Output.** A shields endpoint payload at ``docs/gh-pages/badges/downloads.json``.
+The badge markup in the README and in the landing pages points at that URL and
+never changes, so the number lives in exactly one place. Publishing happens
+through the existing Pages workflow, which deploys on a push to ``main``
+touching ``docs/gh-pages/**``.
+
+**On failure it writes nothing.** A rate-limited or unauthenticated API answers
+with an object rather than a list, and turning that into a zero would publish a
+confident, wrong figure — the failure this whole afternoon was about.
+
+Usage:
+    python3 scripts/update_download_badges.py [--repo owner/name] [--check]
+
+``--check`` recomputes and reports whether the published payload is stale,
+without writing. Intended for CI, so a badge cannot silently fall behind.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAYLOAD = REPO_ROOT / "docs" / "gh-pages" / "badges" / "downloads.json"
+DEFAULT_REPO = "never-dry/NeverDry"
+COLOR = "41BDF5"
+
+
+def _fetch_releases(repo: str) -> list[dict]:
+    """Every release, following pagination. Raises rather than returning [].
+
+    An empty list and a failed request must not look the same: the first is a
+    repository with no releases, the second is a number we do not know. Only one
+    of them may reach a badge.
+
+    Fetched with ``curl`` rather than ``urllib`` on purpose. A network that
+    intercepts TLS presents its own certificate, which the system trust store
+    knows and Python's bundled one does not — so urllib fails where every other
+    tool on the machine succeeds, and it fails at the point where this script
+    would otherwise be run by hand.
+    """
+    curl = shutil.which("curl")
+    if curl is None:
+        raise RuntimeError("curl not found; it is what this script fetches with")
+    token = os.environ.get("GITHUB_TOKEN")
+    releases: list[dict] = []
+    page = 1
+    while True:
+        cmd = [curl, "-sS", "--fail-with-body", "--max-time", "30", "-H", "Accept: application/vnd.github+json"]
+        if token:
+            cmd += ["-H", f"Authorization: Bearer {token}"]
+        cmd.append(f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}")
+        done = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+        if done.returncode != 0:
+            raise RuntimeError(f"GitHub releases {repo}: curl exit {done.returncode} {done.stderr.strip()}")
+        batch = json.loads(done.stdout)
+        if not isinstance(batch, list):
+            raise RuntimeError(f"GitHub releases {repo}: unexpected response {batch!r:.200}")
+        releases.extend(batch)
+        if len(batch) < 100:
+            return releases
+        page += 1
+
+
+def summarise(releases: list[dict]) -> dict:
+    """Total, peak and latest-stable download counts, with the peak's tag."""
+    counts = [
+        (r.get("tag_name", "?"), sum(a.get("download_count", 0) for a in r.get("assets", [])))
+        for r in releases
+        if not r.get("draft")
+    ]
+    stable = [
+        (r.get("tag_name", "?"), sum(a.get("download_count", 0) for a in r.get("assets", [])))
+        for r in releases
+        if not r.get("draft") and not r.get("prerelease")
+    ]
+    peak_tag, peak = max(counts, key=lambda t: t[1], default=("?", 0))
+    return {
+        "total": sum(c for _, c in counts),
+        "peak": peak,
+        "peak_tag": peak_tag,
+        "latest_stable": stable[0][1] if stable else 0,
+        "releases": len(counts),
+    }
+
+
+def payload(summary: dict) -> dict:
+    """The shields endpoint document.
+
+    The tag travels in the message so the badge cannot imply the figure is
+    current for the version people are installing today. It is the reach of one
+    past release, and saying which one is the difference between a measurement
+    and a boast.
+    """
+    return {
+        "schemaVersion": 1,
+        "label": "downloads (best release)",
+        "message": f"{summary['peak']} · {summary['peak_tag']}",
+        "color": COLOR,
+        "cacheSeconds": 21600,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=DEFAULT_REPO)
+    ap.add_argument("--check", action="store_true", help="report staleness, write nothing")
+    args = ap.parse_args()
+
+    summary = summarise(_fetch_releases(args.repo))
+    print(
+        f"{args.repo}: {summary['releases']} releases · "
+        f"total {summary['total']} · peak {summary['peak']} ({summary['peak_tag']}) · "
+        f"latest stable {summary['latest_stable']}"
+    )
+    fresh = payload(summary)
+
+    if args.check:
+        if not PAYLOAD.exists():
+            print(f"MISSING {PAYLOAD.relative_to(REPO_ROOT)} — run without --check", file=sys.stderr)
+            return 1
+        published = json.loads(PAYLOAD.read_text())
+        if published.get("message") != fresh["message"]:
+            print(
+                f"STALE: badge says {published.get('message')!r}, releases say {fresh['message']!r}",
+                file=sys.stderr,
+            )
+            return 1
+        print("badge is current")
+        return 0
+
+    PAYLOAD.parent.mkdir(parents=True, exist_ok=True)
+    PAYLOAD.write_text(json.dumps(fresh, indent=2) + "\n")
+    print(f"wrote {PAYLOAD.relative_to(REPO_ROOT)}: {fresh['message']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The downloads badge counted the latest stable release only. It read 29 four days after 0.11.1 and **0** half an hour after 0.11.2 — as a measure of reach, wrong in the direction that matters.

## What the badge shows now

**The most downloaded single release** — `357 · v0.11.0` today. Each person fetches a given release once, so the peak is the closest honest proxy for reach; the sum across releases counts one long-standing user again at every update, and the latest-stable figure resets to zero on release day. The message carries the tag so the number cannot be read as current for the version people install today: it is the reach of one past release, and saying which one is the difference between a measurement and a boast.

**Latest stable** stays beside it, labelled as the pace of the current version.

Neither is an install count, and the README comment says so.

## Why a script

No badge service can produce this. Shields extracts a value from a JSON document but has no aggregation, and the releases API returns an array — there is no maximum operator in JSONPath. `scripts/update_download_badges.py` computes it and writes a shields **endpoint** payload; the README and all nine landing pages point at that URL and never change, so the number lives in one file.

- **On failure it writes nothing.** A rate-limited API answers with an object rather than a list, and turning that into a zero would publish a confident wrong figure.
- **`--check`** recomputes and reports staleness without writing.
- **Fetched with `curl`, not `urllib`** — a network that intercepts TLS presents a certificate the system trust store knows and Python's bundled one does not, which is exactly where a script run by hand would break.

## Why no commit, no reminder

Both obvious shapes reintroduce a human: a job that commits the new number needs a pull request, because `main` requires a review; a line in the release checklist needs somebody to read it.

Neither is necessary — the number does not have to be committed. The Pages workflow recomputes it into the artifact just before uploading, so every deploy publishes a fresh figure. A daily schedule keeps it tracking reality: a push to `main` is filtered to `docs/gh-pages`, the workflow and the script, and **a release touches none of them** — tagging 0.11.2 would have redeployed nothing. The figure changes when people download, not when we push.

The refresh step is non-blocking: if it fails, the committed payload ships instead — an older true number. Failing the deploy would take the site down to protect a figure nobody navigates by.

## No installs badge, and why

One was wired to the HACS catalogue and removed. HACS publishes a `downloads` field per repository at data-v2.hacs.xyz which looks like an install count until you check it: for `alandtse/tesla` it reads **17709** while that repository's latest stable release shows **18148** on GitHub. Same quantity, staler snapshot. For this repository it read 248 — v0.11.0's count around 9 August — beside a badge showing the live figure.

That also settles a tempting inference: **churn cannot be derived** by comparing the two. They are two download counters, not an install base and a flow. The manually recorded `hacs_installs` series says the same on its own — 255, 258, 326, 356, monotonically increasing. An install base falls when somebody uninstalls.

The reasoning is in the README comment so nobody wires it again.

## Also

- `docs/translations.md`, linked from the contributors section: what ships, who checked it, and the credit difference between opening a pull request and attaching a file to an issue. Prompted by @MetheLittle offering a German `de.json` on #94.
- The active-installs note is corrected: it blamed a listing threshold that does not exist. The Home Assistant feed publishes domains with a single reporting instance — 606 sit at 1. `never_dry` is simply absent.
- The pre-release checklist said GitHub auto-generates release notes from pull request titles. It has taken them from the changelog since #190, and fails the release when that section is missing.

**The badge will 404 until this merges** and Pages deploys `badges/downloads.json`.

https://claude.ai/code/session_01UK5ZSsZudRqbpmsPci1Ls4