### PR TITLE
ci: sync develop with the action pins from #217

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           body_path: ${{ steps.notes.outputs.from_changelog == 'true' && 'release_notes.md' || '' }}
           generate_release_notes: ${{ steps.notes.outputs.from_changelog != 'true' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:python"


### PR DESCRIPTION
Brings `develop` in line with the action pins merged to `main` in #217.

Dependabot only targets `main`, so `develop` still carried the previous pins
(`action-gh-release` v3.0.2, `codeql-action` v4.37.8) and would have taken them into the next
release branch — where they would look like a deliberate downgrade rather than a branch that
was simply never synced.

Straight cherry-pick of 857970c with the original authorship kept. No other change.
