### PR TITLE
docs: make the valve compatibility table generated, not hand-written

### DIFF
--- a/docs/valve-compatibility.csv
+++ b/docs/valve-compatibility.csv
@@ -1,0 +1,4 @@
+vendor,model,firmware,datecode,via,valve_domain,flow_rate,volume_session,volume_aggregate,history,needs_config,caveat,lod,reported_by,issue,date
+SONOFF,SWV,1.0.4,20240820,Z2M 2.13,switch,m3/h,yes,daily,no,none,,,maintainer,,2026-06-01
+SONOFF,SWV-ZFE,1.0.7,20260317,Z2M 2.13,switch,no,yes,hourly,on_request,history,,,maintainer,,2026-07-01
+SONOFF,SWV-ZFE,1.1.0,20260724,Z2M 2.13,switch,no,yes,hourly,on_request,history,unit_change,,maintainer,,2026-08-01

--- a/docs/valve-compatibility.md
+++ b/docs/valve-compatibility.md
@@ -45,14 +45,18 @@ dosing below.
 
 ## Verified valves
 
-| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | History | Needs YAML? | LoD | By |
-|---|---|---|---|---|---|---|---|---|---|
-| SONOFF **SWV** | 1.0.4 (20240820) | Z2M 2.13 | `switch.*` | ✅ m³/h | ✅ session + daily | ❌ | ❌ none | — | maintainer |
-| SONOFF **SWV-ZFE** | 1.0.7 (20260317) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | ⚠️ for history | — | maintainer |
-| SONOFF **SWV-ZFE** | 1.1.0 (20260724) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | ⚠️ for history | — | maintainer |
+<!-- BEGIN GENERATED TABLE: edit valve-compatibility.csv, then run tools/build_valve_table.py -->
+| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | History | Needs config? | Verdict | Why | LoD | By |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| SONOFF **SWV** | 1.0.4 (20240820) | Z2M 2.13 | `switch.*` | m3/h | ✅ session + daily | ❌ | ❌ none | **good** | flow rate in m3/h, session counter | - | maintainer |
+| SONOFF **SWV-ZFE** | 1.0.7 (20260317) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | history | **good** | session counter | - | maintainer |
+| SONOFF **SWV-ZFE** | 1.1.0 (20260724) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | history | **partial** | session counter, but the firmware can change its own counter units | - | maintainer |
+
+**Verdict**, derived from the columns, never typed: *good* = delivery measurement available with no extra setup · *partial* = delivery measurement available, but with a documented caveat or extra step · *timer-only* = no delivery measurement, so NeverDry runs it on a clock
+<!-- END GENERATED TABLE -->
 
 ✅ works out of the box · ⚠️ reachable, with a documented step · ❌ not available ·
-— not measured yet
+- not measured yet
 
 **Read this table with two things in mind.** It is indexed by **firmware, not model**:
 the two SWV-ZFE rows are the same product and differ, which is the whole reason the

--- a/tests/test_valve_compatibility_table.py
+++ b/tests/test_valve_compatibility_table.py
@@ -1,0 +1,97 @@
+"""The compatibility table in the docs must be what the CSV says it is.
+
+``docs/valve-compatibility.csv`` holds the facts a reporter established; the table in
+``docs/valve-compatibility.md`` is rendered from it by ``tools/build_valve_table.py``, and
+the verdict column is derived rather than typed.
+
+Without this test the arrangement is decoration: someone edits the markdown by hand because
+it is right there, the CSV stays behind, and the page a person uses to choose what to buy
+stops matching the data the project actually holds. It is the same failure this repository
+just found between ``strings.json`` and ``en.json``: two documents, no reconciliation, and
+the same remedy.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_CSV = _ROOT / "docs" / "valve-compatibility.csv"
+_MD = _ROOT / "docs" / "valve-compatibility.md"
+
+
+def _builder():
+    """Import ``tools/build_valve_table.py`` without making ``tools`` a package."""
+    spec = importlib.util.spec_from_file_location("build_valve_table", _ROOT / "tools" / "build_valve_table.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_rendered_table_matches_the_csv():
+    assert _builder().main.__module__  # import guard: a broken generator fails here, not silently
+    module = _builder()
+    doc = _MD.read_text(encoding="utf-8")
+    assert module._BEGIN in doc and module._END in doc, "generated-table markers missing from the document"
+
+    current = doc.split(module._BEGIN, 1)[1].split(module._END, 1)[0].strip()
+    assert current == module.render().strip(), (
+        "docs/valve-compatibility.md is out of step with valve-compatibility.csv: "
+        "edit the CSV and run tools/build_valve_table.py, do not edit the table by hand"
+    )
+
+
+def test_every_row_declares_the_columns_the_verdict_rule_reads():
+    """A row missing a field would take a verdict from a default nobody chose."""
+    required = {
+        "vendor",
+        "model",
+        "firmware",
+        "via",
+        "valve_domain",
+        "flow_rate",
+        "volume_session",
+        "volume_aggregate",
+        "history",
+        "needs_config",
+        "caveat",
+        "reported_by",
+    }
+    rows = list(csv.DictReader(_CSV.open(encoding="utf-8")))
+    assert rows, "the compatibility CSV is empty"
+
+    problems: list[str] = []
+    for index, row in enumerate(rows, start=2):
+        missing = required - set(row)
+        if missing:
+            problems.append(f"line {index}: columns absent: {sorted(missing)}")
+        for field in ("vendor", "model", "firmware", "via", "valve_domain", "reported_by"):
+            if not (row.get(field) or "").strip():
+                problems.append(f"line {index}: '{field}' is empty, and it is not optional")
+        if row.get("valve_domain") not in ("switch", "valve"):
+            problems.append(f"line {index}: valve_domain '{row.get('valve_domain')}' is neither switch nor valve")
+    assert not problems, "malformed rows in valve-compatibility.csv:\n  " + "\n  ".join(problems)
+
+
+def test_a_row_with_no_measurement_is_timer_only_not_bad():
+    """The bottom tier says what NeverDry does with the device, not that it is poor.
+
+    An on/off valve is driven on a clock, which is a supported mode. A table that called it
+    "bad" would be telling someone not to buy hardware that works.
+    """
+    module = _builder()
+    barebones = {
+        "flow_rate": "no",
+        "volume_session": "no",
+        "volume_aggregate": "",
+        "history": "no",
+        "needs_config": "none",
+        "caveat": "",
+    }
+    tier, reason = module._verdict(barebones)
+    assert tier == "timer-only"
+    assert "clock" in reason or "delivered" in reason

--- a/tools/build_valve_table.py
+++ b/tools/build_valve_table.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Render the compatibility table in ``docs/valve-compatibility.md`` from the CSV.
+
+``docs/valve-compatibility.csv`` holds **facts only**: what the device exposes, how it
+is reached, who established the row. The verdict is *derived* here, every time, from
+those facts.
+
+That split is the whole point. A hand-written verdict beside hand-written columns is two
+sources of truth with nobody reconciling them: the day a firmware row gains a counter and
+the verdict stays where it was, the table starts lying and no test notices. Deriving it
+means the two cannot disagree, and it means the rule is written down (below) instead of
+living in whoever filled the row.
+
+Run with ``--check`` to verify the document matches the CSV without rewriting it; that is
+what the test does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+_DOCS = Path(__file__).resolve().parent.parent / "docs"
+_CSV = _DOCS / "valve-compatibility.csv"
+_MD = _DOCS / "valve-compatibility.md"
+
+_BEGIN = "<!-- BEGIN GENERATED TABLE: edit valve-compatibility.csv, then run tools/build_valve_table.py -->"
+_END = "<!-- END GENERATED TABLE -->"
+
+# ── The verdict rule ──────────────────────────────────────────────────────
+#
+# The tier answers one question: **how well does this device serve flow-meter mode?**
+# Timer mode needs nothing but a valve entity, so every listed device can do it, which is
+# why the bottom tier is "timer-only" and not "bad". A valve that opens and closes reliably
+# and reports nothing is not a bad valve; it is a valve NeverDry drives on a clock, which is
+# a supported mode, not a degraded one. Calling it "bad" would misinform the person reading
+# the table to decide what to buy.
+_TIERS = {
+    "good": "delivery measurement available with no extra setup",
+    "partial": "delivery measurement available, but with a documented caveat or extra step",
+    "timer-only": "no delivery measurement, so NeverDry runs it on a clock",
+}
+
+
+def _verdict(row: dict[str, str]) -> tuple[str, str]:
+    """Return ``(tier, reason)`` for one CSV row."""
+    has_flow = row["flow_rate"] not in ("", "no")
+    has_session = row["volume_session"] == "yes"
+    has_aggregate = row["volume_aggregate"] not in ("", "no")
+
+    if not (has_flow or has_session or has_aggregate):
+        return "timer-only", "on/off only, and nothing reports what was delivered"
+
+    evidence = []
+    if has_flow:
+        evidence.append(f"flow rate in {row['flow_rate']}")
+    if has_session:
+        evidence.append("session counter")
+    if has_aggregate and not has_session:
+        evidence.append(f"{row['volume_aggregate']} counter only")
+
+    # A caveat that touches the delivery measurement is not a footnote: it is the difference
+    # between a number you can trust and one you cannot. It costs the row its top tier.
+    if row["caveat"] == "unit_change":
+        return "partial", f"{', '.join(evidence)}, but the firmware can change its own counter units"
+    if not has_session and has_aggregate:
+        return "partial", f"{', '.join(evidence)}, subject to the calendar-reset caveat"
+    if row["needs_config"] not in ("", "none") and row["needs_config"] != "history":
+        return "partial", f"{', '.join(evidence)}, reachable only after a documented step"
+    return "good", ", ".join(evidence)
+
+
+_MARK = {"yes": "✅", "no": "❌", "": "-", "on_request": "⚠️ on request", "none": "❌ none"}
+
+
+def _cell(value: str) -> str:
+    return _MARK.get(value, value)
+
+
+def render() -> str:
+    rows = list(csv.DictReader(_CSV.open(encoding="utf-8")))
+    out = [
+        "| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | History | "
+        "Needs config? | Verdict | Why | LoD | By |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        tier, reason = _verdict(row)
+        counters = []
+        if row["volume_session"] == "yes":
+            counters.append("session")
+        if row["volume_aggregate"] not in ("", "no"):
+            counters.append(row["volume_aggregate"])
+        datecode = f" ({row['datecode']})" if row["datecode"] else ""
+        out.append(
+            f"| {row['vendor']} **{row['model']}** "
+            f"| {row['firmware']}{datecode} "
+            f"| {row['via']} | `{row['valve_domain']}.*` "
+            f"| {_cell(row['flow_rate'])} "
+            f"| {'✅ ' + ' + '.join(counters) if counters else '❌'} "
+            f"| {_cell(row['history'])} | {_cell(row['needs_config'])} "
+            f"| **{tier}** | {reason} | {_cell(row['lod'])} | {row['reported_by']} |"
+        )
+    legend = " · ".join(f"*{k}* = {v}" for k, v in _TIERS.items())
+    out += ["", "**Verdict**, derived from the columns, never typed: " + legend]
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="verify without writing")
+    args = parser.parse_args()
+
+    doc = _MD.read_text(encoding="utf-8")
+    if _BEGIN not in doc or _END not in doc:
+        print(f"markers not found in {_MD.name}", file=sys.stderr)
+        return 2
+    head, rest = doc.split(_BEGIN, 1)
+    _, tail = rest.split(_END, 1)
+    rebuilt = f"{head}{_BEGIN}\n{render()}\n{_END}{tail}"
+
+    if args.check:
+        if rebuilt != doc:
+            print(f"{_MD.name} is out of step with {_CSV.name}: run tools/build_valve_table.py", file=sys.stderr)
+            return 1
+        return 0
+    _MD.write_text(rebuilt, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The compatibility table in `docs/valve-compatibility.md` was maintained by hand: ten columns, three rows, all SONOFF, all established from a single installation. It is the page people read before spending money on an irrigation valve, and nothing kept it honest.

### What changes

`docs/valve-compatibility.csv` becomes the source and holds facts only: what the device exposes, how it is reached, who established the row. `tools/build_valve_table.py` renders the table between markers in the document, and `--check` verifies without writing.

The verdict column is derived from those facts on every render, never typed. A hand-written verdict beside hand-written columns is two sources of truth with nobody reconciling them: the day a firmware row gains a counter and the verdict stays where it was, the page starts lying and no test notices. This repository has just seen the same failure between `strings.json` and `en.json`, and this is the same remedy.

### On the wording of the bottom tier

It is `timer-only`, not `bad`. A valve that opens and closes reliably and reports nothing is not a poor valve, it is one NeverDry drives on a clock, which is a supported mode rather than a degraded one. Calling it bad would tell a reader to avoid hardware that works. The three tiers are `good`, `partial`, `timer-only`.

### Verification

`tests/test_valve_compatibility_table.py` asserts the document matches the CSV, validates the row schema, and pins the timer-only rule so it cannot be quietly renamed. Checked against a deliberate break: editing the rendered table by hand fails the test.

### Why now

Groundwork for #223, the open call for valve reports. Every comment that arrives there becomes a row in the CSV, and the table regenerates instead of being retyped.
