### PR TITLE
test: guard translation key parity across both GUIs

### DIFF
--- a/custom_components/never_dry/strings.json
+++ b/custom_components/never_dry/strings.json
@@ -144,9 +144,12 @@
         }
       },
       "model_params": {
-        "title": "ET Model Parameters",
-        "description": "Adjust the evapotranspiration model. Changes take effect immediately.",
+        "title": "System Sensors & ET Model",
+        "description": "Change the input sensors or adjust the evapotranspiration model. Changes take effect immediately.",
         "data": {
+          "temperature_sensor": "Temperature sensor",
+          "rain_sensor": "Rain sensor",
+          "rain_sensor_type": "Rain sensor type",
           "alpha": "ET coefficient (α) — simple method only",
           "t_base": "Base temperature — simple method only",
           "d_max": "Maximum deficit cap",

--- a/tests/test_card_i18n.py
+++ b/tests/test_card_i18n.py
@@ -1,0 +1,165 @@
+"""Consistency guards for the *other* GUI: the Lovelace card.
+
+NeverDry puts text in front of a person through two surfaces, and they do not share a
+mechanism:
+
+* the **backend GUI** — config flow, options flow, entity names — is served by Home
+  Assistant from ``translations/<lang>.json``, with English loaded first and the requested
+  language overlaid on top, so a missing key falls back to English (see
+  ``test_translation_consistency.py``);
+* the **cards** — ``never-dry-zone-card`` and ``never-dry-model-card``, both defined in
+  ``www/never-dry-zone-card.js`` — are JavaScript handed to the browser. They cannot read the
+  integration's translation files, so they share one pair of dictionaries, ``I18N`` and
+  ``VALVE_STATE_I18N``, read through ``t()`` and ``valveStateLabel()``. One dictionary for two
+  cards is why a language is added once and covers both: the ``model*`` and ``measured_*`` /
+  ``derived_*`` keys belong to the model card, the rest to the zone card.
+
+The card is the more fragile of the two. Its lookup ends
+``(I18N[lang] && I18N[lang][key]) || I18N.en[key] || key`` — on the **raw key**. Where the
+backend degrades to English, the card degrades to ``expDeepShade`` printed at the user.
+
+The card is also *mixed*: everything entity-backed (``friendly_name``,
+``formatEntityState``) comes down the backend chain and follows the user's language on its
+own, while the static text does not. The two halves can end up speaking different languages
+inside the same tile — which is exactly what a German ``de.json`` with an English-only card
+produces, and the reason the language check below is a gate rather than a warning.
+
+Everything here is read statically from the source. No JavaScript is executed.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry"
+_CARD = _COMPONENT / "www" / "never-dry-zone-card.js"
+_VALVE_FSM = _COMPONENT / "valve_fsm.py"
+_LANG_DOCS = sorted(_COMPONENT.glob("translations/*.json"))
+
+
+def _object_literal(src: str, name: str) -> str:
+    """Return the body of ``const <name> = { ... }`` by matching braces.
+
+    Quoted strings are skipped while counting, so a brace inside a label cannot end the
+    object early. A regex would have to choose between stopping at the first ``}`` (wrong,
+    the dictionaries are nested) and greedily running to the last one (wrong, it would
+    swallow the next declaration).
+    """
+    start = src.index(f"const {name} = {{") + len(f"const {name} = ")
+    depth, i, quote = 0, start, ""
+    while i < len(src):
+        ch = src[i]
+        if quote:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = ""
+        elif ch in "\"'`":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+    raise AssertionError(f"unbalanced braces while reading {name} from {_CARD.name}")
+
+
+def _dictionary(name: str) -> dict[str, set[str]]:
+    """``{language: {key, ...}}`` for one of the card's translation objects."""
+    body = _object_literal(_CARD.read_text(encoding="utf-8"), name)
+    out: dict[str, set[str]] = {}
+    for match in re.finditer(r"\n  (\w+): \{", body):
+        block = _object_literal("const x = " + body[match.end() - 1 :], "x")
+        out[match.group(1)] = set(re.findall(r"\n\s+(\w+):", block))
+    return out
+
+
+def _valve_states() -> set[str]:
+    """The values of the ``ValveState`` enum, read from ``valve_fsm.py`` without importing it."""
+    tree = ast.parse(_VALVE_FSM.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ValveState":
+            return {
+                stmt.value.value
+                for stmt in node.body
+                if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant)
+            }
+    raise AssertionError("ValveState not found in valve_fsm.py")
+
+
+def test_card_covers_every_shipped_language():
+    """A language shipped in ``translations/`` must also exist in the card.
+
+    This is the gate. Half a GUI in German and half in English is worse than no German at
+    all: the form speaks the user's language, the card underneath it does not, and there is
+    nothing in the product that explains why. Adding ``<lang>.json`` is therefore not a
+    self-contained contribution — it is a commitment across both surfaces, and this test is
+    where that gets said out loud instead of discovered by a user.
+    """
+    shipped = {path.stem for path in _LANG_DOCS}
+    assert shipped, "no translations/*.json found — this guard would pass vacuously"
+
+    problems = [
+        f"{name}: missing {sorted(shipped - set(_dictionary(name)))}"
+        for name in ("I18N", "VALVE_STATE_I18N")
+        if shipped - set(_dictionary(name))
+    ]
+    assert not problems, (
+        f"the card does not speak every language the integration ships ({sorted(shipped)}):\n  " + "\n  ".join(problems)
+    )
+
+
+def test_card_dictionaries_agree_across_languages():
+    """Within a dictionary, every language carries the same keys as English.
+
+    The card's fallback ends on the raw key, so a hole here is not degraded text — it is an
+    identifier printed in the interface.
+    """
+    problems: list[str] = []
+    for name in ("I18N", "VALVE_STATE_I18N"):
+        table = _dictionary(name)
+        english = table["en"]
+        for language, keys in sorted(table.items()):
+            if language == "en":
+                continue
+            for key in sorted(english - keys):
+                problems.append(f"{name}.{language}: missing '{key}' — the raw key is what renders")
+            for key in sorted(keys - english):
+                problems.append(f"{name}.{language}: '{key}' has no English counterpart")
+    assert not problems, "card dictionaries have drifted:\n  " + "\n  ".join(problems)
+
+
+def test_valve_state_labels_cover_the_state_machine():
+    """``VALVE_STATE_I18N`` must name every ``ValveState``, and no more.
+
+    The card renders whatever state the machine reports. A state added to ``valve_fsm.py``
+    without a label here reaches the user as its identifier — ``stuck_open`` in a tile that
+    otherwise reads in whole words. The reverse direction catches the label left behind
+    after a state is removed.
+    """
+    states = _valve_states()
+    labelled = _dictionary("VALVE_STATE_I18N")["en"]
+    assert not (states - labelled), f"ValveState members with no card label: {sorted(states - labelled)}"
+    assert not (labelled - states), f"card labels for states that no longer exist: {sorted(labelled - states)}"
+
+
+def test_statically_referenced_keys_exist():
+    """Keys reached through ``t(hass, "…")`` or ``i18n: "…"`` must exist in ``I18N.en``.
+
+    A **partial** guard, deliberately. Only the two directly greppable call shapes are
+    checked; other keys arrive through lookup tables (``deep_shade: ["expDeepShade", …]``)
+    that cannot be resolved without either running the file or accepting false positives.
+    So this is a ratchet on the common case, not proof that every key resolves — the
+    dictionary defines far more keys than are reachable from here.
+    """
+    src = _CARD.read_text(encoding="utf-8")
+    referenced = set(re.findall(r't\(hass,\s*"(\w+)"', src)) | set(re.findall(r'i18n:\s*"(\w+)"', src))
+    assert referenced, "no t()/i18n call sites found — the extractor has drifted from the card"
+
+    missing = sorted(referenced - _dictionary("I18N")["en"])
+    assert not missing, f"keys used by the card but absent from I18N.en: {missing}"

--- a/tests/test_translation_consistency.py
+++ b/tests/test_translation_consistency.py
@@ -25,6 +25,12 @@ from never_dry import const
 _COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry"
 _CONFIG_FLOW = _COMPONENT / "config_flow.py"
 _EN_JSON = _COMPONENT / "translations" / "en.json"
+_STRINGS = _COMPONENT / "strings.json"
+# The shipped languages are *discovered*, never listed. A hard-coded tuple is exactly how
+# a new translations/<lang>.json slips past every guard in this file on the day it lands:
+# the file is present, the tests are green, and nobody is looking at it.
+_LANG_DOCS = sorted(_COMPONENT.glob("translations/*.json"))
+_ALL_DOCS = [_STRINGS, *_LANG_DOCS]
 
 
 def _resolve_options(node: ast.AST, assignments: dict[str, ast.AST] | None = None) -> set[str] | None:
@@ -204,10 +210,6 @@ class TestResolveOptionsFromVariable:
 # ── Sectioned form fields: labels must be section-qualified ────────────────
 
 
-_STRINGS = _COMPONENT / "strings.json"
-_IT_JSON = _COMPONENT / "translations" / "it.json"
-
-
 def _section_membership() -> dict[str, set[str]]:
     """Map each ``section()`` key in ``config_flow.py`` to the fields it holds.
 
@@ -269,7 +271,7 @@ def test_sectioned_fields_are_labelled_under_their_section():
     assert membership, "no section() found in config_flow.py — this guard would pass vacuously"
 
     errors: list[str] = []
-    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+    for path in _ALL_DOCS:
         doc = json.loads(path.read_text())
         for scope in ("config", "options"):
             for step_id, step in doc.get(scope, {}).get("step", {}).items():
@@ -360,9 +362,6 @@ def test_every_select_options_argument_is_a_list():
 # the same helper started serving the options steps too (GH #196), every code it
 # can raise had to resolve in both — and nothing was checking.
 
-_STRINGS = _COMPONENT / "strings.json"
-_IT_JSON = _COMPONENT / "translations" / "it.json"
-
 
 def _raised_error_codes() -> set[str]:
     """Every error code ``config_flow.py`` can hand to a form."""
@@ -413,7 +412,7 @@ def test_every_raised_error_code_resolves_in_both_flows():
     assert codes, "no error codes found — the extractor has drifted from the source"
 
     missing: list[str] = []
-    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+    for path in _ALL_DOCS:
         data = json.loads(path.read_text())
         for root in ("config", "options"):
             declared = data.get(root, {}).get("error", {})
@@ -428,7 +427,7 @@ def test_the_two_flows_declare_the_same_error_catalogue():
     Divergence here is how a code ends up raisable somewhere it cannot be
     read, which is invisible until a user is standing in front of it.
     """
-    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+    for path in _ALL_DOCS:
         data = json.loads(path.read_text())
         config = set(data.get("config", {}).get("error", {}))
         options = set(data.get("options", {}).get("error", {}))
@@ -480,7 +479,7 @@ def _user_facing_strings(data: dict):
 
 def test_no_user_facing_string_names_an_internal_key():
     offenders: list[str] = []
-    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+    for path in _ALL_DOCS:
         data = json.loads(path.read_text())
         keys = _internal_option_keys(data)
         assert keys, f"{path.name}: no translated options found — the extractor has drifted"
@@ -501,9 +500,95 @@ def test_a_label_is_a_name_not_a_paragraph():
     field announced itself with a paragraph while every neighbour had a name.
     """
     offenders: list[str] = []
-    for path in (_STRINGS, _EN_JSON, _IT_JSON):
+    for path in _ALL_DOCS:
         data = json.loads(path.read_text())
         for where, text in _user_facing_strings(data):
             if ".data." in where and len(text) > 90:
                 offenders.append(f"{path.name}: {where} is {len(text)} characters")
     assert not offenders, "labels that are paragraphs:\n  " + "\n  ".join(offenders)
+
+
+# ── Every shipped language carries every key ──────────────────────────
+#
+# Home Assistant loads English first and then overlays the requested language with
+# ``component_cache.update(flat)`` (``homeassistant/helpers/translation.py``). ``update()``
+# replaces only the keys it carries, so a key missing from ``it.json`` does **not** print
+# raw — it prints the *English* text. The dialog still looks finished.
+#
+# That is what these two guard: not a broken form, a **half-translated one that nobody
+# reports** because nothing looks wrong. The raw key only ever surfaces when English is
+# missing it too, which is the case the sectioned-label guard above already covers.
+#
+# ``strings.json`` is the declared source of truth, and it is the file most at risk: Home
+# Assistant never reads it at runtime for a custom integration (``translation.py`` only ever
+# builds ``f"{language}.json"`` under ``translations/``), and the copy into
+# ``translations/en.json`` is manual because custom components have no build script. A file
+# nobody reads and no tool checks rots — and this one had, silently: three labels of
+# ``options.step.model_params`` absent and two of its strings left at the previous wording,
+# while the same step's ``en``/``it`` were current.
+
+
+def _leaf_paths(doc, prefix: str = "") -> dict[str, object]:
+    """Flatten a translation document into ``dotted.path -> leaf value``."""
+    flat: dict[str, object] = {}
+    if isinstance(doc, dict):
+        for key, value in doc.items():
+            flat.update(_leaf_paths(value, f"{prefix}.{key}" if prefix else key))
+    else:
+        flat[prefix] = doc
+    return flat
+
+
+def test_strings_json_and_en_json_are_the_same_document():
+    """The source of truth and the English shipped to users must not drift apart.
+
+    Keys **and** values. Nothing at runtime reconciles these two files, and no build step
+    generates one from the other, so the only thing that can keep ``strings.json`` honest
+    is this assertion. Without it the source quietly becomes a document describing a GUI
+    that no longer exists — which is the state it was found in.
+    """
+    source = _leaf_paths(json.loads(_STRINGS.read_text(encoding="utf-8")))
+    english = _leaf_paths(json.loads(_EN_JSON.read_text(encoding="utf-8")))
+
+    problems = [f"only in strings.json: {key}" for key in sorted(set(source) - set(english))]
+    problems += [f"only in en.json: {key}" for key in sorted(set(english) - set(source))]
+    problems += [
+        f"{key}: strings.json says {source[key]!r}, en.json says {english[key]!r}"
+        for key in sorted(set(source) & set(english))
+        if source[key] != english[key]
+    ]
+
+    assert not problems, "strings.json and translations/en.json have drifted:\n  " + "\n  ".join(problems)
+
+
+def test_every_language_matches_the_source_of_truth():
+    """Every ``translations/<lang>.json`` carries exactly the keys of ``strings.json``.
+
+    A missing key is English text served inside somebody else's language. A key in excess is
+    text written for a field that no longer exists — the residue of a rename, which is worth
+    catching because it is the half that a translator cannot see from their side.
+
+    Empty leaves are refused in the same pass: ``""`` satisfies key parity perfectly and
+    renders as nothing at all, so it is precisely how a half-finished translation would walk
+    through a key-set check.
+
+    Every deviation is collected and reported together, grouped by file: a translator has to
+    see the whole list at once, not discover it one failing run at a time.
+    """
+    assert _LANG_DOCS, "no translations/*.json found — this guard would pass vacuously"
+
+    expected = set(_leaf_paths(json.loads(_STRINGS.read_text(encoding="utf-8"))))
+    problems: list[str] = []
+
+    for path in _LANG_DOCS:
+        leaves = _leaf_paths(json.loads(path.read_text(encoding="utf-8")))
+        for key in sorted(expected - set(leaves)):
+            problems.append(f"{path.name}: missing {key} (the English text is served instead)")
+        for key in sorted(set(leaves) - expected):
+            problems.append(f"{path.name}: {key} is not in strings.json (stale after a rename?)")
+        for key in sorted(set(leaves) & expected):
+            value = leaves[key]
+            if not isinstance(value, str) or not value.strip():
+                problems.append(f"{path.name}: {key} is empty — it renders as nothing")
+
+    assert not problems, "translations out of step with strings.json:\n  " + "\n  ".join(problems)

--- a/tests/test_translation_decoupling.py
+++ b/tests/test_translation_decoupling.py
@@ -1,0 +1,44 @@
+"""The integration's Python must not read translation files. This keeps it that way.
+
+Localisation belongs to the two presentation surfaces and to nothing else: Home Assistant
+resolves ``translations/<lang>.json`` for the backend GUI, and the card carries its own
+dictionaries for the browser. Neither is the integration's business — the Python side deals
+in identifiers (``estimated_flow``, ``req_open``, error codes) and hands them out; the text
+is somebody else's problem, resolved later, in the user's language, in a layer that knows
+what language that is.
+
+That separation holds today. This test is not here to establish it — it is here so that the
+first module tempted to open a translation file to fish out a label has to argue with a
+failing test first. A guard that currently passes trivially is the cheapest moment to write
+it; the expensive moment is after something already depends on the coupling.
+
+``manifest.json`` is the one file production code legitimately reads (``__init__.py`` takes
+the version from it) and it is not a translation file, so it is out of scope by construction
+rather than by exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "never_dry"
+
+# Substrings that only appear when a module is reaching for translated text.
+_FORBIDDEN = ("strings.json", "translations/", "translations\\")
+
+
+def test_no_production_module_reads_translation_files():
+    offenders: list[str] = []
+    for module in sorted(_COMPONENT.rglob("*.py")):
+        if "__pycache__" in module.parts:
+            continue
+        source = module.read_text(encoding="utf-8")
+        for line_number, line in enumerate(source.splitlines(), start=1):
+            for needle in _FORBIDDEN:
+                if needle in line:
+                    offenders.append(f"{module.relative_to(_COMPONENT)}:{line_number} mentions '{needle}'")
+
+    assert not offenders, (
+        "production code must not read translation files — emit identifiers and let the "
+        "presentation layer resolve them:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Nothing checked that a translation file carried the same keys as English.

The guards in `test_translation_consistency.py` are targeted — selector options, sectioned
labels, error codes — and the three that also read Italian did so from a hard-coded tuple
`(_STRINGS, _EN_JSON, _IT_JSON)`. A new `translations/<lang>.json` would therefore have been
covered by no test at all, which is what made this worth doing now: #218 adds German.

**Why a missing key is not a visible failure.** Home Assistant loads English first and overlays
the requested language with `component_cache.update(flat)`, so a key absent from a language file
does not render raw — it renders the English text. The result is not a broken form, it is a
half-translated one that nobody reports because nothing looks wrong.

**The file that was actually out of parity was ours.** `strings.json` is the declared source of
truth, and `options.step.model_params` was missing the three sensor labels and still carried the
previous title and description, while `en` and `it` were current. Home Assistant never reads
`strings.json` at runtime for a custom integration and no build step generates `en.json` from it,
so nothing but CI can hold the two together.

**Two GUIs, two chains.** The forms are served from `translations/<lang>.json` and degrade to
English. The two cards — `never-dry-zone-card` and `never-dry-model-card`, sharing one dictionary
in `never-dry-zone-card.js` — are JavaScript in the browser, and their lookup ends on the raw key.
A `de.json` with an English-only card is a tile whose entity-backed half speaks German and whose
static half does not, which is why the card language check is a gate rather than a warning.

### Changes

- `strings.json`: align `options.step.model_params` with `en.json`
- discover `translations/*.json` by glob, so the five existing guards cover every language the
  day it lands instead of the day someone remembers to edit a tuple
- `strings.json` and `en.json` must be the same document — keys **and** values
- every language matches the source of truth; empty leaves refused, since `""` satisfies key
  parity and renders as nothing
- new `tests/test_card_i18n.py`: shipped-language gate, key agreement across languages,
  `VALVE_STATE_I18N` against the `ValveState` enum
- new `tests/test_translation_decoupling.py`: no production module reads a translation file —
  true today, kept true from here

### Verification

Full suite 1646 passed / 1 skipped, ruff clean. Each guard was checked against a deliberate
break — key removed from `it.json`, value altered in `strings.json`, key removed from `I18N.it`,
`STUCK_OPEN` added to `ValveState`, `de.json` added with no German card, a module made to read
`translations/` — six failures, six recoveries.

### Draft on purpose

Held until the German card strings are on the #218 branch. Merging this first would put a red
check on a contributor's PR for a file its author never touched, which is the outcome the whole
ordering was designed to avoid. Not a merge blocker on the code — a courtesy blocker.
