### PR TITLE
The meter observes the zone, it does not judge it

### DIFF
--- a/custom_components/never_dry/config_flow.py
+++ b/custom_components/never_dry/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 
 from . import zone_device_identifier
@@ -631,6 +632,74 @@ def _unusual_zone_values(zone: dict, imperial: bool) -> list[str]:
     return warnings
 
 
+def _device_resolver(hass):
+    """Return ``entity_id -> device_id`` as the entity registry answers it.
+
+    Degrades to "cannot say" rather than raising: a registry hiccup must not
+    turn into an accusation about the user's configuration.
+    """
+
+    def resolve(entity_id):
+        if not entity_id:
+            return None
+        try:
+            entry = er.async_get(hass).async_get(entity_id)
+        except Exception:  # pragma: no cover - registry unavailable
+            return None
+        return entry.device_id if entry else None
+
+    return resolve
+
+
+def meter_ownership_warnings(zone, other_zones, device_of) -> list[str]:
+    """Report a flow meter that does not belong to this zone, and a mode without one.
+
+    ``device_of`` maps an entity id to its device id (the entity registry's
+    answer), or ``None`` when it cannot say.
+
+    Only one ownership case is reported: the meter belongs to the valve of
+    *another configured zone*. A meter on a device of its own is left alone,
+    because an in-line meter on the pipe is a legitimate installation and
+    NeverDry consumes whatever entity the user points at rather than dictating
+    the plumbing. Warning on every separate device would train the user to
+    ignore the warning that matters.
+
+    Warnings, never rejections: a valid setup we failed to imagine must not be
+    made impossible to configure.
+    """
+    warnings: list[str] = []
+    meter = zone.get(CONF_ZONE_FLOW_METER_SENSOR)
+    mode = zone.get(CONF_ZONE_DELIVERY_MODE, DEFAULT_DELIVERY_MODE)
+
+    if not meter:
+        if mode == DELIVERY_MODE_FLOW_METER:
+            warnings.append(
+                "delivery mode is 'Valve with flow meter sensor' but no flow meter is set:"
+                " the mode doses by measured volume, so the measuring entity is not optional"
+            )
+        return warnings
+
+    meter_device = device_of(meter)
+    if meter_device is None:
+        # A registry that cannot answer is not evidence of a wrong meter.
+        return warnings
+    if meter_device == device_of(zone.get(CONF_ZONE_VALVE)):
+        return warnings
+
+    for other in other_zones:
+        if other.get(CONF_ZONE_NAME) == zone.get(CONF_ZONE_NAME):
+            continue
+        if device_of(other.get(CONF_ZONE_VALVE)) == meter_device:
+            warnings.append(
+                f"the selected flow meter belongs to the valve of zone"
+                f" '{other.get(CONF_ZONE_NAME)}': it reports that zone's water, not this one's."
+                f" While that zone is idle this meter stays still, and a still meter here"
+                f" means no verified flow and a session that cannot be measured"
+            )
+            break
+    return warnings
+
+
 def _confirm_zone_schema() -> vol.Schema:
     """Checkbox form for the unusual-values confirmation step."""
     return vol.Schema({vol.Required("confirm", default=False): bool})
@@ -888,8 +957,10 @@ class NeverDryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors.update(zone_errors)
             else:
                 zone_metric = _zone_input_to_metric(user_input, imperial)
-                self._pending_warnings = _unusual_zone_values(zone_metric, imperial) + _ignored_override_warnings(
-                    zone_metric
+                self._pending_warnings = (
+                    _unusual_zone_values(zone_metric, imperial)
+                    + _ignored_override_warnings(zone_metric)
+                    + meter_ownership_warnings(zone_metric, self._zones, _device_resolver(self.hass))
                 )
                 if self._pending_warnings:
                     self._pending_zone = zone_metric
@@ -1088,7 +1159,15 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
                     data_schema=_zone_schema_initial(imperial, submitted),
                     errors=errors,
                 )
-            self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(user_input)
+            self._pending_warnings = (
+                _unusual_zone_values(user_input, imperial)
+                + _ignored_override_warnings(user_input)
+                + meter_ownership_warnings(
+                    user_input,
+                    self._config_entry.data.get(CONF_ZONES, []),
+                    _device_resolver(self.hass),
+                )
+            )
             if self._pending_warnings:
                 self._pending_zone = user_input
                 self._pending_form = submitted
@@ -1154,8 +1233,14 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
             user_input = _zone_input_to_metric(user_input, imperial)
             errors = _zone_errors(user_input)
             if not errors:
-                self._pending_warnings = _unusual_zone_values(user_input, imperial) + _ignored_override_warnings(
-                    user_input
+                self._pending_warnings = (
+                    _unusual_zone_values(user_input, imperial)
+                    + _ignored_override_warnings(user_input)
+                    + meter_ownership_warnings(
+                        user_input,
+                        self._config_entry.data.get(CONF_ZONES, []),
+                        _device_resolver(self.hass),
+                    )
                 )
                 if self._pending_warnings:
                     self._pending_zone = user_input
@@ -1488,6 +1573,9 @@ class NeverDryOptionsFlow(config_entries.OptionsFlow):
         findings = []
         for z in zones:
             findings.extend(f"- {z[CONF_ZONE_NAME]}: {w}" for w in _unusual_zone_values(z, imperial))
+            findings.extend(
+                f"- {z[CONF_ZONE_NAME]}: {w}" for w in meter_ownership_warnings(z, zones, _device_resolver(self.hass))
+            )
         return self.async_show_form(
             step_id="check_zones",
             data_schema=vol.Schema({}),

--- a/custom_components/never_dry/controller.py
+++ b/custom_components/never_dry/controller.py
@@ -1337,6 +1337,7 @@ class IrrigationController:
             return await self._deliver_estimated_flow(zone)
 
         if not await self._open_valve(zone.valve):
+            self._credit_when_the_meter_speaks(zone, meter_entity, initial_reading)
             return 0.0
         zone.set_irrigating(True)
         zone.async_write_ha_state()
@@ -1437,6 +1438,50 @@ class IrrigationController:
         if driver is None or baseline is None or not hasattr(driver, "schedule_flow_sample"):
             return
         driver.schedule_flow_sample(meter_entity, baseline, session_s)
+
+    def _credit_when_the_meter_speaks(self, zone, meter_entity: str, baseline: float | None) -> None:
+        """Credit water that ran during an opening we refused, once measurable.
+
+        A verification decides whether we may trust the meter's account of a
+        session. It cannot decide whether the water happened. When the guard
+        closed a healthy valve in the field the session ended in error and the
+        litres that had already run were credited to nobody, so the deficit
+        stood and the zone was watered again the next day: the model wrong in
+        the direction that floods.
+
+        What is credited is what the meter finally reports, never an estimate.
+        That is what makes this safe on the case the guard exists for: if the
+        pipe really was dry, or the valve never opened at all, the counter has
+        not moved and nothing is credited. No need to tell the two kinds of
+        refusal apart -- the meter does it.
+
+        Deferred because the answer does not exist yet. The delivery owes its
+        figure to the caller now, and the meter's closing tick lands on the
+        device's own schedule, so the reading waits for the cadence measured on
+        that meter.
+        """
+        driver = self._driver_for(zone)
+        if driver is None or baseline is None or not hasattr(driver, "async_settled_volume"):
+            return
+        self._hass.async_create_task(self._credit_settled_volume(zone, driver, meter_entity, baseline))
+
+    async def _credit_settled_volume(self, zone, driver, meter_entity: str, baseline: float) -> None:
+        """Await the settled reading and put it against the zone's deficit.
+
+        Only the deficit: the session did fail, so nothing here stamps it as an
+        irrigation. The session counters stay with the paths that completed one.
+        """
+        volume = await driver.async_settled_volume(meter_entity, baseline)
+        if volume is None:
+            return
+        deficit = zone.credit_delivery(volume)
+        zone.async_write_ha_state()
+        _LOGGER.info(
+            "Zone '%s': the opening was refused, but the meter later reported %.1fL. Credited: deficit now %.2fmm",
+            zone.zone_name,
+            volume,
+            deficit,
+        )
 
     async def _deliver_flow_rate(
         self,

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -52,6 +52,11 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
 )
 
+try:  # HA 2024.4+ reports every publication, changed value or not.
+    from homeassistant.helpers.event import async_track_state_report_event
+except ImportError:  # pragma: no cover - below the supported floor
+    async_track_state_report_event = None
+
 from . import flow_utils
 from .const import (
     DEFAULT_DELIVERY_TIMEOUT_S,
@@ -103,6 +108,15 @@ METER_KIND_TOLERANCE: float = 3.0
 #: wait costs nothing but a pending background task, and a meter reporting
 #: hourly is past the point where a session-flow sample is worth keeping one.
 SETTLE_DELAY_MAX_S: float = 600.0
+
+#: How long after the last sight of an open valve the meter is still being
+#: timed, and equally the longest gap that counts as a cadence at all.
+#: Deliberately the same number as the settle ceiling above, for the same
+#: reason: a cadence longer than the longest wait we would ever act on is a
+#: cadence there is no use in having measured. It is generous where the settle
+#: delay is careful because the two do different things -- observing costs
+#: nothing and cannot misfire, while waiting delays a sample.
+METER_WATCH_AFTER_CLOSE_S: float = SETTLE_DELAY_MAX_S
 
 #: There is deliberately no constant for "cadence not yet known". Two of them
 #: existed before (10 s, then 90 s) and both closed healthy valves: the second
@@ -389,8 +403,17 @@ class Driver(abc.ABC):
 
         self._unsub_switch = async_track_state_change_event(hass, [entity_id], self._on_switch_state)
         self._unsub_flow = None
+        #: Publications that carry no change of value. A counter reporting on a
+        #: clock repeats itself between two litres, and that repetition is the
+        #: only evidence of its cadence available without running water --
+        #: which is what a zone whose valve will not open can still offer.
+        self._unsub_flow_report = None
         if flow_sensor_entity_id:
             self._unsub_flow = async_track_state_change_event(hass, [flow_sensor_entity_id], self._on_flow_state)
+            if async_track_state_report_event is not None:
+                self._unsub_flow_report = async_track_state_report_event(
+                    hass, [flow_sensor_entity_id], self._on_flow_report
+                )
         self._unsub_liveness = None
 
     # ── Identity ────────────────────────────────────────────────────────
@@ -519,6 +542,8 @@ class Driver(abc.ABC):
             self._unsub_switch()
         if self._unsub_flow:
             self._unsub_flow()
+        if self._unsub_flow_report:
+            self._unsub_flow_report()
         if self._unsub_liveness:
             self._unsub_liveness()
             self._unsub_liveness = None
@@ -1067,6 +1092,17 @@ class Driver(abc.ABC):
         """HA callback: schedule the async flow-state handler."""
         self._hass.async_create_task(self._handle_flow_state(event))
 
+    @callback
+    def _on_flow_report(self, event) -> None:
+        """HA callback: the meter published without changing value.
+
+        Deliberately does **not** reach the state machine. A republication is
+        not an observation of flow: feeding it in as OBS_FLOW_ZERO would let a
+        chatty device argue that a running zone is dry. It times the meter and
+        nothing else.
+        """
+        self._note_meter_publication()
+
     async def _handle_switch_state(self, event) -> None:
         """Map an actuator state change to the matching FSM observation."""
         new_state = event.data.get("new_state")
@@ -1115,6 +1151,9 @@ class Driver(abc.ABC):
         new_state = event.data.get("new_state")
         if new_state is None:
             return
+        # Timed before the value is even parsed: a publication is a publication
+        # whether or not we can make sense of what it carries.
+        self._note_meter_publication()
         try:
             value = float(new_state.state)
         except (ValueError, TypeError):
@@ -1134,6 +1173,13 @@ class Driver(abc.ABC):
         if moving:
             self._note_meter_movement()
         await self._dispatch(ValveEvent.OBS_FLOW_POSITIVE if moving else ValveEvent.OBS_FLOW_ZERO)
+
+    def _note_meter_publication(self) -> None:  # noqa: B027
+        """Hook: the counter just published, changed value or not.
+
+        Same reason as :meth:`_note_meter_movement` for living here as a no-op:
+        only a zone keeps a tracker to remember it in.
+        """
 
     def _note_meter_movement(self) -> None:  # noqa: B027
         """Hook: the counter just advanced.
@@ -1202,6 +1248,12 @@ class ZoneDriver(Driver):
         self._auto_open_grace_s = auto_open_grace_s
         self._session_flow = SessionFlowTracker(hass, entity_id)
         self._device_entities: tuple[str, ...] | None = None
+        #: Publication timing state. Kept apart from the movement timing above
+        #: because the two answer different questions and accept different
+        #: evidence: this one counts repetitions and runs on past the close.
+        self._last_publication_at: float | None = None
+        self._last_publication_counted: bool = False
+        self._last_seen_open_at: float | None = None
         hass.async_create_task(self._session_flow.async_load())
 
     @property
@@ -1297,6 +1349,43 @@ class ZoneDriver(Driver):
         if self._session_flow.observe_refresh_interval(now - previous):
             self._hass.async_create_task(self._session_flow.async_save())
 
+    def _note_meter_publication(self) -> None:
+        """Time the gap between two publications of the counter.
+
+        Where :meth:`_note_meter_movement` waits for the counter to *advance*
+        and only while the valve is open, this counts every time the device
+        speaks, and keeps listening past the close. Both departures are needed
+        for the case that motivated this: a meter on a five-minute clock, dosed
+        for under three minutes, advances at most once per session and delivers
+        its closing word after the valve is already shut. Under the older rule
+        it could never be measured at all, and the zone was told its cadence
+        was unknown forever.
+
+        Two conditions decide whether a gap is a cadence rather than a calendar
+        entry, and both endpoints must satisfy them:
+
+        * the valve was open, or has been open within
+          ``METER_WATCH_AFTER_CLOSE_S``, so the meter was under observation;
+        * the gap itself fits in that same window, because between two
+          irrigations a counter simply stands still, and the day-long silence
+          that produces describes the schedule, not the device.
+        """
+        now = monotonic()
+        watched = self.is_open or (
+            self._last_seen_open_at is not None and now - self._last_seen_open_at <= METER_WATCH_AFTER_CLOSE_S
+        )
+        previous, self._last_publication_at = self._last_publication_at, now
+        counted, self._last_publication_counted = self._last_publication_counted, watched
+        if self.is_open:
+            self._last_seen_open_at = now
+        if not watched or not counted or previous is None:
+            return
+        interval = now - previous
+        if interval > METER_WATCH_AFTER_CLOSE_S:
+            return
+        if self._session_flow.observe_publication_interval(interval):
+            self._hass.async_create_task(self._session_flow.async_save())
+
     def record_meter_resolution(self, step: float) -> None:
         """Register a counter increment observed outside a delivery (a test)."""
         if self._session_flow.observe_step(step):
@@ -1334,6 +1423,27 @@ class ZoneDriver(Driver):
         return self._session_flow.refresh_samples
 
     @property
+    def meter_publication_median_s(self) -> float | None:
+        """Typical gap between two publications of the counter.
+
+        This is the figure the card shows, and the honest answer to "how often
+        does my meter report". The worst case below is what the machinery uses;
+        showing that one and calling it the cadence is what made a meter look
+        slower than it is.
+        """
+        return self._session_flow.publication_median_s
+
+    @property
+    def meter_publication_peak_s(self) -> float | None:
+        """Worst gap in the window. Diagnostics, not screen."""
+        return self._session_flow.publication_peak_s
+
+    @property
+    def meter_publication_samples(self) -> int:
+        """How many intervals the median rests on."""
+        return self._session_flow.publication_samples
+
+    @property
     def settle_delay_s(self) -> float:
         """How long to wait after closing before reading the meter's final word.
 
@@ -1344,9 +1454,17 @@ class ZoneDriver(Driver):
 
         Never shorter than the historical constant, which suits a prompt meter,
         and capped so a slow one cannot leave a task pending indefinitely. The
-        wait runs in a background task, so it never delays the session itself.
+        wait runs in a background task, so it never delays the session itself:
+        on a slow meter the sample simply lands minutes after the session was
+        reported complete.
+
+        Built on the *typical* gap between publications, falling back to the
+        worst gap between advances where that is all there is. The constant was
+        what lost the field case this fixes: a meter on a five-minute clock
+        spoke 39 s after the close, and the fixed 30 s wait had already given
+        up, so a healthy session taught the zone nothing.
         """
-        cadence = self._session_flow.refresh_cadence_s
+        cadence = self._session_flow.publication_median_s or self._session_flow.refresh_cadence_s
         if cadence is None:
             return SETTLE_DELAY_S
         return min(max(SETTLE_DELAY_S, cadence * FLOW_VERIFY_MARGIN), SETTLE_DELAY_MAX_S)
@@ -1361,7 +1479,7 @@ class ZoneDriver(Driver):
         not water arriving. The distinction is what decides whether the meter
         can guard an opening at all, and it is invisible in any single reading.
         """
-        cadence = self._session_flow.refresh_cadence_s
+        cadence = self._session_flow.publication_median_s or self._session_flow.refresh_cadence_s
         expected = self.time_to_first_tick_s()
         if cadence is None or expected is None or expected <= 0:
             return None

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -65,7 +65,7 @@ from .const import (
     DELIVERY_MODE_VOLUME_PRESET,
     FLOW_METER_POLL_INTERVAL_S,
 )
-from .session_flow import MIN_SESSION_S, SETTLE_DELAY_S, SessionFlowTracker
+from .session_flow import MIN_SESSION_S, SessionFlowTracker
 from .valve_fsm import (
     CancelAllTimers,
     CancelTimer,
@@ -415,6 +415,11 @@ class Driver(abc.ABC):
                     hass, [flow_sensor_entity_id], self._on_flow_report
                 )
         self._unsub_liveness = None
+        #: Raised every time the meter publishes. The post-close reading waits
+        #: on this rather than on a computed delay: the notification already
+        #: arrives, and sleeping a guessed number of seconds beside a callback
+        #: that is about to fire is how a healthy session was thrown away.
+        self._meter_spoke = asyncio.Event()
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -1174,12 +1179,15 @@ class Driver(abc.ABC):
             self._note_meter_movement()
         await self._dispatch(ValveEvent.OBS_FLOW_POSITIVE if moving else ValveEvent.OBS_FLOW_ZERO)
 
-    def _note_meter_publication(self) -> None:  # noqa: B027
-        """Hook: the counter just published, changed value or not.
+    def _note_meter_publication(self) -> None:
+        """The counter just published, changed value or not.
 
-        Same reason as :meth:`_note_meter_movement` for living here as a no-op:
-        only a zone keeps a tracker to remember it in.
+        Waking the settle reading belongs here rather than in the zone: any
+        actuator with a meter can be waited on, and what a zone adds on top is
+        only the remembering. Subclasses that time the cadence override this
+        and call up first.
         """
+        self._meter_spoke.set()
 
     def _note_meter_movement(self) -> None:  # noqa: B027
         """Hook: the counter just advanced.
@@ -1370,6 +1378,7 @@ class ZoneDriver(Driver):
           irrigations a counter simply stands still, and the day-long silence
           that produces describes the schedule, not the device.
         """
+        super()._note_meter_publication()
         now = monotonic()
         watched = self.is_open or (
             self._last_seen_open_at is not None and now - self._last_seen_open_at <= METER_WATCH_AFTER_CLOSE_S
@@ -1442,32 +1451,6 @@ class ZoneDriver(Driver):
     def meter_publication_samples(self) -> int:
         """How many intervals the median rests on."""
         return self._session_flow.publication_samples
-
-    @property
-    def settle_delay_s(self) -> float:
-        """How long to wait after closing before reading the meter's final word.
-
-        The last tick of a session routinely lands after the valve is shut, and
-        by how much is the meter's business, not ours: on the field meter it
-        arrived three and a half minutes later, so the fixed 30 s missed it and
-        the session flow was computed from a truncated volume.
-
-        Never shorter than the historical constant, which suits a prompt meter,
-        and capped so a slow one cannot leave a task pending indefinitely. The
-        wait runs in a background task, so it never delays the session itself:
-        on a slow meter the sample simply lands minutes after the session was
-        reported complete.
-
-        Built on the *typical* gap between publications, falling back to the
-        worst gap between advances where that is all there is. The constant was
-        what lost the field case this fixes: a meter on a five-minute clock
-        spoke 39 s after the close, and the fixed 30 s wait had already given
-        up, so a healthy session taught the zone nothing.
-        """
-        cadence = self._session_flow.publication_median_s or self._session_flow.refresh_cadence_s
-        if cadence is None:
-            return SETTLE_DELAY_S
-        return min(max(SETTLE_DELAY_S, cadence * FLOW_VERIFY_MARGIN), SETTLE_DELAY_MAX_S)
 
     @property
     def meter_refresh_kind(self) -> str | None:
@@ -1691,9 +1674,9 @@ class ZoneDriver(Driver):
         is the only one holding the baseline and the elapsed time. Reaching into
         a private method for this was the wrong seam.
 
-        Deferred rather than awaited: the caller owes its result to the zone now,
-        and ``SETTLE_DELAY_S`` of waiting would show up as a session that takes
-        half a minute longer to finish than it did.
+        Deferred rather than awaited: the caller owes its result to the zone
+        now, and the reading waits for the meter's closing publication, which
+        on a slow counter lands minutes later.
         """
         if session_s < MIN_SESSION_S:
             return
@@ -1707,8 +1690,9 @@ class ZoneDriver(Driver):
         a half minutes later. Reading at the close returns a truncated figure,
         so the wait is the meter's own cadence rather than a constant.
 
-        ``None`` means the question has no answer: an unreadable meter, or a
-        counter that did not advance. A difference that is zero or negative is
+        ``None`` means the question has no answer: an unreadable meter, a
+        counter that did not advance, or a zone that started watering again
+        while we were still waiting. A difference that is zero or negative is
         not a small volume, it is a reset or a stall, and a guess is worse than
         a gap.
 
@@ -1717,12 +1701,51 @@ class ZoneDriver(Driver):
         ran during an opening we refused -- and only the driver knows how long
         its own meter takes to speak.
         """
-        await asyncio.sleep(self.settle_delay_s)
+        spoke = await self._wait_for_the_meter_to_speak()
+        if self.is_open:
+            # A new session began while we waited. Whatever the counter shows
+            # now belongs partly to it, and half of two sessions is not a
+            # measurement of either.
+            return None
         final = flow_utils.read_volume_liters(self._hass, meter)
         if final is None:
             return None
         volume = final - baseline
-        return volume if volume > 0 else None
+        if volume <= 0:
+            return None
+        if not spoke:
+            _LOGGER.debug(
+                "Driver '%s' read the meter without a closing publication; the figure may be short by one counter step",
+                self._name,
+            )
+        return volume
+
+    async def _wait_for_the_meter_to_speak(self) -> bool:
+        """Block until the meter publishes, or the ceiling runs out.
+
+        The wait used to be a computed number of seconds, derived from the
+        meter's measured cadence, and that was one indirection too many. The
+        publication is already an event this driver subscribes to; sleeping a
+        guessed interval next to a callback that is about to fire meant the
+        answer arrived and found nobody waiting for it. In the field it missed
+        by 9 s on one zone and by 172 s on another, and on a meter whose
+        cadence had never been measured -- which is every meter, at first --
+        the guess could not improve, because measuring the cadence needs the
+        very sessions the guess was discarding.
+
+        Waiting for the event needs no cadence at all. The ceiling is only a
+        backstop against a meter that has already said everything it intends
+        to: reading anyway is right, since a cumulative counter that went quiet
+        is simply a counter with nothing to add.
+
+        Returns whether a publication actually arrived, for the log.
+        """
+        self._meter_spoke.clear()
+        try:
+            await asyncio.wait_for(self._meter_spoke.wait(), timeout=SETTLE_DELAY_MAX_S)
+        except TimeoutError:
+            return False
+        return True
 
     async def _record_flow_sample(self, meter: str, baseline: float, session_s: float) -> None:
         """Read the settled meter and record what the session's flow really was."""

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -1581,16 +1581,35 @@ class ZoneDriver(Driver):
             return
         self._hass.async_create_task(self._record_flow_sample(meter, baseline, session_s))
 
-    async def _record_flow_sample(self, meter: str, baseline: float, session_s: float) -> None:
-        """Read the settled meter and record what the session's flow really was."""
+    async def async_settled_volume(self, meter: str, baseline: float) -> float | None:
+        """What the meter finally reports for a session, once it has spoken.
+
+        The last tick routinely lands after the valve is shut, and how long
+        after is the device's business: on the field meter it arrived three and
+        a half minutes later. Reading at the close returns a truncated figure,
+        so the wait is the meter's own cadence rather than a constant.
+
+        ``None`` means the question has no answer: an unreadable meter, or a
+        counter that did not advance. A difference that is zero or negative is
+        not a small volume, it is a reset or a stall, and a guess is worse than
+        a gap.
+
+        Public because two callers need the same settled reading for different
+        reasons -- learning the zone's real flow rate, and crediting water that
+        ran during an opening we refused -- and only the driver knows how long
+        its own meter takes to speak.
+        """
         await asyncio.sleep(self.settle_delay_s)
         final = flow_utils.read_volume_liters(self._hass, meter)
         if final is None:
-            return
+            return None
         volume = final - baseline
-        if volume <= 0:
-            # Either nothing was measured or the counter reset mid-session; both
-            # make the difference meaningless, and a guess is worse than a gap.
+        return volume if volume > 0 else None
+
+    async def _record_flow_sample(self, meter: str, baseline: float, session_s: float) -> None:
+        """Read the settled meter and record what the session's flow really was."""
+        volume = await self.async_settled_volume(meter, baseline)
+        if volume is None:
             return
         lpm = volume / (session_s / 60.0)
         self._session_flow.window.record(lpm)

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -94,6 +94,11 @@ FLOW_VERIFY_MIN_S: float = 10.0
 #: Past this, the window stops being a guard: "commanded but dry" would take
 #: too long to notice, so verification is declared inapplicable instead.
 FLOW_VERIFY_MAX_S: float = 180.0
+#: How far past ``resolution / rate`` a cadence may sit and still count as
+#: "publishes per volume". Generous: the point is to separate a meter that
+#: tracks water from one that answers to a clock, and the field gap was 11x.
+METER_KIND_TOLERANCE: float = 3.0
+
 #: There is deliberately no constant for "cadence not yet known". Two of them
 #: existed before (10 s, then 90 s) and both closed healthy valves: the second
 #: was the first made generous, which changed how long the guard waited and not
@@ -1312,6 +1317,45 @@ class ZoneDriver(Driver):
         if not resolution or rate <= 0:
             return None
         return resolution / rate * 60.0
+
+    @property
+    def meter_refresh_cadence_s(self) -> float | None:
+        """Longest observed gap between two publications of the counter."""
+        return self._session_flow.refresh_cadence_s
+
+    @property
+    def meter_refresh_samples(self) -> int:
+        """How many gaps that cadence was measured from."""
+        return self._session_flow.refresh_samples
+
+    @property
+    def meter_refresh_kind(self) -> str | None:
+        """``"volume"``, ``"periodic"``, or ``None`` while undecidable.
+
+        Compares what the meter does against what its step would imply: a
+        counter publishing per litre delivered reports at about
+        ``resolution / rate``, so a cadence far beyond that is a clock talking,
+        not water arriving. The distinction is what decides whether the meter
+        can guard an opening at all, and it is invisible in any single reading.
+        """
+        cadence = self._session_flow.refresh_cadence_s
+        expected = self.time_to_first_tick_s()
+        if cadence is None or expected is None or expected <= 0:
+            return None
+        return "volume" if cadence <= expected * METER_KIND_TOLERANCE else "periodic"
+
+    @property
+    def meter_guard_usable(self) -> bool:
+        """Whether this zone's flow verification can actually run.
+
+        Deliberately "does it" and not "could it": in ESTIMATED_FLOW nothing
+        guards however prompt the meter, because the user declared that the
+        duration is the dose.
+        """
+        if not self.flow_guard_armed:
+            return False
+        _, verdict = self.flow_verify_window()
+        return verdict is None
 
     def flow_verify_window(self) -> tuple[float, str | None]:
         """How long to wait for the first sign of flow, and why if it is hopeless.

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -99,6 +99,11 @@ FLOW_VERIFY_MAX_S: float = 180.0
 #: tracks water from one that answers to a clock, and the field gap was 11x.
 METER_KIND_TOLERANCE: float = 3.0
 
+#: Ceiling on how long the post-close reading may wait for a late tick. The
+#: wait costs nothing but a pending background task, and a meter reporting
+#: hourly is past the point where a session-flow sample is worth keeping one.
+SETTLE_DELAY_MAX_S: float = 600.0
+
 #: There is deliberately no constant for "cadence not yet known". Two of them
 #: existed before (10 s, then 90 s) and both closed healthy valves: the second
 #: was the first made generous, which changed how long the guard waited and not
@@ -1329,6 +1334,24 @@ class ZoneDriver(Driver):
         return self._session_flow.refresh_samples
 
     @property
+    def settle_delay_s(self) -> float:
+        """How long to wait after closing before reading the meter's final word.
+
+        The last tick of a session routinely lands after the valve is shut, and
+        by how much is the meter's business, not ours: on the field meter it
+        arrived three and a half minutes later, so the fixed 30 s missed it and
+        the session flow was computed from a truncated volume.
+
+        Never shorter than the historical constant, which suits a prompt meter,
+        and capped so a slow one cannot leave a task pending indefinitely. The
+        wait runs in a background task, so it never delays the session itself.
+        """
+        cadence = self._session_flow.refresh_cadence_s
+        if cadence is None:
+            return SETTLE_DELAY_S
+        return min(max(SETTLE_DELAY_S, cadence * FLOW_VERIFY_MARGIN), SETTLE_DELAY_MAX_S)
+
+    @property
     def meter_refresh_kind(self) -> str | None:
         """``"volume"``, ``"periodic"``, or ``None`` while undecidable.
 
@@ -1560,7 +1583,7 @@ class ZoneDriver(Driver):
 
     async def _record_flow_sample(self, meter: str, baseline: float, session_s: float) -> None:
         """Read the settled meter and record what the session's flow really was."""
-        await asyncio.sleep(SETTLE_DELAY_S)
+        await asyncio.sleep(self.settle_delay_s)
         final = flow_utils.read_volume_liters(self._hass, meter)
         if final is None:
             return

--- a/custom_components/never_dry/driver.py
+++ b/custom_components/never_dry/driver.py
@@ -94,9 +94,11 @@ FLOW_VERIFY_MIN_S: float = 10.0
 #: Past this, the window stops being a guard: "commanded but dry" would take
 #: too long to notice, so verification is declared inapplicable instead.
 FLOW_VERIFY_MAX_S: float = 180.0
-#: Used until a delivery or a test reveals the meter's step. Deliberately more
-#: generous than the old 10 s constant, which is what failed in the field.
-FLOW_VERIFY_UNKNOWN_RESOLUTION_S: float = 90.0
+#: There is deliberately no constant for "cadence not yet known". Two of them
+#: existed before (10 s, then 90 s) and both closed healthy valves: the second
+#: was the first made generous, which changed how long the guard waited and not
+#: whether it had the standing to judge. Without a measured cadence the check
+#: declares itself inapplicable instead.
 
 # ``volume_preset``: how long to wait for a smart valve to auto-open on a
 # ``number.set_value`` dose before we send an explicit open (idempotent).
@@ -298,6 +300,7 @@ class Driver(abc.ABC):
         entity_id: str,
         *,
         flow_sensor_entity_id: str | None = None,
+        flow_guard: bool | None = None,
         name: str = "",
         fsm_config: FsmConfig | None = None,
         max_retries: int = 5,
@@ -321,8 +324,14 @@ class Driver(abc.ABC):
         # One command owns 1 + max_retries attempts, so the retry budget can
         # never trip MAINTENANCE mid-command — a fully-failed command reaches
         # it exactly at its definitive failure.
+        # Having a meter and being judged by it are two different things.
+        # Conflating them meant a zone that declared "I measure nothing" could
+        # still have its valve closed by a silent counter, which made the
+        # simple-valve and metered-valve declarations behave identically on
+        # opening. ``flow_guard`` is the second question; the subscription to
+        # the sensor below is the first, and stays on either way.
         self._fsm_config = fsm_config or FsmConfig(
-            has_flow_meter=flow_sensor_entity_id is not None,
+            has_flow_meter=(flow_guard if flow_guard is not None else flow_sensor_entity_id is not None),
             max_consecutive_failures=max_retries + 1,
         )
         self._fsm = ValveFsm(self._fsm_config)
@@ -337,6 +346,10 @@ class Driver(abc.ABC):
             hass, flow_sensor_entity_id
         )
         self._last_flow_level: float | None = None
+        #: When the counter last advanced, to time the gap to the next advance.
+        #: Cleared on every opening: an interval that spans two irrigations
+        #: measures the schedule, not the meter.
+        self._last_meter_move_at: float | None = None
         self._notifier = notifier
         # Static float or zero-arg callable re-evaluated at every open, so the
         # watchdog and hardware timer track the current deficit, not a snapshot.
@@ -450,6 +463,7 @@ class Driver(abc.ABC):
         terminals: tuple[ValveState, ...] = (
             (ValveState.OPEN_VERIFIED,) if self._fsm_config.has_flow_meter else (ValveState.OPEN,)
         )
+        self._last_meter_move_at = None
         return await self._run_command(cmd=ValveEvent.CMD_OPEN, terminals=terminals)
 
     async def async_turn_off(self) -> OperationResult:
@@ -981,6 +995,14 @@ class Driver(abc.ABC):
                 return
         self._timers[name] = self._hass.async_create_task(self._timer(name, seconds))
 
+    @property
+    def flow_guard_armed(self) -> bool:
+        """Whether a still meter may refuse this valve's opening.
+
+        Distinct from owning a meter: see the note in :meth:`__init__`.
+        """
+        return self._fsm_config.has_flow_meter
+
     def flow_verify_window(self) -> tuple[float, str | None]:
         """Seconds to wait for the first sign of flow, and why if it is hopeless.
 
@@ -1099,7 +1121,18 @@ class Driver(abc.ABC):
                 return
             moving = value > previous
 
+        if moving:
+            self._note_meter_movement()
         await self._dispatch(ValveEvent.OBS_FLOW_POSITIVE if moving else ValveEvent.OBS_FLOW_ZERO)
+
+    def _note_meter_movement(self) -> None:  # noqa: B027
+        """Hook: the counter just advanced.
+
+        Deliberately not abstract. Learning a meter's cadence is a zone concern
+        because only :class:`ZoneDriver` owns a ``SessionFlowTracker`` to keep
+        it in; the master valve has nothing to learn here and must not be
+        forced to say so.
+        """
 
 
 # ── Zone actuator (the model's ``ZoneDriver``) ─────────────────────────────
@@ -1145,8 +1178,13 @@ class ZoneDriver(Driver):
         it once, before opening: the deficit shrinks as water arrives, so a
         bound recomputed mid-session follows the session it should bound.
         """
+        mode = DeliveryMode(delivery_mode)
+        # The user's declaration decides who answers for the water: in
+        # ESTIMATED_FLOW the duration is the dose and the rate is the user's
+        # figure, so the meter refines that figure and nothing more.
+        base_kwargs.setdefault("flow_guard", mode is not DeliveryMode.ESTIMATED_FLOW and flow_meter_sensor is not None)
         super().__init__(hass, entity_id, flow_sensor_entity_id=flow_meter_sensor, **base_kwargs)
-        self._delivery_mode = DeliveryMode(delivery_mode)
+        self._delivery_mode = mode
         self._flow_rate_lpm = flow_rate_lpm
         self._volume_entity = volume_entity
         self._flow_meter_sensor = flow_meter_sensor
@@ -1232,6 +1270,23 @@ class ZoneDriver(Driver):
             _LOGGER.debug("Could not resolve the device of '%s'", self._entity_id, exc_info=True)
             return (self._entity_id,)
 
+    def _note_meter_movement(self) -> None:
+        """Time the gap between two advances of the counter, while watering.
+
+        Measured only with the valve open, because between two irrigations the
+        counter stands still for hours and that gap describes the schedule, not
+        the meter. The first advance after an opening yields no interval: we do
+        not know when the previous one would have landed.
+        """
+        if not self.is_open:
+            return
+        now = monotonic()
+        previous, self._last_meter_move_at = self._last_meter_move_at, now
+        if previous is None:
+            return
+        if self._session_flow.observe_refresh_interval(now - previous):
+            self._hass.async_create_task(self._session_flow.async_save())
+
     def record_meter_resolution(self, step: float) -> None:
         """Register a counter increment observed outside a delivery (a test)."""
         if self._session_flow.observe_step(step):
@@ -1245,9 +1300,12 @@ class ZoneDriver(Driver):
     def time_to_first_tick_s(self) -> float | None:
         """Seconds before the meter *can* move: resolution ÷ flow rate.
 
-        The quantity behind both the verification window and the shortest test
-        worth running. It needs no measurement of its own — the design rate is
-        always present, so a zone can answer this before it has ever run.
+        Diagnostics and test sizing only. This **no longer sizes the
+        verification window**: it answers "how much water must pass before the
+        counter could register anything", which is a lower bound on a meter
+        that publishes per litre and says nothing at all about one that
+        publishes on a clock. The window comes from the observed cadence, see
+        :meth:`flow_verify_window`.
         """
         resolution = self._session_flow.resolution_l
         rate = self.effective_flow_lpm
@@ -1258,33 +1316,40 @@ class ZoneDriver(Driver):
     def flow_verify_window(self) -> tuple[float, str | None]:
         """How long to wait for the first sign of flow, and why if it is hopeless.
 
-        A fixed window cannot work, because the time before a counter *can*
-        move is a property of the installation: resolution over flow rate. At
-        1 L and 1.2 L/min that is 50 s, and the constant was 10 — the check
-        could not pass however healthy the valve was (GH #173).
+        The threshold belongs to the device, not to us. What bounds how long a
+        healthy meter may stay silent is its **reporting cadence**, and that is
+        a property of the firmware: some meters publish once per litre
+        delivered, others on a fixed clock regardless of flow.
 
-        Making the window merely generous is not the fix either. A long window
-        means "valve commanded, no water arriving" takes minutes to notice, and
-        that detection is a safety layer. So the window is derived, and when the
-        derivation exceeds what is still useful as a guard, the verification is
-        declared inapplicable instead of being stretched: on a meter stepping in
-        28 L units, no window both passes on a healthy valve and catches a dead
-        one, and pretending otherwise only produces false failures.
+        The earlier derivation, ``resolution / flow rate``, assumes the first
+        kind. Against the second it predicts a first tick that cannot arrive:
+        on a SONOFF SWV-ZFE reporting every 300 s it produced windows of 20 to
+        160 s, so the guard closed a healthy valve in 7 openings out of 10 and
+        the log recorded it as ``ACTUATION_FAILED`` -- a device fault, for a
+        window we had chosen badly (field case 2026-09-08).
+
+        So: no cadence, no threshold, no guard. Declaring the check
+        inapplicable is the honest verdict when the quantity that defines it
+        has not been measured yet, and it is safer in the only direction that
+        matters, since closing a working valve is a failure the guard itself
+        causes.
         """
-        expected = self.time_to_first_tick_s()
-        if expected is None:
-            # Resolution unknown (no delivery or test has revealed a step yet).
-            # Be conservative rather than strict: the constant is what caused the
-            # field failures, and a false ACTUATION_FAILED closes a working zone.
-            return FLOW_VERIFY_UNKNOWN_RESOLUTION_S, None
-        window = expected * FLOW_VERIFY_MARGIN
+        cadence = self._session_flow.refresh_cadence_s
+        if cadence is None:
+            return (
+                FLOW_VERIFY_MAX_S,
+                "flow verification not applicable: this meter's reporting cadence "
+                "has not been measured yet, so no window can tell a dry pipe from a "
+                "counter that has simply not spoken. Proceeding; flow remains an "
+                "observer, not a gate",
+            )
+        window = cadence * FLOW_VERIFY_MARGIN
         if window > FLOW_VERIFY_MAX_S:
             return (
                 FLOW_VERIFY_MAX_S,
-                f"flow verification not applicable — the meter needs about {expected:.0f}s "
-                f"to register its first {self._session_flow.resolution_l:g} L step at "
-                f"{self.effective_flow_lpm:.2f} L/min, longer than any useful guard. "
-                f"Proceeding; flow remains an observer, not a gate",
+                f"flow verification not applicable: this meter reports about every "
+                f"{cadence:.0f}s, longer than any useful guard. Proceeding; flow "
+                f"remains an observer, not a gate",
             )
         return max(window, FLOW_VERIFY_MIN_S), None
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -2616,6 +2616,14 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
         self._zone.mark_irrigated(
             source=source, at=datetime.now(), credited_liters=delivered_liters, duration_s=duration_s
         )
+        # The same channel ``settle_cycle`` uses, and for the same reason. This
+        # is the branch a *successful* delivery takes, so leaving it silent meant
+        # the figures that change at the close were refreshed on every partial
+        # run and on no complete one -- the case that happens every day. On the
+        # field install the expected duration stood at 80 s, the value written
+        # while the deficit was still owed, for as long as it took the next tick
+        # to arrive (pino, 2026-09-10).
+        self.notify_session_listeners()
 
     @property
     def volume_liters(self) -> float:

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -2807,9 +2807,19 @@ class ZoneDeficitSensor(SensorEntity):
         if device_info:
             self._attr_device_info = device_info
         zone_sensor._dryness.register_zone_listener(self._on_update)
+        # And on session close, not only on the periodic broadcast. The deficit
+        # is settled the moment a run ends, and waiting for the next tick left
+        # the figure showing the debt the irrigation had just paid off -- which
+        # is exactly the minute somebody looks (field, pino 2026-09-10: 0.34 mm
+        # on screen, 0.00 in the model, for the three minutes after the close).
+        zone_sensor.register_session_listener(self._on_session_update)
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
+
+    def _on_session_update(self) -> None:
         if getattr(self, "hass", None):
             self.async_write_ha_state()
 
@@ -2919,9 +2929,16 @@ class ZoneSessionWaterSensor(SensorEntity):
         if device_info:
             self._attr_device_info = device_info
         zone_sensor._dryness.register_zone_listener(self._on_update)
+        # A running total has to stop running the moment the run does, or the
+        # zero written at the close is not seen until the next hourly tick.
+        zone_sensor.register_session_listener(self._on_session_update)
 
     def _on_update(self, dt_h: float, et_h: float, rain: float) -> None:
         """Update when the dryness sensor broadcasts."""
+        if getattr(self, "hass", None):
+            self.async_write_ha_state()
+
+    def _on_session_update(self) -> None:
         if getattr(self, "hass", None):
             self.async_write_ha_state()
 

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -2712,6 +2712,19 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
             if warnings:
                 attrs["warnings"] = warnings
 
+        operator = getattr(self, "_operator", None)
+        if operator is not None and getattr(operator, "meter_refresh_samples", None) is not None:
+            # What the meter's silence is worth. A counter reporting every 300 s
+            # cannot supervise a 359 s session, and that is visible here and
+            # nowhere else: no single reading shows a cadence. Absent rather
+            # than zero while unmeasured, since a zero would read as "instant".
+            attrs["meter_refresh_samples"] = operator.meter_refresh_samples
+            attrs["meter_guard_usable"] = operator.meter_guard_usable
+            if (cadence := operator.meter_refresh_cadence_s) is not None:
+                attrs["meter_refresh_s"] = round(cadence)
+            if (kind := operator.meter_refresh_kind) is not None:
+                attrs["meter_refresh_kind"] = kind
+
         if self._last_valve_test:
             # Prefixed and flat: the card and the report block read these, and a
             # nested dict in an attribute is awkward for both.

--- a/custom_components/never_dry/sensor.py
+++ b/custom_components/never_dry/sensor.py
@@ -121,6 +121,7 @@ from .const import (
 from .controller import IrrigationController
 from .environment import DEFAULT_LATITUDE, Environment, RainSensorType
 from .services import async_setup_services
+from .session_flow import MIN_PUBLICATION_SAMPLES
 from .unit_convert import LITERS_TO_GALLONS, LPM_TO_GPH, LPM_TO_LPH
 from .valve_fsm import FailureKind, ValveState
 from .water_balance_model import (
@@ -2713,15 +2714,23 @@ class IrrigationZoneSensor(SensorEntity, RestoreEntity):
                 attrs["warnings"] = warnings
 
         operator = getattr(self, "_operator", None)
-        if operator is not None and getattr(operator, "meter_refresh_samples", None) is not None:
+        if operator is not None and getattr(operator, "meter_publication_samples", None) is not None:
             # What the meter's silence is worth. A counter reporting every 300 s
             # cannot supervise a 359 s session, and that is visible here and
             # nowhere else: no single reading shows a cadence. Absent rather
             # than zero while unmeasured, since a zero would read as "instant".
-            attrs["meter_refresh_samples"] = operator.meter_refresh_samples
             attrs["meter_guard_usable"] = operator.meter_guard_usable
-            if (cadence := operator.meter_refresh_cadence_s) is not None:
-                attrs["meter_refresh_s"] = round(cadence)
+            # What the card shows is the typical gap between publications, and
+            # the count of intervals behind it, so "measured" is visibly
+            # different from "seen once". The worst case rides along for
+            # diagnostics: it is what sizes the post-close wait, and reading a
+            # long wait against a short cadence is otherwise puzzling.
+            attrs["meter_refresh_samples"] = operator.meter_publication_samples
+            attrs["meter_refresh_min_samples"] = MIN_PUBLICATION_SAMPLES
+            if (median := operator.meter_publication_median_s) is not None:
+                attrs["meter_refresh_s"] = round(median)
+            if (peak := operator.meter_publication_peak_s) is not None:
+                attrs["meter_refresh_peak_s"] = round(peak)
             if (kind := operator.meter_refresh_kind) is not None:
                 attrs["meter_refresh_kind"] = kind
 

--- a/custom_components/never_dry/session_flow.py
+++ b/custom_components/never_dry/session_flow.py
@@ -47,6 +47,13 @@ MIN_SAMPLES: int = 3
 SETTLE_DELAY_S: float = 30.0
 #: Shorter sessions are dominated by the counter's own resolution.
 MIN_SESSION_S: float = 60.0
+#: How many publication intervals to keep. A rolling window rather than a
+#: running figure because the quantity is reported to the user as a median,
+#: and a median needs the samples it came from.
+PUBLICATION_WINDOW_SIZE: int = 20
+#: Below this the cadence is shown as still being measured. One interval is an
+#: accident, two are a coincidence; the same reasoning as MIN_SAMPLES above.
+MIN_PUBLICATION_SAMPLES: int = 3
 
 _STORAGE_VERSION: int = 1
 
@@ -125,6 +132,18 @@ class SessionFlowTracker:
         #: interval is not a cadence, and the user must be able to see the
         #: difference between "measured" and "seen once".
         self.refresh_samples: int = 0
+        #: Gaps between two *publications* of the counter, whether or not the
+        #: value changed. A separate quantity from ``refresh_cadence_s`` above,
+        #: which times *advances* and only while water is flowing: that one
+        #: bounds how long a meter may stay silent mid-delivery, and the guard
+        #: is built on its worst case. This one answers the plainer question
+        #: the user asks -- how often does my counter speak -- and is reported
+        #: as a median, because what belongs on screen is the typical
+        #: behaviour, not the worst one.
+        self.publication_intervals: deque[float] = deque(maxlen=PUBLICATION_WINDOW_SIZE)
+        #: Median at the last save, so a stable cadence stops rewriting the
+        #: store every time the meter reports.
+        self._saved_publication_median: float | None = None
 
     def observe_refresh_interval(self, seconds: float) -> bool:
         """Record a gap between two counter publications; True if it widens the estimate.
@@ -141,6 +160,52 @@ class SessionFlowTracker:
             self.refresh_cadence_s = seconds
             return True
         return False
+
+    def observe_publication_interval(self, seconds: float) -> bool:
+        """Record a gap between two publications; True when it is worth saving.
+
+        Every accepted interval enters the window, but a store write is only
+        worth doing when the number the user sees actually moves. A meter
+        settled at 300 s would otherwise rewrite its file on every report.
+        """
+        if seconds <= 0:
+            return False
+        self.publication_intervals.append(seconds)
+        median = self.publication_median_s
+        if median is None:
+            return False
+        if self._saved_publication_median is None or round(median) != round(self._saved_publication_median):
+            self._saved_publication_median = median
+            return True
+        return False
+
+    @property
+    def publication_samples(self) -> int:
+        """How many intervals the cadence was measured from."""
+        return len(self.publication_intervals)
+
+    @property
+    def publication_median_s(self) -> float | None:
+        """Typical gap between two publications, or ``None`` while unmeasured.
+
+        Median rather than mean because the outliers here are artefacts, not
+        behaviour: a restart of Home Assistant, or a device that dropped off
+        the mesh for an hour, produce one enormous gap that says nothing about
+        the meter. A mean would follow it; the median ignores it.
+        """
+        if not self.publication_intervals:
+            return None
+        ordered = sorted(self.publication_intervals)
+        n = len(ordered)
+        mid = n // 2
+        if n % 2:
+            return ordered[mid]
+        return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+    @property
+    def publication_peak_s(self) -> float | None:
+        """Worst gap in the window. Diagnostics only; the card shows the median."""
+        return max(self.publication_intervals) if self.publication_intervals else None
 
     def observe_step(self, step: float) -> bool:
         """Record a counter increment; returns True when it lowers the estimate.
@@ -174,6 +239,14 @@ class SessionFlowTracker:
             # Same reasoning as the resolution below: an unusable stored cadence
             # means the guard cannot be armed, which is the safe direction.
             pass
+        for gap in data.get("publication_intervals", []):
+            try:
+                value = float(gap)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                self.publication_intervals.append(value)
+        self._saved_publication_median = self.publication_median_s
         try:
             if (res := data.get("resolution_l")) is not None:
                 self.resolution_l = float(res)
@@ -191,6 +264,7 @@ class SessionFlowTracker:
                 "resolution_l": self.resolution_l,
                 "refresh_cadence_s": self.refresh_cadence_s,
                 "refresh_samples": self.refresh_samples,
+                "publication_intervals": list(self.publication_intervals),
             }
         )
 
@@ -203,4 +277,7 @@ class SessionFlowTracker:
             "meter_resolution_l": self.resolution_l,
             "meter_refresh_cadence_s": self.refresh_cadence_s,
             "meter_refresh_samples": self.refresh_samples,
+            "meter_publication_median_s": self.publication_median_s,
+            "meter_publication_peak_s": self.publication_peak_s,
+            "meter_publication_samples": self.publication_samples,
         }

--- a/custom_components/never_dry/session_flow.py
+++ b/custom_components/never_dry/session_flow.py
@@ -121,6 +121,10 @@ class SessionFlowTracker:
         #: The worst gap, not the typical one, because a verification window
         #: has to survive an opening that lands just after a report.
         self.refresh_cadence_s: float | None = None
+        #: How many intervals went into that figure. Published because one
+        #: interval is not a cadence, and the user must be able to see the
+        #: difference between "measured" and "seen once".
+        self.refresh_samples: int = 0
 
     def observe_refresh_interval(self, seconds: float) -> bool:
         """Record a gap between two counter publications; True if it widens the estimate.
@@ -132,6 +136,7 @@ class SessionFlowTracker:
         """
         if seconds <= 0:
             return False
+        self.refresh_samples += 1
         if self.refresh_cadence_s is None or seconds > self.refresh_cadence_s:
             self.refresh_cadence_s = seconds
             return True
@@ -164,6 +169,7 @@ class SessionFlowTracker:
         try:
             if (cadence := data.get("refresh_cadence_s")) is not None:
                 self.refresh_cadence_s = float(cadence)
+            self.refresh_samples = int(data.get("refresh_samples") or 0)
         except (TypeError, ValueError):
             # Same reasoning as the resolution below: an unusable stored cadence
             # means the guard cannot be armed, which is the safe direction.
@@ -184,6 +190,7 @@ class SessionFlowTracker:
                 "samples": list(self.window._samples),
                 "resolution_l": self.resolution_l,
                 "refresh_cadence_s": self.refresh_cadence_s,
+                "refresh_samples": self.refresh_samples,
             }
         )
 
@@ -195,4 +202,5 @@ class SessionFlowTracker:
             **self.window.as_dict(),
             "meter_resolution_l": self.resolution_l,
             "meter_refresh_cadence_s": self.refresh_cadence_s,
+            "meter_refresh_samples": self.refresh_samples,
         }

--- a/custom_components/never_dry/session_flow.py
+++ b/custom_components/never_dry/session_flow.py
@@ -13,11 +13,12 @@ opens, the meter again after it closes, the elapsed time in between:
 
 Two details carry the accuracy, and both come from the field.
 
-The reading *after* the close is deliberately delayed by ``SETTLE_DELAY_S``.
-A Zigbee counter reports on its own cadence, so the last tick of a session
+The reading *after* the close waits for the meter's next publication. A
+Zigbee counter reports on its own cadence, so the last tick of a session
 routinely lands after the valve is already shut; sampling at the instant of
-closing silently loses it. (The same late tick, read as an instantaneous
-rate, is what makes a closed valve look like it is still leaking.)
+closing silently loses it, and so does sleeping any fixed number of seconds
+chosen in advance. (The same late tick, read as an instantaneous rate, is
+what makes a closed valve look like it is still leaking.)
 
 Sessions shorter than ``MIN_SESSION_S`` are refused rather than averaged in.
 On a counter whose smallest step is a whole liter, a short run is mostly
@@ -42,9 +43,6 @@ from homeassistant.helpers.storage import Store
 WINDOW_SIZE: int = 20
 #: Below this, report nothing: a median of one or two sessions is an anecdote.
 MIN_SAMPLES: int = 3
-#: Grace after the valve closes before reading the meter, so a counter that
-#: reports late still gets counted. Not part of the measured duration.
-SETTLE_DELAY_S: float = 30.0
 #: Shorter sessions are dominated by the counter's own resolution.
 MIN_SESSION_S: float = 60.0
 #: How many publication intervals to keep. A rolling window rather than a

--- a/custom_components/never_dry/session_flow.py
+++ b/custom_components/never_dry/session_flow.py
@@ -113,6 +113,29 @@ class SessionFlowTracker:
         #: Smallest non-zero counter increment ever seen — the meter's limit of
         #: detection. Learned by watching deliveries, so it needs no test.
         self.resolution_l: float | None = None
+        #: Longest gap seen between two publications of the counter. Not the
+        #: same quantity as the resolution, and not derivable from it: some
+        #: meters publish per litre delivered, others on a fixed clock. On a
+        #: SONOFF SWV-ZFE the gap is ~300 s whatever the flow rate, so
+        #: ``resolution / rate`` predicts a first tick that cannot arrive.
+        #: The worst gap, not the typical one, because a verification window
+        #: has to survive an opening that lands just after a report.
+        self.refresh_cadence_s: float | None = None
+
+    def observe_refresh_interval(self, seconds: float) -> bool:
+        """Record a gap between two counter publications; True if it widens the estimate.
+
+        Takes the maximum, where :meth:`observe_step` takes the minimum, and the
+        asymmetry is deliberate: the step bounds what the meter *can* detect, so
+        the smallest is the honest one, while the cadence bounds how long it may
+        stay silent while water flows, so the longest is.
+        """
+        if seconds <= 0:
+            return False
+        if self.refresh_cadence_s is None or seconds > self.refresh_cadence_s:
+            self.refresh_cadence_s = seconds
+            return True
+        return False
 
     def observe_step(self, step: float) -> bool:
         """Record a counter increment; returns True when it lowers the estimate.
@@ -139,6 +162,13 @@ class SessionFlowTracker:
             except (TypeError, ValueError):
                 continue
         try:
+            if (cadence := data.get("refresh_cadence_s")) is not None:
+                self.refresh_cadence_s = float(cadence)
+        except (TypeError, ValueError):
+            # Same reasoning as the resolution below: an unusable stored cadence
+            # means the guard cannot be armed, which is the safe direction.
+            pass
+        try:
             if (res := data.get("resolution_l")) is not None:
                 self.resolution_l = float(res)
         except (TypeError, ValueError):
@@ -149,10 +179,20 @@ class SessionFlowTracker:
 
     async def async_save(self) -> None:
         """Persist the current window to HA storage."""
-        await self._store.async_save({"samples": list(self.window._samples), "resolution_l": self.resolution_l})
+        await self._store.async_save(
+            {
+                "samples": list(self.window._samples),
+                "resolution_l": self.resolution_l,
+                "refresh_cadence_s": self.refresh_cadence_s,
+            }
+        )
 
     def median_lpm(self) -> float | None:
         return self.window.median_lpm()
 
     def as_dict(self) -> dict[str, Any]:
-        return {**self.window.as_dict(), "meter_resolution_l": self.resolution_l}
+        return {
+            **self.window.as_dict(),
+            "meter_resolution_l": self.resolution_l,
+            "meter_refresh_cadence_s": self.refresh_cadence_s,
+        }

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -36,14 +36,15 @@ const I18N = {
     irrigateNow: "Irrigate now",
     irrigating: "Irrigating",
     dosing: "Dosing",
-    doseByTime: "by time (declared rate)",
-    doseByMeter: "by measured volume",
-    doseByValve: "by the valve's own dose",
-    meterRefresh: "Meter reports every",
+    doseByTime: "by time",
+    doseByMeter: "by volume",
+    doseByValve: "by the valve",
+    meterRefresh: "Meter refresh",
     meterRefreshUnknown: "not measured yet",
     meterPeriodic: "on a clock",
     meterByVolume: "per volume",
     meterGuardOff: "cannot verify opening",
+    meterMeasuring: "measuring",
     maintenance: "Maintenance",
     unreachable: "Valve not responding",
     waitingForValve: "waiting for first contact",
@@ -101,14 +102,15 @@ const I18N = {
     irrigateNow: "Irriga ora",
     irrigating: "In irrigazione",
     dosing: "Dosaggio",
-    doseByTime: "a tempo (portata dichiarata)",
-    doseByMeter: "a volume misurato",
-    doseByValve: "a dose sulla valvola",
-    meterRefresh: "Il contatore riporta ogni",
+    doseByTime: "a tempo",
+    doseByMeter: "a volume",
+    doseByValve: "a dose valvola",
+    meterRefresh: "Aggiornamento contatore",
     meterRefreshUnknown: "non ancora misurato",
     meterPeriodic: "a orologio",
     meterByVolume: "a volume",
     meterGuardOff: "non puo' verificare l'apertura",
+    meterMeasuring: "in misura",
     maintenance: "Manutenzione",
     unreachable: "Valvola non raggiungibile",
     waitingForValve: "in attesa di risposta",
@@ -166,14 +168,15 @@ const I18N = {
     irrigateNow: "Jetzt bewässern",
     irrigating: "Bewässerung läuft",
     dosing: "Dosierung",
-    doseByTime: "nach Zeit (angegebene Durchflussrate)",
-    doseByMeter: "nach gemessenem Volumen",
-    doseByValve: "nach der Dosis des Ventils",
-    meterRefresh: "Zähler meldet alle",
+    doseByTime: "nach Zeit",
+    doseByMeter: "nach Volumen",
+    doseByValve: "nach Ventildosis",
+    meterRefresh: "Zähler-Aktualisierung",
     meterRefreshUnknown: "noch nicht gemessen",
     meterPeriodic: "nach Uhr",
     meterByVolume: "nach Volumen",
     meterGuardOff: "kann Öffnung nicht prüfen",
+    meterMeasuring: "wird gemessen",
     maintenance: "Wartung",
     unreachable: "Ventil antwortet nicht",
     waitingForValve: "Warte auf erste Ventil-Rückmeldung",
@@ -678,7 +681,8 @@ class NeverDryZoneCard extends HTMLElement {
         this._exposureCell(ents) +
         this._rows([["mdi:speedometer", ents.flowRate, t(hass, "designFlow")]]) +
         this._measuredFlowCell(ents) +
-        this._deliveryCell(_zoneAttrs),
+        this._deliveryCell(_zoneAttrs) +
+        this._meterRefreshCell(_zoneAttrs),
     );
 
     this._updateConfigLink(ents);
@@ -776,10 +780,11 @@ class NeverDryZoneCard extends HTMLElement {
    * `volume_preset` the valve does. Until now nothing on screen said which,
    * so two zones behaving differently for a good reason looked identical.
    *
-   * The refresh cadence is shown next to it because it is the number that
-   * decides whether the meter can supervise an opening at all: one reporting
-   * every 300 s on a session lasting 359 s is visibly unfit, and no single
-   * reading reveals it.
+   * The meter's refresh cadence used to ride along in this same value, and
+   * that was the mistake: a cell value is clipped with an ellipsis at one
+   * column's width, so three facts joined by separators meant the last two
+   * were never read. It now has its own cell, and the qualifiers that used to
+   * lengthen the value live in the label, which wraps instead of truncating.
    */
   _deliveryCell(a) {
     const mode = a.delivery_mode;
@@ -791,25 +796,53 @@ class NeverDryZoneCard extends HTMLElement {
     };
     const label = byMode[mode];
     if (!label) return "";
-    let value = t(this._hass, label);
-
-    if (a.flow_meter_sensor) {
-      const cadence = Number(a.meter_refresh_s);
-      if (Number.isFinite(cadence)) {
-        const kind = a.meter_refresh_kind === "periodic" ? "meterPeriodic" : "meterByVolume";
-        value += ` · ${t(this._hass, "meterRefresh")} ${cadence}s (${t(this._hass, kind)})`;
-      } else {
-        value += ` · ${t(this._hass, "meterRefresh")} ${t(this._hass, "meterRefreshUnknown")}`;
-      }
-      if (a.meter_guard_usable === false && mode !== "estimated_flow") {
-        value += ` · ${t(this._hass, "meterGuardOff")}`;
-      }
-    }
     return `
         <div class="nd-cell">
           <ha-icon icon="mdi:water-pump"></ha-icon>
           <div class="nd-cell-txt">
             <span class="nd-cell-lbl">${escapeHtml(t(this._hass, "dosing"))}</span>
+            <span class="nd-cell-val">${escapeHtml(t(this._hass, label))}</span>
+          </div>
+        </div>`;
+  }
+
+  /**
+   * How often this zone's counter speaks, and what that is worth.
+   *
+   * The typical gap, not the worst one: the worst is what sizes the wait for
+   * a late tick, and showing it here would make a prompt meter look slow. Two
+   * states short of a number are distinguished on purpose, because they call
+   * for different things from the user: "not measured yet" means no interval
+   * has been timed at all, while "measuring (1/3)" means the figure is coming
+   * on its own and there is nothing to do.
+   *
+   * A meter that cannot supervise an opening says so in the label rather than
+   * the value: the label wraps, the value is clipped, and a caveat that gets
+   * cut off is worse than no caveat.
+   */
+  _meterRefreshCell(a) {
+    if (!a.flow_meter_sensor) return "";
+    let label = t(this._hass, "meterRefresh");
+    if (a.meter_guard_usable === false && a.delivery_mode !== "estimated_flow") {
+      label += `, ${t(this._hass, "meterGuardOff")}`;
+    }
+    const median = Number(a.meter_refresh_s);
+    const samples = Number(a.meter_refresh_samples) || 0;
+    const need = Number(a.meter_refresh_min_samples) || 3;
+    let value;
+    if (Number.isFinite(median) && samples >= need) {
+      const kind = a.meter_refresh_kind === "periodic" ? "meterPeriodic" : "meterByVolume";
+      value = `${median}s (${t(this._hass, kind)})`;
+    } else if (samples > 0) {
+      value = `${t(this._hass, "meterMeasuring")} (${samples}/${need})`;
+    } else {
+      value = t(this._hass, "meterRefreshUnknown");
+    }
+    return `
+        <div class="nd-cell">
+          <ha-icon icon="mdi:timer-sync-outline"></ha-icon>
+          <div class="nd-cell-txt">
+            <span class="nd-cell-lbl">${escapeHtml(label)}</span>
             <span class="nd-cell-val">${escapeHtml(value)}</span>
           </div>
         </div>`;

--- a/custom_components/never_dry/www/never-dry-zone-card.js
+++ b/custom_components/never_dry/www/never-dry-zone-card.js
@@ -35,6 +35,15 @@ const I18N = {
     barUnavailable: "deficit / threshold unavailable",
     irrigateNow: "Irrigate now",
     irrigating: "Irrigating",
+    dosing: "Dosing",
+    doseByTime: "by time (declared rate)",
+    doseByMeter: "by measured volume",
+    doseByValve: "by the valve's own dose",
+    meterRefresh: "Meter reports every",
+    meterRefreshUnknown: "not measured yet",
+    meterPeriodic: "on a clock",
+    meterByVolume: "per volume",
+    meterGuardOff: "cannot verify opening",
     maintenance: "Maintenance",
     unreachable: "Valve not responding",
     waitingForValve: "waiting for first contact",
@@ -91,6 +100,15 @@ const I18N = {
     barUnavailable: "deficit / soglia non disponibili",
     irrigateNow: "Irriga ora",
     irrigating: "In irrigazione",
+    dosing: "Dosaggio",
+    doseByTime: "a tempo (portata dichiarata)",
+    doseByMeter: "a volume misurato",
+    doseByValve: "a dose sulla valvola",
+    meterRefresh: "Il contatore riporta ogni",
+    meterRefreshUnknown: "non ancora misurato",
+    meterPeriodic: "a orologio",
+    meterByVolume: "a volume",
+    meterGuardOff: "non puo' verificare l'apertura",
     maintenance: "Manutenzione",
     unreachable: "Valvola non raggiungibile",
     waitingForValve: "in attesa di risposta",
@@ -147,6 +165,15 @@ const I18N = {
     barUnavailable: "Defizit / Grenzwert nicht verfügbar",
     irrigateNow: "Jetzt bewässern",
     irrigating: "Bewässerung läuft",
+    dosing: "Dosierung",
+    doseByTime: "nach Zeit (angegebene Durchflussrate)",
+    doseByMeter: "nach gemessenem Volumen",
+    doseByValve: "nach der Dosis des Ventils",
+    meterRefresh: "Zähler meldet alle",
+    meterRefreshUnknown: "noch nicht gemessen",
+    meterPeriodic: "nach Uhr",
+    meterByVolume: "nach Volumen",
+    meterGuardOff: "kann Öffnung nicht prüfen",
     maintenance: "Wartung",
     unreachable: "Ventil antwortet nicht",
     waitingForValve: "Warte auf erste Ventil-Rückmeldung",
@@ -650,7 +677,8 @@ class NeverDryZoneCard extends HTMLElement {
         ]) +
         this._exposureCell(ents) +
         this._rows([["mdi:speedometer", ents.flowRate, t(hass, "designFlow")]]) +
-        this._measuredFlowCell(ents),
+        this._measuredFlowCell(ents) +
+        this._deliveryCell(_zoneAttrs),
     );
 
     this._updateConfigLink(ents);
@@ -740,6 +768,53 @@ class NeverDryZoneCard extends HTMLElement {
    * for — the one that says whether the zone delivers what it was designed to —
    * the cell stays and reports its own progress instead of disappearing.
    */
+  /**
+   * What this zone doses by, and what its meter is worth.
+   *
+   * The delivery mode decides who answers for the water: in `estimated_flow`
+   * the user's declared rate does, in `flow_meter` the measurement does, in
+   * `volume_preset` the valve does. Until now nothing on screen said which,
+   * so two zones behaving differently for a good reason looked identical.
+   *
+   * The refresh cadence is shown next to it because it is the number that
+   * decides whether the meter can supervise an opening at all: one reporting
+   * every 300 s on a session lasting 359 s is visibly unfit, and no single
+   * reading reveals it.
+   */
+  _deliveryCell(a) {
+    const mode = a.delivery_mode;
+    if (!mode) return "";
+    const byMode = {
+      estimated_flow: "doseByTime",
+      flow_meter: "doseByMeter",
+      volume_preset: "doseByValve",
+    };
+    const label = byMode[mode];
+    if (!label) return "";
+    let value = t(this._hass, label);
+
+    if (a.flow_meter_sensor) {
+      const cadence = Number(a.meter_refresh_s);
+      if (Number.isFinite(cadence)) {
+        const kind = a.meter_refresh_kind === "periodic" ? "meterPeriodic" : "meterByVolume";
+        value += ` · ${t(this._hass, "meterRefresh")} ${cadence}s (${t(this._hass, kind)})`;
+      } else {
+        value += ` · ${t(this._hass, "meterRefresh")} ${t(this._hass, "meterRefreshUnknown")}`;
+      }
+      if (a.meter_guard_usable === false && mode !== "estimated_flow") {
+        value += ` · ${t(this._hass, "meterGuardOff")}`;
+      }
+    }
+    return `
+        <div class="nd-cell">
+          <ha-icon icon="mdi:water-pump"></ha-icon>
+          <div class="nd-cell-txt">
+            <span class="nd-cell-lbl">${escapeHtml(t(this._hass, "dosing"))}</span>
+            <span class="nd-cell-val">${escapeHtml(value)}</span>
+          </div>
+        </div>`;
+  }
+
   _measuredFlowCell(ents) {
     const st = ents.measuredFlow;
     if (!st) return "";

--- a/custom_components/never_dry/zone.py
+++ b/custom_components/never_dry/zone.py
@@ -183,12 +183,23 @@ class WaterCounters:
         """Add ``liters`` to every counter, rolling the yearly total on year change."""
         credited = round(liters, 1)
         self.last_volume_l = credited
-        self.session_water_l = credited
         self.total_water_l += credited
         if self.yearly_water_year != year:
             self.yearly_water_l = 0.0
             self.yearly_water_year = year
         self.yearly_water_l += credited
+
+    def end_session(self) -> None:
+        """Clear the running total for the session that just closed.
+
+        ``session_water_l`` answers "how much has this run delivered so far",
+        and once the run is over the honest answer is none: what it finally
+        delivered is ``last_volume_l``, which is a different question with its
+        own home. Leaving the running figure standing meant the card described
+        the previous irrigation under a label that says "session", with nothing
+        to say the run had ended.
+        """
+        self.session_water_l = 0.0
 
     def reset_yearly(self, *, year: int) -> None:
         """Clear the yearly total, preserving the lifetime one (user-invoked reset)."""
@@ -339,6 +350,7 @@ class Zone:
         """
         self.credit_delivery(delivery)
         self.counters.credit(delivery.liters_delivered, year=at.year)
+        self.counters.end_session()
         self.last_irrigated = at
         self.last_source = source
         self.last_duration_s = round(delivery.elapsed_s)
@@ -372,6 +384,7 @@ class Zone:
         credited = self.water_demand_l if credited_liters is None else credited_liters
         self.deficit = self.deficit.with_value(0.0).clamped()
         self.counters.credit(credited, year=at.year)
+        self.counters.end_session()
         self.last_irrigated = at
         self.last_source = source
         # Left alone when unknown rather than zeroed: the hose case has no

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -27,7 +27,11 @@ New contributors: see [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) first.
 - [`flow-rate-provenance.md`](flow-rate-provenance.md) — **Accepted (ADR)**: the
   three flow rates (design, telemetered, historical), which one answers which
   question, and why a still meter may qualify an action but never refuse one.
-  Read before touching flow verification, leak detection or delivery planning.
+  Also distinguishes a meter's resolution from its reporting cadence, which are
+  two quantities and were long treated as one. Read before touching flow
+  verification, leak detection or delivery planning; then read
+  [`delivery-contract.md`](delivery-contract.md), which says who answers for the
+  water in each delivery mode.
 - [`unit-system.md`](unit-system.md) — metric-internal architecture (SI core,
   imperial only at the edges).
 - [`dependency-management.md`](dependency-management.md) — **Accepted (ADR)**: why
@@ -52,6 +56,15 @@ New contributors: see [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) first.
   which rain-delay evidence ships first, and how far a freeze may be overridden.
   Discussion:
   [#74](https://github.com/never-dry/NeverDry/issues/74).
+  *Status: Draft → Proposed (RFC) → Accepted (ADR).*
+- [`delivery-contract.md`](delivery-contract.md): **Proposed (RFC)**. What a
+  zone's delivery mode declares beyond how a session ends. Each mode names who
+  answers for the water (the user, NeverDry, or the valve), and that decides
+  which witness the system may appeal to: why a flow guard in `estimated_flow`
+  is somebody else's check, why in `flow_meter` the guard's threshold belongs to
+  the device and not to us, and why the deficit falls in all three modes under
+  three different titles. Written from the field failure of 2026-09-08.
+  Discussion: [#232](https://github.com/never-dry/NeverDry/pull/232).
   *Status: Draft → Proposed (RFC) → Accepted (ADR).*
 - [`soil-moisture-model.md`](soil-moisture-model.md) — **Draft**: what a soil
   probe's reading is allowed to mean. Argues that "site-level" is not a physical

--- a/docs/design/delivery-contract.md
+++ b/docs/design/delivery-contract.md
@@ -1,0 +1,171 @@
+# The delivery contract: three modes, three responsibilities
+
+**Status:** Proposed (RFC), 2026-09-09. Most of it runs; one case and one
+consequence do not, and they are named in *What holds today* at the end. It
+becomes Accepted when the code respects all of it.
+Discussion: [#232](https://github.com/never-dry/NeverDry/pull/232).
+
+A zone's delivery mode is usually read as a setting: how NeverDry should decide
+that a session is over. It is more than that. **The way a zone doses also
+declares which witness it owns, and therefore which witness the system may
+appeal to.** The user's declaration is a contract, and it binds the system
+before it binds the user.
+
+Reading it as a mere setting is what produced the field failure of 2026-09-08,
+where a healthy valve was closed by a check that had no business running on that
+zone at all, and the water it had already delivered was credited to nobody.
+
+## The three declarations
+
+### Case 1. A plain on/off valve (`estimated_flow`)
+
+Declared: *I measure nothing. The duration is the dose.*
+
+- A delivery sensor, if configured, serves exactly one purpose: refining the
+  design flow rate with the observed one.
+- It is **not binding on opening**. No condition on flow may prevent or
+  interrupt a run.
+- If the counter says nothing, the session proceeds. It had no part to play.
+
+### Case 2. A metered valve (`flow_meter`)
+
+Declared: *I measure the volume, and the dose ends when the volume is reached.*
+
+- The meter **must** be declared. Without it the mode is meaningless and the
+  configuration refuses it.
+- The meter's **reporting cadence** is measured and kept.
+- If the meter is to guard an opening, the guard's threshold **is that measured
+  cadence**, not a NeverDry constant. This is the centre of the whole document:
+  the threshold belongs to the device.
+- A meter whose cadence is not yet known cannot guard. Not out of caution, but
+  because the quantity that defines the threshold does not exist yet.
+
+### Case 3. A smart valve dosing by volume (`volume_preset`)
+
+Declared: *I arm the dose on the valve, and the valve closes itself.*
+
+- The dose never depends on flow. The valve governs it.
+- A declared meter falls under Case 2: it may guard, by the same rule, with the
+  window derived from that meter's cadence.
+
+## The invariant: who answers for the water
+
+| Mode | Answers for delivery | Consequence |
+|---|---|---|
+| `estimated_flow` | **the user** | declared the rate, so the deficit falls by force of that declaration |
+| `flow_meter` | **NeverDry** | measures, so answers for the measurement and for its timing |
+| `volume_preset` | **the valve** | accepted the dose and closes itself, so answers for it |
+
+This is what turns three conventions into one rule. It also settles a question
+that looked like a policy choice and is not.
+
+## The deficit always falls, with three different titles
+
+| Mode | Verifiable? | Deficit falls? | By force of |
+|---|---|---|---|
+| `estimated_flow` | never, **by contract** | **yes** | the declared design rate |
+| `flow_meter` | **yes**, once the meter's cadence is allowed for | **yes** | the measurement, awaited |
+| `volume_preset` | verifiable by the device itself | **yes** | the valve's own declaration |
+
+There is no configuration in which the correct answer is to credit nothing. Only
+the *title* changes.
+
+The question that sounded reasonable, "should we trust an unverifiable
+delivery?", was malformed. In Case 1 unverifiability is not a fault, it is the
+user's declared choice, and denying its consequences means refusing a
+configuration after having accepted it. In Case 2 unverifiability does not exist,
+provided the window is the right one. In Case 3 the verification happens, and the
+valve performs it.
+
+Two consequences follow, and both were field defects before they were rules:
+
+- **A flow failure cannot prevent crediting.** It may qualify a delivery, never
+  cancel it. On 2026-09-08 a zone delivered six measured litres and its deficit
+  moved by 0.1 mm, because the session ended in error before the water was
+  counted. So the water left the pipe and the model did not know.
+- **In Case 2 the count waits for the meter's last word.** A metered session is
+  not over when the valve shuts, it is over when the counter has finished
+  speaking. Counting at the close understated one measured session by 5%: 271
+  litres against roughly 285 delivered, because the closing tick landed three
+  and a half minutes later.
+
+## Why a guard in Case 1 is somebody else's control
+
+The objection to the guard in `estimated_flow` is often put as "a second check
+cannot hurt". It can, and the reason is not redundancy.
+
+In Case 1 the responsible party is the user. A flow guard makes NeverDry assume a
+responsibility that is not its own, that of verifying delivery, and then **refuse
+to carry out what the user declared** in the name of that verification. It is not
+abusive because it is a second check. It is abusive because it is somebody
+else's check.
+
+There is a plainer test of the same thing: if a still meter could still close the
+valve, then declaring a plain valve and declaring a metered one would produce
+identical behaviour on opening, and the choice the user made would mean nothing.
+
+## The obligation that comes with the guard
+
+If NeverDry answers for the measurement in Case 2, the guard has a right to
+exist. It also carries a symmetric obligation: whoever assumes a responsibility
+must answer for it when they get it wrong.
+
+When a 90 s window expired on a meter publishing every 300 s, the verification
+failed through an error of ours, in choosing the threshold. It was recorded as:
+
+```
+ACTUATION_FAILED     ->     "the valve failed to actuate"
+```
+
+which attributes it to the device. That is not only unfair, it is expensive: the
+log accused a valve that had done its job, and the diagnosis took a day. So when
+our own window cannot conclude, the outcome is `FLOW_UNVERIFIABLE` and the run
+proceeds. A failure kind that names the device is reserved for evidence about the
+device.
+
+## Where the title is recorded
+
+`DeliveryQuality` (`driver.py`) already distinguishes `MEASURED`, `ESTIMATED`,
+`PARTIAL`, `DELAYED`, `LOW_CONFIDENCE` and `DECLARED`. It came out of an external
+review ([#74](https://github.com/never-dry/NeverDry/issues/74)) and is written on
+every `DeliveryResult`. Nothing reads it: not the controller, not the sensors,
+not the card.
+
+It stayed inert because the decision that would consume it had not been taken.
+While the question was "credit or not", quality was useless, since a binary
+session outcome answered it. With the rule above, quality finds its consumer:
+**it does not decide whether to credit, it records the title under which
+crediting happened.** The three titles in the table are three values the enum
+already has.
+
+It is also how the difference between the three cases becomes visible without
+being studied. A session that reduces the deficit declaring `estimated` is saying
+"I trusted your figure"; one declaring `measured` is saying "I counted it".
+
+## What holds today
+
+| | State |
+|---|---|
+| Case 1 is not bound by flow | **implemented**: the guard arms only outside `estimated_flow`, and the meter keeps feeding the learned rate |
+| Case 2 threshold is the device's cadence | **implemented**: no cadence means no guard, and a cadence too long to guard yields a verdict rather than a longer window |
+| Case 2 count waits for the meter | **implemented**: the post-close wait derives from the same cadence |
+| A refusal of ours does not cancel the credit | **implemented for cumulative meters**: the deficit is credited from the settled reading. Rate-only sensors have no cumulative baseline and are not covered yet |
+| Case 3 may guard, by the Case 2 rule | **not implemented**: `_deliver_volume_preset` bypasses the driver deliberately, so the arming that exists there is unreachable |
+| `DeliveryQuality` records the title | **not implemented**: still written and never read |
+
+The gap in Case 3 is worth stating plainly, because it is easy to mistake for
+compliance. That mode is today the only one immune to the guard defect, but by
+accident rather than by design: it never reaches the state machine. Under this
+contract it should move from "no guard, by accident" to "a guard available by
+choice, with the right rule", and it is the case where a guard is most useful,
+since the dose is run by a device whose cycle NeverDry does not control.
+
+## Open
+
+- Whether Case 3 should be routed through the operator, or the unreachable
+  arming removed so the door is not left ajar.
+- What honest figure, if any, can be credited on a rate-only sensor after a
+  refusal, given there is no cumulative baseline to difference.
+- Whether the deferred credit should also move the session counters (total and
+  yearly water), which today stay with the paths that completed a session. The
+  water did leave the pipe; the session did not complete.

--- a/docs/design/flow-rate-provenance.md
+++ b/docs/design/flow-rate-provenance.md
@@ -1,8 +1,15 @@
 # Three flow rates — design, telemetered, historical
 
-**Status:** Accepted (ADR), 2026-08-18. All three are implemented: the historical
-rate is collected from every metered session, the configured field is named
-*design flow rate*, and planning prefers history over design.
+**Status:** Accepted (ADR), 2026-08-18. Revised 2026-09-09: the decision is
+unchanged, its coverage was not what this document claimed. The rule below said
+"the code follows now" while one branch of flow verification still refused
+openings on a constant, and the mechanism described as resolving it covered only
+meters that report per litre delivered. Both are corrected here, with the field
+case that exposed them.
+
+All three rates are implemented: the historical rate is collected from every
+metered session, the configured field is named *design flow rate*, and planning
+prefers history over design.
 
 NeverDry has called one thing "flow rate" while meaning three. They come from
 different places, fail in different ways, and are trustworthy for different
@@ -41,10 +48,11 @@ If the counter moves, water is flowing — that inference is sound. If the
 counter does not move, nothing follows: the flow may be below the meter's
 limit of detection, or the meter may simply not have reported yet.
 
-This asymmetry is not a subtlety, it is the whole safety argument. Two defects
-came from reading silence as evidence of absence; both are fixed, and both are
-worth keeping on the record because the reasoning that produced them is easy to
-repeat:
+This asymmetry is not a subtlety, it is the whole safety argument. Three defects
+came from reading silence as evidence of absence, and the third arrived after the
+first two were fixed, which is the reason all of them stay on the record: the
+reasoning that produces them is easy to repeat, and repeating it is exactly what
+happened.
 
 - **Open verification.** The FSM waits a fixed 10 s (`valve_fsm.py`,
   `flow_verify_timeout_s`) for flow to appear, then declares `ACTUATION_FAILED`.
@@ -56,17 +64,64 @@ repeat:
   `CLOSE_LEAK`, then a stuck-open escalation that calls `never_dry.stop` on the
   whole integration. On 2026-08-18 this fired on a valve that HA recorded as
   closed twenty seconds earlier.
+- **Open verification again, from the other end** (2026-09-08). The 10 s
+  constant above was replaced by a window derived from `resolution / flow rate`,
+  which assumes a counter reporting once per litre delivered. A SONOFF SWV-ZFE
+  does not: it publishes on a fixed clock every 300 s (measured: mean 300.2 s,
+  standard deviation 1.1 s) whatever the flow. Against such a meter the
+  derivation predicts a first tick that cannot arrive, and where the resolution
+  was still unknown the code fell back to a 90 s constant and kept the power to
+  close. A 90 s window against a 300 s cadence passes 90/300 of the time, so
+  roughly 7 openings in 10 were refused on a valve that was watering normally:
+  four of the five observed sessions failed, each logged as `ACTUATION_FAILED`,
+  a device fault. The valve itself had reported `actual_irrigation_amount = 6`
+  litres for one of them.
 
 The rule the code follows now: **a still meter qualifies an action, it never
 refuses one.** Absence of evidence is not evidence of absence.
 
-Concretely: the verification window is derived per zone from
-`resolution / flow rate`, and where that exceeds what is still useful as a
-guard the check is declared *not applicable* — a distinct FSM event
-(`FLOW_UNVERIFIABLE`) that lets the run proceed with flow demoted to observer,
-rather than a failure that closes a working valve. On the closing side, a
-cumulative counter is judged on whether it is **still climbing** after a second
-close, never on whether its total exceeds a threshold.
+Concretely: the verification window is derived per zone from the meter's
+**reporting cadence**, and where that cadence is unknown, or longer than any
+window still useful as a guard, the check is declared *not applicable*. That is
+a distinct FSM event (`FLOW_UNVERIFIABLE`) which lets the run proceed with flow
+demoted to observer, rather than a failure that closes a working valve. No
+cadence means no threshold, so no guard: an unmeasured quantity is not a licence
+to substitute a constant for it. On the closing side, a cumulative counter is
+judged on whether it is **still climbing** after a second close, never on
+whether its total exceeds a threshold.
+
+## Two quantities of a meter, not one
+
+A counter has a **resolution**, the smallest increment it can express, and a
+**reporting cadence**, how often it speaks at all. They are independent, and
+reading one as if it were the other is what produced the second open-verification
+defect above.
+
+| | Resolution | Reporting cadence |
+|---|---|---|
+| What it is | the smallest step the counter can express, in litres | the interval between publications, in seconds |
+| Decided by | the sensing element | the firmware |
+| Observed from | the smallest increment ever seen | the interval between increments while the valve is open |
+| Answers | is a supervised test practicable? | how long may a healthy meter stay silent? |
+
+`resolution / flow rate` is the time to the first tick **of a meter that
+publishes once per litre delivered**. On a meter that publishes on a clock it is
+a number about a different device: it can be twenty times too small, and the
+error does not announce itself, because every individual reading looks perfectly
+sane. What bounds legitimate silence in both cases is the cadence, so that is
+what the guard's window is made of.
+
+Taken together the two also *classify* the meter, which no single reading does: a
+cadence far longer than `resolution / rate` is a clock talking, not water
+arriving. That verdict is published as `meter_refresh_kind` beside the cadence
+itself, because it decides whether the meter can supervise an opening at all and
+no amount of tuning changes it. A zone whose meter cannot guard is not a
+misconfigured zone: it is a zone whose meter answers a different question.
+
+Both are learned rather than declared, and both start unknown. The interval
+between increments only counts **while the valve is open**: with the valve shut a
+counter stands still for hours, and taking that as the cadence would disable
+verification on a perfectly prompt meter.
 
 ## What each one is for
 
@@ -118,14 +173,19 @@ One sample per metered session (`session_flow.py`, wired into
 `ZoneDriver._deliver_by_volume`):
 
 ```
-lpm = (meter[close + 30 s] − meter[before open]) / minutes the valve was open
+lpm = (meter[close + settle] − meter[before open]) / minutes the valve was open
 ```
 
 Three decisions in that formula, each paid for by a field defect:
 
-- **The reading after the close is delayed by 30 s.** The last tick routinely
-  lands after the valve shuts — the same late report that fakes a leak. Sampling
-  at the instant of closing quietly loses it. The delay is waiting, not measured
+- **The reading after the close waits for the meter, not for a constant.** The
+  last tick routinely lands after the valve shuts, which is the same late report
+  that fakes a leak, and sampling at the instant of closing quietly loses it.
+  A fixed 30 s of patience suited a prompt counter and missed a slow one: on the
+  300 s device the closing tick arrived three and a half minutes late, and the
+  session's volume was computed from a truncated figure. The wait is now derived
+  from that meter's own cadence and capped, so the number that sizes the
+  verification window sizes this one too. The delay is waiting, not measured
   time, and it is deferred rather than awaited so the session still ends when
   the water stops.
 - **The baseline is not the delivery loop's running total.** That one is rebased
@@ -220,7 +280,8 @@ replaces a constant that the field had already refuted:
 |---|---|---|
 | Confirmation latency (`ValveLatencyTracker`) | fixed open/close timeouts | how long to wait for the switch to answer |
 | Flow rate (`SessionFlowWindow`) | the design rate, for planning | durations, timeout scaling, credited estimates |
-| Meter resolution (`resolution_l`) | the assumption that a counter ticks promptly | the flow-verification window, and whether a test is practicable |
+| Meter resolution (`resolution_l`) | the assumption that a counter ticks promptly | whether a supervised test is practicable, and half of the meter's classification |
+| Reporting cadence (`refresh_cadence_s`) | the assumption that silence means a dry pipe | the flow-verification window, the post-close wait, and whether the guard may arm at all |
 
 Together they are a measured model of this particular controller, valve and
 meter — more accurate than the ratings precisely because it is observed rather

--- a/docs/design/valve-state-machine.md
+++ b/docs/design/valve-state-machine.md
@@ -56,6 +56,7 @@ stateDiagram-v2
 
     OPEN --> OPEN_VERIFIED: OBS_FLOW_POSITIVE<br/>CancelTimer(flow)
     OPEN --> IDLE: TIMEOUT_FLOW<br/>SendSwitchOff<br/>NotifyFailure(ACTUATION_FAILED)
+    OPEN --> OPEN_VERIFIED: FLOW_UNVERIFIABLE<br/>CancelTimer(flow)<br/>(the check does not apply here)
     OPEN --> REQ_CLOSE: CMD_CLOSE<br/>CancelTimer(flow)<br/>SendSwitchOff<br/>StartTimer(close)
     OPEN --> IDLE: OBS_SWITCH_OFF (external close)<br/>CancelAllTimers<br/>(counter reset)
 
@@ -142,7 +143,8 @@ itself have produced the false `CLOSE_VERIFICATION_FAILED`.
 | Kind | Condition | Likely cause |
 |---|---|---|
 | `OPEN_FAILED` | `REQ_OPEN` did not see `OBS_SWITCH_ON` within `open_timeout_s` | Zigbee packet loss, sleepy device |
-| `ACTUATION_FAILED` | Switch reported on but flow stayed at zero | Water shut off upstream, stuck/calcified valve, broken flow sensor |
+| `ACTUATION_FAILED` | Switch reported on but the meter did not move inside a window we chose | Water shut off upstream, stuck/calcified valve, broken flow sensor, **or a window shorter than the meter's reporting cadence**, which is our fault and not the device's |
+| `FLOW_UNVERIFIABLE` | Not a failure: no window can distinguish a dry pipe from a counter that has not spoken yet | A meter that publishes on a clock, or one whose cadence has never been measured. The run proceeds with flow demoted to observer |
 | `CLOSE_VERIFICATION_FAILED` | `REQ_CLOSE` did not see `OBS_SWITCH_OFF` within `close_timeout_s` | Zigbee packet loss |
 | `CLOSE_LEAK` | Switch reported off but flow stayed positive | Valve mechanically stuck open — most dangerous mode |
 
@@ -151,7 +153,7 @@ itself have produced the false `CLOSE_VERIFICATION_FAILED`.
 | Setting | Default | Notes |
 |---|---|---|
 | `open_timeout_s` | 10.0 | `REQ_OPEN` → `OBS_SWITCH_ON` |
-| `flow_verify_timeout_s` | 10.0 | `OPEN` → `OBS_FLOW_POSITIVE` (flow meter only) |
+| `flow_verify_timeout_s` | 10.0 | `OPEN` → `OBS_FLOW_POSITIVE` (flow meter only). **The dataclass default, not the value in force**: `ZoneDriver.flow_verify_window()` decides it per zone from that meter's measured cadence, and returns a verdict instead of a window when no cadence can support one |
 | `close_timeout_s` | 10.0 | `REQ_CLOSE` → `OBS_SWITCH_OFF` |
 | `leak_timeout_s` | 10.0 | `CLOSED` → `OBS_FLOW_ZERO` (flow meter only) |
 | `max_consecutive_failures` | 3 in `FsmConfig`, **6** in production | Threshold for entering `MAINTENANCE`. `ValveOperator` always overrides the FSM default with `max_retries + 1` |
@@ -202,6 +204,7 @@ in total). Physical failures are surfaced immediately:
 | `OPEN_FAILED` | ✓ | Likely Zigbee packet loss / sleepy device — second try often lands |
 | `CLOSE_VERIFICATION_FAILED` | ✓ | Same comms class |
 | `ACTUATION_FAILED` | ✗ | Hydraulic / mechanical issue — retry cannot unblock it |
+| `FLOW_UNVERIFIABLE` | n/a | Never raised as a failure. It is the verdict that keeps the previous row honest: when the check could not conclude, saying so is not the same as accusing the valve |
 | `CLOSE_LEAK` | ✗ | Stuck-open valve — retry wastes water during the second close attempt |
 
 Default backoff: `(1.0s, 2.0s, 4.0s, 8.0s, 16.0s)` — exponential, indexed

--- a/docs/design_water_balance_reference_model.md
+++ b/docs/design_water_balance_reference_model.md
@@ -1,7 +1,7 @@
 # Design — Water-Balance Reference Model
 
 **Status:** Draft (RFC)
-**Last updated:** 2026-07-23
+**Last updated:** 2026-09-09
 **Related:** #123, [Domain Object Model](design_domain_object_model.md), backlog AI-189 (bug), AI-174 (per-zone VWC RFC)
 
 ## Why this document exists
@@ -53,13 +53,28 @@ inert until a later phase wires today's `DrynessIndexSensor` ET/VWC fork onto it
 | **Rain** (→ `rain_delta`) | **System feed** | one sensor for all zones, applied to every zone's balance |
 | **Deficit** (`+ ET·Kc·Δt − rain − irrigation`) | **Zone** | authoritative state |
 | **Kc, threshold, area, valve, irrigation state** | **Zone** | — |
-| **VWC sensor + `field_capacity` + `root_depth`** | **System (interim)** | until AI-174 → then per-zone |
+| **VWC sensor, system** (`vwc_sensor`, model params) | **System** | drives the deficit in VWC mode, bypassing ET |
+| **VWC probe, per zone** (`vwc_sensor` on the zone) | **Zone** | shipped. It does *not* own the zone's deficit: it publishes its reading and the deficit that reading alone would imply, beside the model's. AI-174 is the model-level work that would let a zone's deficit follow its own probe |
+| **`field_capacity`, `root_depth`** | **Neither** | not exposed in any form, system or zone. Fixed at 0.30 / 0.30 in `const.py` |
 
 So the only permanent system-level things are the two environmental **feeds**
-(temperature, rain). Everything else lives in the zone. The VWC model
-(`vwc_sensor`, `field_capacity`, `root_depth`) is system-level only until the
-per-zone VWC work (AI-174) lands, after which nothing but the feeds remains
-shared.
+(temperature, rain). Everything else lives in the zone, or is on its way there.
+
+The VWC row above was one line until 2026-09-09, reading "system-level until
+AI-174 lands". It had become false in one of its three parts and misleading in
+the other two, which is why it is now three rows. A zone can bind its own probe
+today, and that binding shipped without AI-174, because it gave the probe a role
+that does not require owning a deficit: characterising the soil, and revealing a
+hydraulic fault when water is delivered and the moisture does not move. What
+AI-174 still owes is the model-level step, a zone's deficit following its own
+probe.
+
+`field_capacity` and `root_depth` are the part worth reading twice. They are not
+system-level parameters, they are not parameters at all: no form writes them, so
+every installation runs on 0.30 / 0.30. They are also the two numbers a per-zone
+probe would be best placed to establish, since the plateau a probe settles at
+after drainage *is* that soil's field capacity. The measurement that could fix
+the constant is already bound to the zone, and the constant is still a constant.
 
 ## Decisions
 

--- a/docs/valve-compatibility.csv
+++ b/docs/valve-compatibility.csv
@@ -1,4 +1,4 @@
-vendor,model,firmware,datecode,via,valve_domain,flow_rate,volume_session,volume_aggregate,history,needs_config,caveat,lod,reported_by,issue,date
-SONOFF,SWV,1.0.4,20240820,Z2M 2.13,switch,m3/h,yes,daily,no,none,,,maintainer,,2026-06-01
-SONOFF,SWV-ZFE,1.0.7,20260317,Z2M 2.13,switch,no,yes,hourly,on_request,history,,,maintainer,,2026-07-01
-SONOFF,SWV-ZFE,1.1.0,20260724,Z2M 2.13,switch,no,yes,hourly,on_request,history,unit_change,,maintainer,,2026-08-01
+vendor,model,firmware,datecode,via,valve_domain,flow_rate,volume_session,volume_aggregate,history,needs_config,caveat,lod,meter_update_s,meter_update_kind,meter_resolution_l,flow_rate_lpm,flow_rate_measured_lpm,reported_by,issue,date
+SONOFF,SWV,1.0.4,20240820,Z2M 2.13,switch,m3/h,yes,daily,no,none,,,,volume,1,,,maintainer,,2026-06-01
+SONOFF,SWV-ZFE,1.0.7,20260317,Z2M 2.13,switch,no,yes,hourly,on_request,history,,,300,periodic,,28.0,18.9,maintainer,,2026-07-01
+SONOFF,SWV-ZFE,1.1.0,20260724,Z2M 2.13,switch,no,yes,hourly,on_request,history,unit_change,,300,periodic,2,4.4,3.9,maintainer,,2026-08-01

--- a/docs/valve-compatibility.md
+++ b/docs/valve-compatibility.md
@@ -18,10 +18,17 @@ expose different things too. The table below is the only honest answer.
 | **Valve** | The entity NeverDry commands. `switch.*` and `valve.*` are both supported and equivalent — the integration sends the services that domain understands. |
 | **Flow rate** | An *instantaneous* volume/time reading: the witness that water is moving right now. Integrated over a run it also estimates a volume, so that estimate is only as good as the reporting cadence. |
 | **Volume counters** | *session* = restarts at zero each run, and is the best source of all: when the run ends its value already **is** the volume delivered. *daily* / *hourly* = a total that resets on a calendar boundary — usable, with the [reset caveat](#the-caveats-that-apply-to-every-counter). |
+| **Meter reports** | *When* the counter speaks, which is not the same as what it can express. *per volume* = one report per counter step, so silence really does mean no water. *on a clock* = a fixed interval whatever the flow, so silence means nothing until the interval has passed. This is the column that decides whether the meter can supervise an opening, and it is why a valve can be perfectly sound and still unable to guard. |
 | **History** | Past sessions kept on the device — the series in which delivery *decaying* over weeks becomes visible, which is how clogged drippers announce themselves. |
 | **Needs YAML?** | Whether anything beyond picking an entity is required. ❌ means genuinely nothing. |
 | **LoD** | Limit of detection — [what it is and how to measure it](#limit-of-detection-lod). Empty on every row so far, and it is the one number no config file contains. |
 | **By** | Who established the row. Rows credited to *maintainer* were read off the project's own field installation. |
+
+Three further fields live in the CSV without appearing above, because they
+describe the reporter's installation rather than the device: `flow_rate_lpm`,
+`flow_rate_measured_lpm` and `meter_resolution_l`. The first two are worth more
+as a pair than separately, since the gap between a declared rate and the one
+actually observed is invisible in either number alone.
 
 ### R / W / G — read, write, get
 
@@ -46,11 +53,11 @@ dosing below.
 ## Verified valves
 
 <!-- BEGIN GENERATED TABLE: edit valve-compatibility.csv, then run tools/build_valve_table.py -->
-| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | History | Needs config? | Verdict | Why | LoD | By |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| SONOFF **SWV** | 1.0.4 (20240820) | Z2M 2.13 | `switch.*` | m3/h | ✅ session + daily | ❌ | ❌ none | **good** | flow rate in m3/h, session counter | - | maintainer |
-| SONOFF **SWV-ZFE** | 1.0.7 (20260317) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | history | **good** | session counter | - | maintainer |
-| SONOFF **SWV-ZFE** | 1.1.0 (20260724) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | ⚠️ on request | history | **partial** | session counter, but the firmware can change its own counter units | - | maintainer |
+| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | Meter reports | History | Needs config? | Verdict | Why | LoD | By |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| SONOFF **SWV** | 1.0.4 (20240820) | Z2M 2.13 | `switch.*` | m3/h | ✅ session + daily | per volume (1 L steps) | ❌ | ❌ none | **good** | flow rate in m3/h, session counter | - | maintainer |
+| SONOFF **SWV-ZFE** | 1.0.7 (20260317) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | on a clock, ~300 s | ⚠️ on request | history | **partial** | session counter, but it reports every ~300 s on a clock, too late to supervise an opening, and the dose lands in steps that size | - | maintainer |
+| SONOFF **SWV-ZFE** | 1.1.0 (20260724) | Z2M 2.13 | `switch.*` | ❌ | ✅ session + hourly | on a clock, ~300 s | ⚠️ on request | history | **partial** | session counter, but it reports every ~300 s on a clock, too late to supervise an opening, and the dose lands in steps that size; and the firmware can change its own counter units | - | maintainer |
 
 **Verdict**, derived from the columns, never typed: *good* = delivery measurement available with no extra setup · *partial* = delivery measurement available, but with a documented caveat or extra step · *timer-only* = no delivery measurement, so NeverDry runs it on a clock
 <!-- END GENERATED TABLE -->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ def _create_ha_stubs():
     # homeassistant.helpers.event
     event_mod = ModuleType("homeassistant.helpers.event")
     event_mod.async_track_state_change_event = MagicMock()
+    event_mod.async_track_state_report_event = MagicMock()
     event_mod.async_track_time_change = MagicMock()
     event_mod.async_track_time_interval = MagicMock()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -614,7 +614,8 @@ class TestManualValveDetection:
         )
         controller._on_valve_state_change(self._make_valve_event("switch.valve_orto", "on", "off"))
 
-        assert zone_orto._session_water_delivered == pytest.approx(40.0, abs=0.5)
+        assert zone_orto._last_volume_delivered == pytest.approx(40.0, abs=0.5)
+        assert zone_orto._session_water_delivered == 0.0, "the manual session ended with the close"
         assert zone_orto._total_water_delivered - total_before == pytest.approx(40.0, abs=0.5)
         assert zone_orto._yearly_water_delivered - yearly_before == pytest.approx(40.0, abs=0.5)
 

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -18,6 +18,7 @@ Design notes: docs/design/flow-rate-provenance.md (a still meter qualifies an
 action, it never refuses one) and docs/design/delivery-contract.md.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -446,30 +447,6 @@ class TestTheCadenceSurvivesAShortDose:
         assert driver.meter_publication_peak_s == pytest.approx(590.0)
 
 
-class TestTheWaitFollowsTheMeasuredMeter:
-    """The 30 s constant is what lost the field sample, by nine seconds."""
-
-    def test_an_unmeasured_meter_keeps_the_historical_constant(self):
-        driver = _zone(DeliveryMode.FLOW_METER)
-        assert driver.settle_delay_s == pytest.approx(30.0)
-
-    def test_a_measured_meter_is_waited_for(self):
-        driver = _zone(DeliveryMode.FLOW_METER)
-        for _ in range(3):
-            driver._session_flow.observe_publication_interval(FIELD_METER_CADENCE_S)
-
-        # 39 s late was enough to miss it; the wait now clears that by minutes.
-        assert driver.settle_delay_s > 39.0
-        assert driver.settle_delay_s == pytest.approx(FIELD_METER_CADENCE_S * 1.5)
-
-    def test_the_wait_stays_bounded_on_a_very_slow_meter(self):
-        driver = _zone(DeliveryMode.FLOW_METER)
-        for _ in range(3):
-            driver._session_flow.observe_publication_interval(599.0)
-
-        assert driver.settle_delay_s <= 600.0
-
-
 class TestMeasuringTheMeterDoesNotArmTheGuard:
     """Non-regression: the guard keeps its own, stricter evidence.
 
@@ -538,36 +515,84 @@ class TestTheMeterIsClassifiedNotJustMeasured:
         assert driver.meter_refresh_samples == 1
 
 
-class TestTheSettleWaitFollowsTheMeterToo:
-    """The last tick of a session lands after the valve is shut, by how much
-    the meter decides.
+class TestTheSettleReadWaitsForTheEventNotTheClock:
+    """The closing tick is announced; nothing had to guess when it would come.
 
-    A fixed 30 s wait was already there for exactly this reason, and it is the
-    same shape of defect as the verification window: a constant standing in for
-    a property of the device. On the field meter the closing tick arrived three
-    and a half minutes after the valve shut, so 30 s of patience missed it and
-    the session's measured flow was computed from a truncated volume.
+    The wait used to be a computed number of seconds. Both field zones lost a
+    healthy sample to it -- by 9 s on one meter and by 172 s on the other --
+    and the number could not improve on its own, because it was derived from a
+    cadence that only those same discarded sessions could have measured.
 
-    The wait runs in a background task and never delays the session, so
-    lengthening it costs nothing but a later diagnostic.
+    The driver already subscribes to the meter's publications, so the answer
+    was arriving on a callback while a sleeper waited beside it. Waiting on
+    the event needs no cadence, and works the first time a meter is ever seen.
     """
 
-    def test_a_prompt_meter_keeps_the_default_wait(self):
-        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0, cadence_s=14.0)
-        assert driver.settle_delay_s == pytest.approx(30.0)
+    @staticmethod
+    def _meter_at(driver, value: float) -> None:
+        driver._hass.states.get = MagicMock(
+            return_value=MagicMock(state=str(value), attributes={"unit_of_measurement": "L"}),
+        )
 
-    def test_the_field_meter_gets_a_wait_that_can_see_its_last_tick(self):
-        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=6.0, cadence_s=FIELD_METER_CADENCE_S)
-        assert driver.settle_delay_s > FIELD_METER_CADENCE_S
-
-    def test_an_unmeasured_cadence_falls_back_to_the_default(self):
+    @pytest.mark.asyncio
+    async def test_the_reading_happens_when_the_meter_speaks(self):
+        """The field case of pino, 2026-09-10: silent at 30 s, 25 L at 202 s."""
         driver = _zone(DeliveryMode.FLOW_METER)
-        assert driver.settle_delay_s == pytest.approx(30.0)
+        self._meter_at(driver, 0.0)
 
-    def test_the_wait_is_capped_so_a_task_cannot_hang_around_for_ever(self):
-        """A meter reporting hourly would otherwise leave a task pending all that time."""
-        driver = _zone(DeliveryMode.FLOW_METER, cadence_s=3600.0)
-        assert driver.settle_delay_s <= 600.0
+        pending = asyncio.ensure_future(driver.async_settled_volume("sensor.meter", 0.0))
+        await asyncio.sleep(0)
+        assert not pending.done(), "read before the meter spoke: this is the defect"
+
+        self._meter_at(driver, 25.0)
+        driver._note_meter_publication()
+
+        assert await asyncio.wait_for(pending, timeout=1.0) == pytest.approx(25.0)
+
+    @pytest.mark.asyncio
+    async def test_a_meter_with_nothing_more_to_say_is_still_read(self, monkeypatch):
+        """The ceiling is a backstop, not a verdict.
+
+        A cumulative counter that went quiet has simply finished talking, and
+        its standing value is the right answer.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER)
+        self._meter_at(driver, 108.0)
+
+        async def instant_timeout(awaitable, timeout):
+            awaitable.close()
+            raise TimeoutError
+
+        monkeypatch.setattr("never_dry.driver.asyncio.wait_for", instant_timeout)
+
+        assert await driver.async_settled_volume("sensor.meter", 100.0) == pytest.approx(8.0)
+
+    @pytest.mark.asyncio
+    async def test_a_zone_watering_again_has_no_settled_volume(self, monkeypatch):
+        """Half of two sessions is not a measurement of either."""
+        driver = _zone(DeliveryMode.FLOW_METER)
+        self._meter_at(driver, 25.0)
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: True))
+
+        pending = asyncio.ensure_future(driver.async_settled_volume("sensor.meter", 0.0))
+        await asyncio.sleep(0)
+        driver._note_meter_publication()
+
+        assert await asyncio.wait_for(pending, timeout=1.0) is None
+
+    @pytest.mark.asyncio
+    async def test_a_stale_publication_does_not_answer_for_the_next_session(self):
+        """The event is re-armed before waiting, or every read returns at once."""
+        driver = _zone(DeliveryMode.FLOW_METER)
+        self._meter_at(driver, 25.0)
+        driver._note_meter_publication()  # a publication from before this read
+
+        pending = asyncio.ensure_future(driver.async_settled_volume("sensor.meter", 0.0))
+        await asyncio.sleep(0)
+        assert not pending.done(), "an old publication satisfied a new wait"
+
+        driver._note_meter_publication()
+        assert await asyncio.wait_for(pending, timeout=1.0) == pytest.approx(25.0)
 
 
 class TestCase1CreditsWhatTheUserDeclared:
@@ -816,25 +841,24 @@ class TestOurOwnRefusalNeverCancelsTheCredit:
         assert zone._zone_deficit == pytest.approx(5.0)
 
     @pytest.mark.asyncio
-    async def test_the_reading_waits_for_the_meters_own_cadence(self, hass_mock, di_sensor, monkeypatch):
+    async def test_the_credit_waits_for_the_meter_before_it_answers(self, hass_mock, di_sensor):
         """The condition the credit depends on: read too early and it reads zero.
 
-        Not a constant and not immediate -- the same cadence that decides the
-        verification window and the settle wait.
+        Neither a constant nor immediate. What the credited figure waits for is
+        the meter's own next word, whenever that comes.
         """
         driver = _zone(DeliveryMode.FLOW_METER, resolution_l=6.0, cadence_s=FIELD_METER_CADENCE_S)
-        waited = []
+        driver._hass.states.get = MagicMock(
+            return_value=MagicMock(state="100.0", attributes={"unit_of_measurement": "L"}),
+        )
 
-        async def record(seconds):
-            waited.append(seconds)
+        pending = asyncio.ensure_future(driver.async_settled_volume("sensor.meter", 100.0))
+        await asyncio.sleep(0)
+        assert not pending.done(), "answered before the meter had spoken"
 
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", record)
         driver._hass.states.get = MagicMock(
             return_value=MagicMock(state="108.0", attributes={"unit_of_measurement": "L"}),
         )
+        driver._note_meter_publication()
 
-        volume = await driver.async_settled_volume("sensor.meter", 100.0)
-
-        assert volume == pytest.approx(8.0)
-        assert waited == [driver.settle_delay_s]
-        assert waited[0] > FIELD_METER_CADENCE_S, "reading before the next tick reads the truncated figure"
+        assert await asyncio.wait_for(pending, timeout=1.0) == pytest.approx(8.0)

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -32,6 +32,7 @@ from never_dry.const import (
     CONF_ZONE_SYSTEM_TYPE,
     CONF_ZONE_VALVE,
     CONF_ZONE_VOLUME_ENTITY,
+    DELIVERY_MODE_FLOW_METER,
     DELIVERY_MODE_VOLUME_PRESET,
     SYSTEM_TYPE_CUSTOM,
 )
@@ -592,3 +593,114 @@ class TestCase3IsNotGuardedOnTheLivePath:
 
         assert await ctrl._open_valve(zone.valve) is True
         operator.async_turn_on.assert_awaited_once()
+
+
+class TestOurOwnRefusalNeverCancelsTheCredit:
+    """T9: a check we could not conclude must not cost the zone its water.
+
+    The invariant of the contract, and the one worth the most: the verification
+    decides whether we may *trust* the meter's account of a session, never
+    whether the water that already left the pipe happened. When the guard closed
+    a healthy valve in the field, the session ended in error and the litres that
+    had run were credited to nobody -- so the deficit stood, the zone was
+    watered again the next day, and the model was wrong in the direction that
+    floods rather than the one that dries.
+
+    What is credited is what the meter finally reports, not an estimate. A
+    genuinely dry pipe therefore credits nothing, which is correct and is the
+    reason this cannot be done with time multiplied by the declared rate.
+
+    The reading has to wait for the meter's own cadence: on the field device the
+    closing tick landed three and a half minutes after the valve shut, so an
+    immediate read would return the same truncated figure that caused the whole
+    diagnosis to take a day.
+    """
+
+    @staticmethod
+    def _refused_open():
+        return MagicMock(status=OperationStatus.FAILED, error_detail="flow_unverifiable")
+
+    def _zone_and_controller(self, hass_mock, di_sensor, *, reading="100.0"):
+        zone = _zone_sensor(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+            },
+        )
+        zone._zone_deficit = 5.0
+        hass_mock.states.get = MagicMock(side_effect=_frozen_meter(zone, "sensor.flow_meter", reading))
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        return zone, ctrl
+
+    @staticmethod
+    def _capture_tasks(hass_mock):
+        """Run the deferred work deterministically instead of hoping it ran."""
+        spawn = hass_mock.async_create_task
+        tasks = []
+
+        def capture(coro):
+            task = spawn(coro)
+            tasks.append(task)
+            return task
+
+        hass_mock.async_create_task = capture
+        return tasks
+
+    @pytest.mark.asyncio
+    async def test_a_refused_opening_still_credits_what_the_meter_saw(self, hass_mock, di_sensor):
+        zone, ctrl = self._zone_and_controller(hass_mock, di_sensor)
+        driver = MagicMock()
+        driver.async_turn_on = AsyncMock(return_value=self._refused_open())
+        driver.async_settled_volume = AsyncMock(return_value=8.0)
+        ctrl._valve_operators[zone.valve] = driver
+        tasks = self._capture_tasks(hass_mock)
+
+        delivered = await ctrl._deliver_flow_meter(zone)
+        for task in tasks:
+            await task
+
+        assert delivered == 0.0, "the session did fail: the synchronous figure is honest"
+        # 8 L on 20 m2 at 0.90 efficiency is 0.36 mm of the 5 mm owed.
+        assert zone._zone_deficit == pytest.approx(5.0 - 8.0 * 0.90 / 20.0)
+
+    @pytest.mark.asyncio
+    async def test_a_dry_pipe_credits_nothing(self, hass_mock, di_sensor):
+        """The guard exists for this case, and the fix must not blunt it."""
+        zone, ctrl = self._zone_and_controller(hass_mock, di_sensor)
+        driver = MagicMock()
+        driver.async_turn_on = AsyncMock(return_value=self._refused_open())
+        driver.async_settled_volume = AsyncMock(return_value=None)
+        ctrl._valve_operators[zone.valve] = driver
+        tasks = self._capture_tasks(hass_mock)
+
+        await ctrl._deliver_flow_meter(zone)
+        for task in tasks:
+            await task
+
+        assert zone._zone_deficit == pytest.approx(5.0)
+
+    @pytest.mark.asyncio
+    async def test_the_reading_waits_for_the_meters_own_cadence(self, hass_mock, di_sensor, monkeypatch):
+        """The condition the credit depends on: read too early and it reads zero.
+
+        Not a constant and not immediate -- the same cadence that decides the
+        verification window and the settle wait.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=6.0, cadence_s=FIELD_METER_CADENCE_S)
+        waited = []
+
+        async def record(seconds):
+            waited.append(seconds)
+
+        monkeypatch.setattr("never_dry.driver.asyncio.sleep", record)
+        driver._hass.states.get = MagicMock(
+            return_value=MagicMock(state="108.0", attributes={"unit_of_measurement": "L"}),
+        )
+
+        volume = await driver.async_settled_volume("sensor.meter", 100.0)
+
+        assert volume == pytest.approx(8.0)
+        assert waited == [driver.settle_delay_s]
+        assert waited[0] > FIELD_METER_CADENCE_S, "reading before the next tick reads the truncated figure"

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -268,3 +268,52 @@ class TestTheCadenceIsActuallyLearned:
         await driver._handle_flow_state(self._meter_event(16.0))
 
         assert driver._session_flow.refresh_cadence_s is None
+
+
+class TestTheMeterIsClassifiedNotJustMeasured:
+    """A cadence is a number; what the user needs is what it means.
+
+    Two meters with the same 1 L step behave differently: one publishes per
+    litre delivered, the other on a clock. The first can guard an opening, the
+    second cannot, and no amount of tuning changes that. So the classification
+    is published, not left for the reader to derive.
+    """
+
+    def test_a_prompt_meter_is_classified_as_publishing_per_volume(self):
+        """1 L step at 4.4 L/min is a tick every ~14 s, and that is what is seen."""
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0, cadence_s=14.0)
+        assert driver.meter_refresh_kind == "volume"
+
+    def test_the_field_meter_is_classified_as_publishing_on_a_clock(self):
+        """A 2 L step at 4.4 L/min should tick every ~27 s. It reports every 300.
+
+        The gap between what the volume would imply and what the meter does is
+        the whole diagnosis: this is the SWV-ZFE.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=2.0, cadence_s=FIELD_METER_CADENCE_S)
+        assert driver.meter_refresh_kind == "periodic"
+
+    def test_without_a_resolution_there_is_nothing_to_compare(self):
+        """Honest silence: the classification needs both quantities."""
+        driver = _zone(DeliveryMode.FLOW_METER, cadence_s=FIELD_METER_CADENCE_S)
+        assert driver.meter_refresh_kind is None
+
+    def test_guard_usable_says_no_for_the_field_meter(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=2.0, cadence_s=FIELD_METER_CADENCE_S)
+        assert driver.meter_guard_usable is False
+
+    def test_guard_usable_says_yes_for_a_prompt_meter(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0, cadence_s=14.0)
+        assert driver.meter_guard_usable is True
+
+    def test_guard_usable_says_no_in_a_mode_that_does_not_guard(self):
+        """Not "could it", but "does it": in Case 1 nothing guards, however good the meter."""
+        driver = _zone(DeliveryMode.ESTIMATED_FLOW, resolution_l=1.0, cadence_s=14.0)
+        assert driver.meter_guard_usable is False
+
+    def test_the_sample_count_is_published_so_a_lone_reading_is_visible(self):
+        """One interval is not a cadence, and the user must be able to see that."""
+        driver = _zone(DeliveryMode.FLOW_METER)
+        assert driver.meter_refresh_samples == 0
+        driver._session_flow.observe_refresh_interval(300.0)
+        assert driver.meter_refresh_samples == 1

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -317,3 +317,35 @@ class TestTheMeterIsClassifiedNotJustMeasured:
         assert driver.meter_refresh_samples == 0
         driver._session_flow.observe_refresh_interval(300.0)
         assert driver.meter_refresh_samples == 1
+
+
+class TestTheSettleWaitFollowsTheMeterToo:
+    """The last tick of a session lands after the valve is shut, by how much
+    the meter decides.
+
+    A fixed 30 s wait was already there for exactly this reason, and it is the
+    same shape of defect as the verification window: a constant standing in for
+    a property of the device. On the field meter the closing tick arrived three
+    and a half minutes after the valve shut, so 30 s of patience missed it and
+    the session's measured flow was computed from a truncated volume.
+
+    The wait runs in a background task and never delays the session, so
+    lengthening it costs nothing but a later diagnostic.
+    """
+
+    def test_a_prompt_meter_keeps_the_default_wait(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0, cadence_s=14.0)
+        assert driver.settle_delay_s == pytest.approx(30.0)
+
+    def test_the_field_meter_gets_a_wait_that_can_see_its_last_tick(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=6.0, cadence_s=FIELD_METER_CADENCE_S)
+        assert driver.settle_delay_s > FIELD_METER_CADENCE_S
+
+    def test_an_unmeasured_cadence_falls_back_to_the_default(self):
+        driver = _zone(DeliveryMode.FLOW_METER)
+        assert driver.settle_delay_s == pytest.approx(30.0)
+
+    def test_the_wait_is_capped_so_a_task_cannot_hang_around_for_ever(self):
+        """A meter reporting hourly would otherwise leave a task pending all that time."""
+        driver = _zone(DeliveryMode.FLOW_METER, cadence_s=3600.0)
+        assert driver.settle_delay_s <= 600.0

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -21,7 +21,23 @@ action, it never refuses one) and docs/design/delivery-contract.md.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from never_dry.driver import DeliveryMode, ZoneDriver
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_DELIVERY_MODE,
+    CONF_ZONE_DELIVERY_TIMEOUT,
+    CONF_ZONE_EFFICIENCY,
+    CONF_ZONE_FLOW_METER_SENSOR,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_NAME,
+    CONF_ZONE_SYSTEM_TYPE,
+    CONF_ZONE_VALVE,
+    CONF_ZONE_VOLUME_ENTITY,
+    DELIVERY_MODE_VOLUME_PRESET,
+    SYSTEM_TYPE_CUSTOM,
+)
+from never_dry.controller import IrrigationController
+from never_dry.driver import DeliveryMode, OperationStatus, ZoneDriver
+from never_dry.sensor import IrrigationZoneSensor
 
 #: The cadence measured on the SWV-ZFE in the field, in seconds.
 FIELD_METER_CADENCE_S = 300.0
@@ -73,6 +89,43 @@ def _zone(
     if cadence_s is not None:
         driver._session_flow.refresh_cadence_s = cadence_s
     return driver
+
+
+def _zone_sensor(hass_mock, di_sensor, **overrides):
+    """A configured zone as the integration builds it, for the controller path.
+
+    The driver-level ``_zone`` above answers "would the guard arm?". This one is
+    needed for the other half of the contract, which is only decidable where the
+    water is credited: the controller.
+    """
+    config = {
+        CONF_ZONE_NAME: "TestZone",
+        CONF_ZONE_VALVE: "switch.valve_test",
+        CONF_ZONE_AREA: 20.0,
+        CONF_ZONE_SYSTEM_TYPE: SYSTEM_TYPE_CUSTOM,
+        CONF_ZONE_EFFICIENCY: 0.90,
+        CONF_ZONE_FLOW_RATE: 8.0,
+    }
+    config.update(overrides)
+    return IrrigationZoneSensor(hass_mock, config, di_sensor)
+
+
+def _frozen_meter(zone, meter_entity: str, reading: str = "100.0"):
+    """states.get side effect: the meter never moves, the valve reads "on"."""
+
+    def get_state(entity_id):
+        if entity_id == meter_entity:
+            state = MagicMock()
+            state.state = reading
+            state.attributes = {"unit_of_measurement": "L"}
+            return state
+        if entity_id == zone.valve:
+            state = MagicMock()
+            state.state = "on"
+            return state
+        return None
+
+    return get_state
 
 
 class TestCase1TheUserAnswersForTheWater:
@@ -200,6 +253,37 @@ class TestTheFieldCaseDoesNotRecur:
         cadence is unfit, whatever produced it.
         """
         assert OLD_CONSTANT_S < FIELD_METER_CADENCE_S
+
+    @pytest.mark.parametrize("phase_fraction", [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    @pytest.mark.parametrize("cadence_s", [60.0, FIELD_METER_CADENCE_S])
+    def test_no_phase_of_the_meters_grid_may_refuse_a_healthy_valve(self, cadence_s, phase_fraction):
+        """The same healthy valve, opened at ten points of the meter's grid.
+
+        ``phase_fraction`` is how far into the reporting interval the valve
+        opens, so the first tick is still ``cadence x (1 - fraction)`` away.
+        NeverDry does not choose that phase: the schedule fires when it fires
+        and the device's clock is its own, which is why a verdict that depends
+        on it is a coin toss rather than a measurement.
+
+        Two cadences on purpose, because they exercise the two halves of the
+        rule and a single one would let the test pass for the wrong reason. At
+        300 s the guard must stand down; at 60 s it stays armed, so the only way
+        through is a window that outlasts the wait. The old derivation,
+        resolution over rate, gives about 14 s for this meter and fails the
+        second half at every phase but the last.
+        """
+        driver = _zone(
+            DeliveryMode.FLOW_METER,
+            resolution_l=1.0,
+            cadence_s=cadence_s,
+        )
+        window, verdict = driver.flow_verify_window()
+        wait_for_first_tick = cadence_s * (1.0 - phase_fraction)
+        assert verdict is not None or window >= wait_for_first_tick, (
+            f"opened {phase_fraction:.0%} into a {cadence_s:.0f}s grid, the first tick is "
+            f"{wait_for_first_tick:.0f}s away and the window is {window:.0f}s: "
+            f"a watering valve is closed and blamed"
+        )
 
 
 class TestFailuresAreAttributedToWhoeverCausedThem:
@@ -349,3 +433,162 @@ class TestTheSettleWaitFollowsTheMeterToo:
         """A meter reporting hourly would otherwise leave a task pending all that time."""
         driver = _zone(DeliveryMode.FLOW_METER, cadence_s=3600.0)
         assert driver.settle_delay_s <= 600.0
+
+
+class TestCase1CreditsWhatTheUserDeclared:
+    """T2: in estimated_flow the declared rate is the answer, not a proposal.
+
+    The other half of Case 1. That the guard cannot refuse the opening is only
+    useful if the water then reaches the model: a session that runs and is
+    credited nothing leaves the deficit standing, the zone is watered again
+    tomorrow, and the meter that was demoted to observer has quietly kept its
+    veto -- moved from the valve to the arithmetic.
+
+    The meter may still improve the figure when it has one to offer. What it may
+    not do is reduce the credit to zero by saying nothing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_zone_without_a_meter_credits_the_declared_rate(self, hass_mock, di_sensor):
+        """No witness at all is the plain case, and the dose is the duration."""
+        zone = _zone_sensor(hass_mock, di_sensor)
+        zone._zone_deficit = 5.0
+        target = zone.volume_liters
+        assert target > 0, "the fixture must ask for water, or the test proves nothing"
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda duration, **kwargs: duration)
+
+        await ctrl._irrigate_zones(["TestZone"])
+
+        assert zone._total_water_delivered == pytest.approx(target, abs=0.2)
+        assert zone._zone_deficit == 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_meter_that_never_moves_does_not_zero_the_credit(self, hass_mock, di_sensor):
+        """A frozen counter is an observer with nothing to say, not a verdict.
+
+        Far more likely a stalled sensor than a dry pipe: the valve was
+        commanded open and the user's own figure says what that delivers.
+        """
+        zone = _zone_sensor(
+            hass_mock,
+            di_sensor,
+            **{CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter"},
+        )
+        zone._zone_deficit = 5.0
+        target = zone.volume_liters
+        hass_mock.states.get = MagicMock(side_effect=_frozen_meter(zone, "sensor.flow_meter"))
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        ctrl._wait_with_stop_check = AsyncMock(side_effect=lambda duration, **kwargs: duration)
+
+        delivered = await ctrl._deliver_estimated_flow(zone)
+
+        assert delivered == pytest.approx(target, abs=0.2)
+
+
+class TestCase3CreditsTheDoseTheValveAccepted:
+    """T7: in volume_preset the valve answers, so its dose is the credit.
+
+    NeverDry arms a volume and the valve closes itself on it. Crediting anything
+    else would be second-guessing the only party that measured the water, and
+    the mode exists precisely because that party is better placed than we are.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_credit_is_the_dose_armed_on_the_valve(self, hass_mock, di_sensor, monkeypatch):
+        zone = _zone_sensor(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
+                CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
+                CONF_ZONE_DELIVERY_TIMEOUT: 10,
+            },
+        )
+        zone._zone_deficit = 5.0
+        target = zone.volume_liters
+        assert target > 0
+
+        # The valve reads "off" throughout: it never auto-opens, and the poll
+        # loop sees it shut and treats that as the self-close.
+        closed = MagicMock()
+        closed.state = "off"
+        hass_mock.states.get = MagicMock(return_value=closed)
+        monkeypatch.setattr("never_dry.controller.asyncio.sleep", AsyncMock())
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        delivered = await ctrl._deliver_volume_preset(zone)
+
+        assert delivered == pytest.approx(target)
+
+
+class TestCase3IsNotGuardedOnTheLivePath:
+    """T8: what the seam claims about Case 3, and what actually runs.
+
+    The plan of 2026-09-08 decided that the guard stays a gate in Cases 2 and 3
+    with the device's threshold. It is implemented for Case 2 only, and this
+    test exists so that the gap is a recorded fact rather than a belief.
+
+    ``ZoneDriver`` does arm the guard for volume_preset, but nothing on the live
+    path asks it: ``_deliver_volume_preset`` bypasses the driver deliberately,
+    because a smart valve driving its own state does not fit "I command, you
+    obey". So the arming is real and unreachable, in the same way that
+    ``deliver()`` itself is (AI-345).
+
+    This test is written to fail the day Case 3 is routed through the operator,
+    which is exactly when the divergence should be reconsidered rather than
+    silently resolved.
+    """
+
+    def test_the_driver_seam_would_guard_it(self):
+        driver = _zone(DeliveryMode.VOLUME_PRESET, resolution_l=1.0, cadence_s=14.0)
+        assert driver.flow_guard_armed is True
+        assert driver.meter_guard_usable is True
+
+    @pytest.mark.asyncio
+    async def test_but_the_live_path_never_consults_the_driver(self, hass_mock, di_sensor, monkeypatch):
+        zone = _zone_sensor(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_VOLUME_PRESET,
+                CONF_ZONE_VOLUME_ENTITY: "number.valve_volume",
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.flow_meter",
+                CONF_ZONE_DELIVERY_TIMEOUT: 10,
+            },
+        )
+        zone._zone_deficit = 5.0
+
+        closed = MagicMock()
+        closed.state = "off"
+        hass_mock.states.get = MagicMock(return_value=closed)
+        monkeypatch.setattr("never_dry.controller.asyncio.sleep", AsyncMock())
+
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        operator = MagicMock()
+        operator.async_turn_on = AsyncMock()
+        ctrl._valve_operators[zone.valve] = operator
+
+        await ctrl._deliver_volume_preset(zone)
+
+        operator.async_turn_on.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_spy_above_is_wired_and_would_have_seen_it(self, hass_mock, di_sensor):
+        """Without this, "never called" could just mean "never registered".
+
+        An assertion that something did not happen is worth exactly as much as
+        the proof that it could have. ``_open_valve`` is the seam volume_preset
+        skips, so consulting it here shows the same registration the previous
+        test relies on is live.
+        """
+        zone = _zone_sensor(hass_mock, di_sensor)
+        ctrl = IrrigationController(hass_mock, di_sensor, [zone], inter_zone_delay=0)
+        operator = MagicMock()
+        operator.async_turn_on = AsyncMock(return_value=MagicMock(status=OperationStatus.OK))
+        ctrl._valve_operators[zone.valve] = operator
+
+        assert await ctrl._open_valve(zone.valve) is True
+        operator.async_turn_on.assert_awaited_once()

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -1,0 +1,270 @@
+"""The delivery contract: three modes, three responsibilities.
+
+Each delivery mode declares who answers for the water that leaves the pipe,
+and therefore which witness the system may appeal to:
+
+    estimated_flow  -> the user     (declared the flow rate; duration is the dose)
+    flow_meter      -> NeverDry     (measures, so answers for its own measurement)
+    volume_preset   -> the valve    (accepted the dose and closes itself)
+
+The field case these tests encode (2026-09-08/09, zone "Giardino Melograno"):
+a SONOFF SWV-ZFE publishes its volume counter on a fixed 300 s cadence rather
+than per litre delivered. The open-verification window was a 90 s constant, so
+the guard closed a healthy valve in 7 openings out of 10 -- the counter simply
+had not spoken yet. Same valve, same plumbing, opposite verdicts depending on
+where the device's clock fell.
+
+Design notes: docs/design/flow-rate-provenance.md (a still meter qualifies an
+action, it never refuses one) and docs/design/delivery-contract.md.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from never_dry.driver import DeliveryMode, ZoneDriver
+
+#: The cadence measured on the SWV-ZFE in the field, in seconds.
+FIELD_METER_CADENCE_S = 300.0
+
+#: The constant that closed healthy valves. Any window derived from a fake
+#: meter must be able to exceed it, or the test cannot see the defect.
+OLD_CONSTANT_S = 90.0
+
+
+def _hass(meter_reading: float = 0.0) -> MagicMock:
+    """A hass mock whose meter entity sits at ``meter_reading`` and never moves."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    state = MagicMock()
+    state.state = str(meter_reading)
+    state.attributes = {"unit_of_measurement": "L"}
+    hass.states.get = MagicMock(return_value=state)
+    hass.async_create_task = MagicMock()
+    return hass
+
+
+def _zone(
+    mode: DeliveryMode,
+    *,
+    meter: str | None = "sensor.meter",
+    flow_rate_lpm: float = 4.4,
+    resolution_l: float | None = None,
+    cadence_s: float | None = None,
+) -> ZoneDriver:
+    """A zone as the user configured it, with no fsm_config override.
+
+    Passing ``fsm_config`` explicitly is what hides this defect in the existing
+    suite: it bypasses the ``has_flow_meter = meter is not None`` derivation that
+    the real integration uses. These tests must go through that derivation.
+    """
+    driver = ZoneDriver(
+        _hass(),
+        "switch.valve",
+        delivery_mode=mode,
+        flow_meter_sensor=meter,
+        flow_rate_lpm=flow_rate_lpm,
+        max_retries=0,
+        backoff_s=(0.01,),
+        name="testzone",
+    )
+    if resolution_l is not None:
+        driver._session_flow.resolution_l = resolution_l
+    if cadence_s is not None:
+        driver._session_flow.refresh_cadence_s = cadence_s
+    return driver
+
+
+class TestCase1TheUserAnswersForTheWater:
+    """estimated_flow: the user declared the rate, the duration is the dose.
+
+    A meter may be configured -- it refines the design rate -- but it is an
+    observer. If it could still close the valve, declaring a simple on/off valve
+    and declaring a metered one would produce identical behaviour on opening,
+    and the choice the user made would mean nothing.
+    """
+
+    def test_a_silent_meter_never_refuses_the_opening(self):
+        """T1: the guard must not be armed at all in this mode."""
+        driver = _zone(DeliveryMode.ESTIMATED_FLOW)
+        assert driver.flow_guard_armed is False
+
+    def test_it_holds_even_when_the_meter_is_declared_and_healthy(self):
+        """T11: the presence of a meter is not a grant of authority over the valve."""
+        driver = _zone(DeliveryMode.ESTIMATED_FLOW, resolution_l=1.0, cadence_s=14.0)
+        assert driver.flow_guard_armed is False
+
+    def test_the_meter_stays_an_observer(self):
+        """T3: disarming the guard must not disconnect the meter.
+
+        Removing the sensor from the configuration is the field workaround, and
+        it costs the zone its learned flow rate for good. The fix must keep the
+        observation and drop only the veto.
+        """
+        driver = _zone(DeliveryMode.ESTIMATED_FLOW)
+        assert driver._flow_sensor_entity_id == "sensor.meter"
+
+
+class TestCase2NeverDryAnswersForItsOwnMeasurement:
+    """flow_meter: the guard is legitimate, but the threshold is the device's.
+
+    A window that NeverDry picks is a claim about a device it has not measured.
+    When the claim is wrong the valve pays, and the log blames the valve.
+    """
+
+    def test_the_window_comes_from_the_cadence_not_from_resolution_over_rate(self):
+        """T4: the two derivations are made to disagree, and the cadence must win.
+
+        A meter with a 1 L step on a 60 L/min zone can move its counter one
+        second in: resolution/rate says a 10 s window is generous. But this
+        meter only publishes every 60 s, so a valve opened just after a report
+        waits a minute while watering normally.
+
+            resolution / rate -> ~1 s   -> window would be 10 s (the floor)
+            cadence           -> 60 s   -> window must exceed 60 s
+        """
+        driver = _zone(
+            DeliveryMode.FLOW_METER,
+            resolution_l=1.0,
+            flow_rate_lpm=60.0,
+            cadence_s=60.0,
+        )
+        window, verdict = driver.flow_verify_window()
+        assert verdict is None, "a 60 s cadence is still short enough to guard"
+        assert window > 60.0, (
+            f"window of {window:.0f}s follows resolution/rate, not the cadence: "
+            f"a healthy valve opened just after a report is closed while watering"
+        )
+
+    def test_a_cadence_too_long_to_guard_is_declared_inapplicable(self):
+        """The field meter: 300 s of legitimate silence is past any useful guard.
+
+        Stretching the window instead would make "commanded but dry" take five
+        minutes to notice, and that detection is the only reason the guard
+        exists. So it steps aside rather than growing without limit.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=6.0, cadence_s=FIELD_METER_CADENCE_S)
+        _, verdict = driver.flow_verify_window()
+        assert verdict is not None
+        assert "300" in verdict, "the verdict should name the cadence that caused it"
+
+    def test_an_unknown_cadence_cannot_arm_the_guard(self):
+        """T5: absence of the defining quantity is not licence to invent one.
+
+        This is the branch that produced every field failure. The existing test
+        in test_session_flow.py asserts ``verdict is None`` here, which is the
+        defect written down as an expectation.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=2.0)
+        _, verdict = driver.flow_verify_window()
+        assert verdict is not None, "no cadence means no threshold, so no guard"
+
+    def test_a_prompt_meter_still_gets_a_tight_window(self):
+        """A correct fix must not buy safety by making every window generous."""
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0, cadence_s=14.0)
+        window, verdict = driver.flow_verify_window()
+        assert verdict is None
+        assert window < OLD_CONSTANT_S
+
+
+class TestTheFieldCaseDoesNotRecur:
+    """T12: the regression test for the 2026-09-08 field failure.
+
+    The valve is healthy. What varies is only the phase between the opening and
+    the meter's 300 s grid, and NeverDry does not control that phase: a schedule
+    fires when it fires, and the device's clock is its own.
+
+    So the window must cover the worst case, which is opening one instant after
+    a report -- nearly a full cadence of silence with water already flowing.
+    Anything less is a guard whose verdict depends on a coin toss: with the 90 s
+    constant against a 300 s cadence it passed 90/300 of the time, which is the
+    7-failures-in-10 measured in the field.
+    """
+
+    def test_the_window_covers_a_full_cadence_of_silence(self):
+        driver = _zone(
+            DeliveryMode.FLOW_METER,
+            resolution_l=6.0,
+            cadence_s=FIELD_METER_CADENCE_S,
+        )
+        window, verdict = driver.flow_verify_window()
+        assert verdict is not None or window >= FIELD_METER_CADENCE_S, (
+            f"window of {window:.0f}s against a {FIELD_METER_CADENCE_S:.0f}s cadence: "
+            f"a valve opened just after a report is closed while it is watering"
+        )
+
+    def test_the_old_constant_could_not_have_passed(self):
+        """Guards the reasoning itself, so the constant cannot quietly return.
+
+        Not a test of today's code: a statement that any window shorter than the
+        cadence is unfit, whatever produced it.
+        """
+        assert OLD_CONSTANT_S < FIELD_METER_CADENCE_S
+
+
+class TestFailuresAreAttributedToWhoeverCausedThem:
+    """T10: our own inconclusive check must not be recorded as the device's fault.
+
+    ACTUATION_FAILED reads as "the valve did not actuate", and is documented in
+    valve-state-machine.md as a hydraulic or mechanical issue that retrying
+    cannot unblock. When the real cause is that our window was shorter than the
+    meter's cadence, that verdict names the wrong party -- which is also why the
+    field diagnosis was slow: the log accused a valve that had done its job.
+    """
+
+    def test_an_unknown_cadence_yields_unverifiable_not_a_device_failure(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=2.0)
+        _, verdict = driver.flow_verify_window()
+        assert verdict is not None
+        assert "not applicable" in verdict or "unverifiable" in verdict.lower()
+
+
+class TestTheCadenceIsActuallyLearned:
+    """T16: the measurement must have a caller, or the guard never arms.
+
+    A quantity nothing writes stays None for ever, and a guard that needs it
+    silently never arms. That failure would look exactly like the fix working,
+    which is why it gets its own test rather than being assumed.
+    """
+
+    @staticmethod
+    def _meter_event(value: float):
+        event = MagicMock()
+        state = MagicMock()
+        state.state = str(value)
+        event.data = {"new_state": state}
+        return event
+
+    @pytest.mark.asyncio
+    async def test_two_advances_while_open_teach_the_interval(self, monkeypatch):
+        driver = _zone(DeliveryMode.FLOW_METER)
+        driver._dispatch = AsyncMock()
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: True))
+
+        # One reading per advance: the first advance starts the clock, the
+        # second closes the interval.
+        clock = iter([1000.0, 1000.0 + FIELD_METER_CADENCE_S])
+        monkeypatch.setattr("never_dry.driver.monotonic", lambda: next(clock))
+
+        await driver._handle_flow_state(self._meter_event(10.0))  # first level, no movement yet
+        await driver._handle_flow_state(self._meter_event(16.0))  # advance: starts the clock
+        await driver._handle_flow_state(self._meter_event(22.0))  # advance: 300 s later
+
+        assert driver._session_flow.refresh_cadence_s == pytest.approx(FIELD_METER_CADENCE_S)
+
+    @pytest.mark.asyncio
+    async def test_a_gap_between_irrigations_is_not_a_cadence(self, monkeypatch):
+        """With the valve shut the counter stands still for hours.
+
+        Taking that as the cadence would push the window past any useful guard
+        and disable verification on a perfectly prompt meter.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER)
+        driver._dispatch = AsyncMock()
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: False))
+        monkeypatch.setattr("never_dry.driver.monotonic", lambda: 1000.0)
+
+        await driver._handle_flow_state(self._meter_event(10.0))
+        await driver._handle_flow_state(self._meter_event(16.0))
+
+        assert driver._session_flow.refresh_cadence_s is None

--- a/tests/test_delivery_contract.py
+++ b/tests/test_delivery_contract.py
@@ -326,9 +326,12 @@ class TestTheCadenceIsActuallyLearned:
         driver._dispatch = AsyncMock()
         monkeypatch.setattr(type(driver), "is_open", property(lambda self: True))
 
-        # One reading per advance: the first advance starts the clock, the
-        # second closes the interval.
-        clock = iter([1000.0, 1000.0 + FIELD_METER_CADENCE_S])
+        # Two consumers read the clock per publication now: every report is
+        # timed for the publication cadence, and an advance is timed again for
+        # this one. The advances land on readings 3 and 5, so those are the two
+        # that have to sit a cadence apart.
+        t0 = 1000.0
+        clock = iter([t0, t0, t0, t0 + FIELD_METER_CADENCE_S, t0 + FIELD_METER_CADENCE_S])
         monkeypatch.setattr("never_dry.driver.monotonic", lambda: next(clock))
 
         await driver._handle_flow_state(self._meter_event(10.0))  # first level, no movement yet
@@ -352,6 +355,137 @@ class TestTheCadenceIsActuallyLearned:
         await driver._handle_flow_state(self._meter_event(10.0))
         await driver._handle_flow_state(self._meter_event(16.0))
 
+        assert driver._session_flow.refresh_cadence_s is None
+
+
+class TestTheCadenceSurvivesAShortDose:
+    """The field case of 2026-09-09, and why the older rule could never see it.
+
+    Melograno was dosed for 171 s by a meter on a 300 s clock. Across the whole
+    session the counter never advanced, so it never spoke twice while open and
+    the cadence stayed unmeasured for ever. Its closing word landed 39 s after
+    the valve shut -- outside the old rule in both respects, being neither an
+    advance nor something observed while open.
+
+    So publications are timed rather than advances, and the timing runs on past
+    the close. Both departures are needed: either one alone still misses this.
+    """
+
+    @staticmethod
+    def _meter_event(value: float):
+        event = MagicMock()
+        state = MagicMock()
+        state.state = str(value)
+        event.data = {"new_state": state}
+        return event
+
+    @pytest.mark.asyncio
+    async def test_the_closing_tick_after_the_valve_shut_still_teaches_the_cadence(self, monkeypatch):
+        """21:05:02 open, 21:09:21 closed, 21:10:00 the meter finally speaks."""
+        driver = _zone(DeliveryMode.FLOW_METER)
+        driver._dispatch = AsyncMock()
+        open_now = True
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: open_now))
+
+        now = 1000.0
+        monkeypatch.setattr("never_dry.driver.monotonic", lambda: now)
+        await driver._handle_flow_state(self._meter_event(19.0))  # while open
+
+        open_now = False  # the valve shuts, and the meter has not spoken since
+        now = 1000.0 + 298.0
+        await driver._handle_flow_state(self._meter_event(39.0))
+
+        assert driver._session_flow.publication_median_s == pytest.approx(298.0)
+
+    @pytest.mark.asyncio
+    async def test_a_republication_with_no_new_water_is_still_a_publication(self, monkeypatch):
+        """A meter repeating itself is timing information, not a flow observation.
+
+        It must reach the cadence and nothing else: fed to the state machine a
+        repeat would argue that a running zone is dry.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER)
+        driver._dispatch = AsyncMock()
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: True))
+
+        now = 1000.0
+        monkeypatch.setattr("never_dry.driver.monotonic", lambda: now)
+        driver._on_flow_report(self._meter_event(19.0))
+        now = 1000.0 + FIELD_METER_CADENCE_S
+        driver._on_flow_report(self._meter_event(19.0))
+
+        assert driver._session_flow.publication_median_s == pytest.approx(FIELD_METER_CADENCE_S)
+        driver._dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_silence_between_two_irrigations_is_not_a_cadence(self, monkeypatch):
+        """Both ends of a gap must be under observation, and the gap must fit.
+
+        A zone watered once a day would otherwise report a cadence of 24 hours,
+        which is the schedule talking, not the meter.
+        """
+        driver = _zone(DeliveryMode.FLOW_METER)
+        driver._dispatch = AsyncMock()
+        monkeypatch.setattr(type(driver), "is_open", property(lambda self: True))
+
+        now = 1000.0
+        monkeypatch.setattr("never_dry.driver.monotonic", lambda: now)
+        await driver._handle_flow_state(self._meter_event(19.0))
+        now = 1000.0 + 86400.0  # same time tomorrow
+        await driver._handle_flow_state(self._meter_event(25.0))
+
+        assert driver._session_flow.publication_median_s is None
+
+    def test_what_reaches_the_card_is_the_median_not_the_worst_case(self):
+        """One long gap is an artefact -- a restart, a device off the mesh."""
+        driver = _zone(DeliveryMode.FLOW_METER)
+        for interval in (300.0, 300.0, 300.0, 590.0):
+            driver._session_flow.observe_publication_interval(interval)
+
+        assert driver.meter_publication_median_s == pytest.approx(300.0)
+        assert driver.meter_publication_peak_s == pytest.approx(590.0)
+
+
+class TestTheWaitFollowsTheMeasuredMeter:
+    """The 30 s constant is what lost the field sample, by nine seconds."""
+
+    def test_an_unmeasured_meter_keeps_the_historical_constant(self):
+        driver = _zone(DeliveryMode.FLOW_METER)
+        assert driver.settle_delay_s == pytest.approx(30.0)
+
+    def test_a_measured_meter_is_waited_for(self):
+        driver = _zone(DeliveryMode.FLOW_METER)
+        for _ in range(3):
+            driver._session_flow.observe_publication_interval(FIELD_METER_CADENCE_S)
+
+        # 39 s late was enough to miss it; the wait now clears that by minutes.
+        assert driver.settle_delay_s > 39.0
+        assert driver.settle_delay_s == pytest.approx(FIELD_METER_CADENCE_S * 1.5)
+
+    def test_the_wait_stays_bounded_on_a_very_slow_meter(self):
+        driver = _zone(DeliveryMode.FLOW_METER)
+        for _ in range(3):
+            driver._session_flow.observe_publication_interval(599.0)
+
+        assert driver.settle_delay_s <= 600.0
+
+
+class TestMeasuringTheMeterDoesNotArmTheGuard:
+    """Non-regression: the guard keeps its own, stricter evidence.
+
+    Publication timing is generous on purpose -- it observes, and observing
+    cannot misfire. The guard closes valves, so it still rests on the worst gap
+    between *advances while water flows*. Letting the lenient measurement arm
+    the strict decision is exactly how a healthy valve gets closed again.
+    """
+
+    def test_a_measured_publication_cadence_leaves_verification_inapplicable(self):
+        driver = _zone(DeliveryMode.FLOW_METER, resolution_l=1.0)
+        for _ in range(5):
+            driver._session_flow.observe_publication_interval(20.0)
+
+        _, verdict = driver.flow_verify_window()
+        assert verdict is not None
         assert driver._session_flow.refresh_cadence_s is None
 
 

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -1328,3 +1328,80 @@ class TestTheRateToEstimateWith:
         credited = ctrl._fallback_volume_estimate(zone, elapsed_s=600.0, measured=0.0)
 
         assert credited == pytest.approx(3.4 * 600.0 / 60.0)
+
+
+class TestTheMeterFactsReachTheCard:
+    """The card reads the carrier entity's attributes; the facts must be there.
+
+    Without these the user cannot see why a zone behaves as it does: a meter
+    reporting every 300 s on a session lasting 359 s is visibly unfit to
+    supervise it, but only if the number is on screen. Diagnosing it took a
+    manual read of the recorder.
+    """
+
+    def _zone_with_meter(self, hass_mock, di_sensor, cadence, resolution):
+        zone = _make_zone(
+            hass_mock,
+            di_sensor,
+            **{
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.meter",
+            },
+        )
+        operator = MagicMock()
+        operator.meter_refresh_cadence_s = cadence
+        operator.meter_refresh_samples = 7
+        operator.meter_refresh_kind = "periodic"
+        operator.meter_guard_usable = False
+        zone._operator = operator
+        return zone
+
+    def test_the_cadence_and_its_meaning_are_published(self, hass_mock, di_sensor):
+        zone = self._zone_with_meter(hass_mock, di_sensor, cadence=300.0, resolution=2.0)
+        attrs = zone.extra_state_attributes
+        assert attrs["meter_refresh_s"] == 300
+        assert attrs["meter_refresh_kind"] == "periodic"
+        assert attrs["meter_refresh_samples"] == 7
+        assert attrs["meter_guard_usable"] is False
+
+    def test_a_zone_without_a_meter_publishes_none_of_it(self, hass_mock, di_sensor):
+        """No meter, no meter facts: empty keys would read as measured zeroes."""
+        zone = _make_zone(hass_mock, di_sensor)
+        zone._operator = None
+        assert "meter_refresh_s" not in zone.extra_state_attributes
+
+    def test_an_unmeasured_cadence_is_absent_rather_than_zero(self, hass_mock, di_sensor):
+        zone = self._zone_with_meter(hass_mock, di_sensor, cadence=None, resolution=None)
+        zone._operator.meter_refresh_cadence_s = None
+        zone._operator.meter_refresh_kind = None
+        assert "meter_refresh_s" not in zone.extra_state_attributes
+        assert zone.extra_state_attributes["meter_refresh_samples"] == 7
+
+
+class TestTheCardActuallyReadsTheDeliveryFacts:
+    """A static guard: the attributes existed for months and nothing read them.
+
+    ``delivery_mode`` and ``flow_meter_sensor`` were already published on the
+    carrier entity, and the card never mentioned either. The user could not
+    tell a zone dosing by time from one dosing by measured volume, which is
+    also the difference between who answers for the water. Reaching the card
+    is what makes a capability real, so it gets a test of its own.
+    """
+
+    def test_the_card_reads_the_delivery_mode(self):
+        src = _CARD.read_text(encoding="utf-8")
+        assert "delivery_mode" in src
+        for mode in ("estimated_flow", "flow_meter", "volume_preset"):
+            assert mode in src, f"the card cannot name {mode}"
+
+    def test_the_card_reads_the_meter_cadence(self):
+        src = _CARD.read_text(encoding="utf-8")
+        assert "meter_refresh_s" in src
+        assert "meter_refresh_kind" in src
+        assert "flow_meter_sensor" in src
+
+    def test_the_cell_is_rendered_and_not_merely_defined(self):
+        """The defect this whole change is about: defined, never called."""
+        src = _CARD.read_text(encoding="utf-8")
+        assert "_deliveryCell(" in src
+        assert src.count("_deliveryCell(") >= 2, "defined but never invoked"

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -563,8 +563,8 @@ class TestSettleWaterAccounting:
 
         assert zone._zone_deficit == 0.0
         assert zone._total_water_delivered == pytest.approx(total_before + target, abs=0.2)
-        assert zone._session_water_delivered == pytest.approx(target, abs=0.2)
         assert zone._last_volume_delivered == pytest.approx(target, abs=0.2)
+        assert zone._session_water_delivered == 0.0, "the cycle closed, so its running total did too"
 
     @pytest.mark.asyncio
     async def test_partial_flow_meter_delivery_credits_actual_volume(self, controller, zone_orto):
@@ -583,7 +583,8 @@ class TestSettleWaterAccounting:
         # Partial: deficit reduced but not zero, counters reflect partial volume.
         assert zone._zone_deficit > 0.0
         assert zone._total_water_delivered == pytest.approx(partial, abs=0.2)
-        assert zone._session_water_delivered == pytest.approx(partial, abs=0.2)
+        assert zone._last_volume_delivered == pytest.approx(partial, abs=0.2)
+        assert zone._session_water_delivered == 0.0
 
     def test_estimated_flow_no_timeout_in_attributes(self, hass_mock, di_sensor):
         zone = _make_zone(hass_mock, di_sensor)

--- a/tests/test_delivery_modes.py
+++ b/tests/test_delivery_modes.py
@@ -1349,6 +1349,11 @@ class TestTheMeterFactsReachTheCard:
             },
         )
         operator = MagicMock()
+        # What the card shows is the typical gap; the worst one rides along
+        # because it is what sizes the post-close wait.
+        operator.meter_publication_median_s = cadence
+        operator.meter_publication_peak_s = cadence
+        operator.meter_publication_samples = 7
         operator.meter_refresh_cadence_s = cadence
         operator.meter_refresh_samples = 7
         operator.meter_refresh_kind = "periodic"
@@ -1375,6 +1380,7 @@ class TestTheMeterFactsReachTheCard:
         zone._operator.meter_refresh_cadence_s = None
         zone._operator.meter_refresh_kind = None
         assert "meter_refresh_s" not in zone.extra_state_attributes
+        assert "meter_refresh_peak_s" not in zone.extra_state_attributes
         assert zone.extra_state_attributes["meter_refresh_samples"] == 7
 
 
@@ -1405,3 +1411,34 @@ class TestTheCardActuallyReadsTheDeliveryFacts:
         src = _CARD.read_text(encoding="utf-8")
         assert "_deliveryCell(" in src
         assert src.count("_deliveryCell(") >= 2, "defined but never invoked"
+
+    def test_the_meter_has_a_cell_of_its_own_and_it_is_rendered(self):
+        """Three facts in one value are two facts nobody reads.
+
+        A cell value is clipped at one column's width, so the cadence appended
+        after the dosing mode was cut off on every zone that had one. Splitting
+        it is the fix, and a split cell that is never invoked is the same
+        defect wearing a different name.
+        """
+        src = _CARD.read_text(encoding="utf-8")
+        assert src.count("_meterRefreshCell(") >= 2, "defined but never invoked"
+
+    def test_the_card_can_tell_measuring_from_never_measured(self):
+        """Two silences that ask different things of the user.
+
+        "Not measured yet" invites a look at the configuration; "measuring
+        (1/3)" says the figure is on its way and there is nothing to do. The
+        threshold comes from the integration rather than a number retyped here,
+        because the two drifting apart is how a card starts lying quietly.
+        """
+        src = _CARD.read_text(encoding="utf-8")
+        assert "meter_refresh_min_samples" in src
+        assert "meterMeasuring" in src
+        assert "meterRefreshUnknown" in src
+
+    def test_the_qualifiers_moved_out_of_the_clipped_line(self):
+        """The guard caveat belongs to the label, which wraps, not the value."""
+        src = _CARD.read_text(encoding="utf-8")
+        cell = src.split("_meterRefreshCell(a) {", 1)[1].split("\n  }", 1)[0]
+        assert "meterGuardOff" in cell, "the caveat left the dosing cell but never arrived"
+        assert "label +=" in cell, "the caveat must lengthen the label, not the value"

--- a/tests/test_end_trigger_matrix.py
+++ b/tests/test_end_trigger_matrix.py
@@ -187,7 +187,9 @@ def _assert_partial_with_residual(zone, *, max_running_s):
     assert zone._last_irrigation_source != "manual"
     # History written once: totals match the single credited session.
     assert zone._total_water_delivered == pytest.approx(delivered, abs=0.06)
-    assert zone._session_water_delivered == pytest.approx(delivered, abs=0.06)
+    assert zone._last_volume_delivered == pytest.approx(delivered, abs=0.06)
+    # However the session ended, its running total stops running with it.
+    assert zone._session_water_delivered == 0.0
     assert zone._last_irrigated is not None
     # Running time coherent with the credited volume (guard-flow credit:
     # delivered = FLOW x elapsed / 60 -> elapsed = delivered x 60 / FLOW).

--- a/tests/test_meter_ownership.py
+++ b/tests/test_meter_ownership.py
@@ -1,0 +1,212 @@
+"""A zone must not be judged by another zone's water meter.
+
+Field case, 2026-09-09: while fixing an unrelated problem the flow meter of
+"Giardino Melograno" was set to the counter belonging to "Giardino Melino".
+Melino irrigates at 06:00, so at 22:00 its counter sat still, the open guard
+saw no flow, and every session of Melograno failed while the valve watered
+normally. Nothing in the UI said the two belonged to different devices.
+
+A meter on a different device is not wrong by itself: an in-line flow meter
+installed on the pipe is a legitimate setup, and NeverDry consumes whatever
+entity the user points at. What is almost certainly a mistake is pointing a
+zone at the meter of *another configured zone's valve*, and that is what these
+guards catch. A warning, not a rejection: the boundary rule is that NeverDry
+consumes HA entities and does not dictate the plumbing.
+"""
+
+import pytest
+from never_dry import config_flow as cf
+from never_dry.const import (
+    CONF_ZONE_AREA,
+    CONF_ZONE_DELIVERY_MODE,
+    CONF_ZONE_FLOW_METER_SENSOR,
+    CONF_ZONE_FLOW_RATE,
+    CONF_ZONE_NAME,
+    CONF_ZONE_VALVE,
+    DELIVERY_MODE_ESTIMATED_FLOW,
+    DELIVERY_MODE_FLOW_METER,
+)
+
+#: Entity ids with nothing zone-like in them, for the naming-independence tests.
+OPAQUE_DEVICES = {
+    "switch.0x00124b0022ab": "dev_a",
+    "sensor.0x00124b0022ab_volume": "dev_a",
+    "switch.0x00124b0099ff": "dev_b",
+    "sensor.0x00124b0099ff_volume": "dev_b",
+}
+
+
+@pytest.fixture
+def _flow_env(monkeypatch):
+    """Fill the gaps in the conftest HA stubs for driving flow steps.
+
+    Same shim as tests/test_zone_config_guards.py: the stubbed
+    ``homeassistant`` is not a package and the stub flow base classes have no
+    ``async_show_form``. Patch just enough to run the steps and read back
+    where they routed.
+    """
+    monkeypatch.setattr(cf, "_is_imperial", lambda hass: False)
+    monkeypatch.setattr(cf.vol, "Schema", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cf.vol, "Required", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf.vol, "Optional", lambda *a, **k: object(), raising=False)
+    monkeypatch.setattr(cf, "_confirm_zone_schema", lambda: None)
+    monkeypatch.setattr(cf, "_zone_schema_initial", lambda imperial, current=None: None)
+
+    def _show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+        return {"type": "form", "step_id": step_id, "errors": errors}
+
+    def _create_entry(self, *, data=None, title=None):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    for klass in (cf.NeverDryConfigFlow, cf.NeverDryOptionsFlow):
+        monkeypatch.setattr(klass, "async_show_form", _show_form, raising=False)
+        monkeypatch.setattr(klass, "async_create_entry", _create_entry, raising=False)
+
+
+MELOGRANO_VALVE = "switch.giardino_melograno"
+MELOGRANO_METER = "sensor.giardino_melograno_real_time_irrigation_volume"
+MELINO_VALVE = "switch.giardino_melino"
+MELINO_METER = "sensor.giardino_melino_real_time_irrigation_volume"
+INLINE_METER = "sensor.main_pipe_flow"
+
+#: entity -> device, as the entity registry would resolve it.
+DEVICES = {
+    MELOGRANO_VALVE: "dev_melograno",
+    MELOGRANO_METER: "dev_melograno",
+    MELINO_VALVE: "dev_melino",
+    MELINO_METER: "dev_melino",
+    INLINE_METER: "dev_pipe_sensor",
+}
+
+
+def _zone(name, valve, meter=None, mode=DELIVERY_MODE_FLOW_METER):
+    zone = {CONF_ZONE_NAME: name, CONF_ZONE_VALVE: valve, CONF_ZONE_DELIVERY_MODE: mode}
+    if meter is not None:
+        zone[CONF_ZONE_FLOW_METER_SENSOR] = meter
+    return zone
+
+
+OTHER_ZONES = [_zone("Giardino Melino", MELINO_VALVE, MELINO_METER)]
+
+
+class TestAMeterBelongingToAnotherZoneIsFlagged:
+    def test_the_field_case_is_caught(self):
+        """T13: Melograno pointed at Melino's counter."""
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, MELINO_METER)
+        warnings = cf.meter_ownership_warnings(zone, OTHER_ZONES, DEVICES.get)
+        assert warnings, "a meter owned by another zone's valve must be reported"
+        assert "Melino" in warnings[0], "the warning must name the zone it belongs to"
+
+    def test_the_zones_own_meter_is_silent(self):
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, MELOGRANO_METER)
+        assert cf.meter_ownership_warnings(zone, OTHER_ZONES, DEVICES.get) == []
+
+    def test_an_inline_meter_on_its_own_device_is_allowed(self):
+        """Not every separate device is a mistake: a pipe meter is a real setup.
+
+        Warning on this would train the user to ignore the warning that matters.
+        """
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, INLINE_METER)
+        assert cf.meter_ownership_warnings(zone, OTHER_ZONES, DEVICES.get) == []
+
+    def test_an_unresolvable_entity_is_not_an_accusation(self):
+        """A registry that cannot answer is not evidence of a wrong meter."""
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, "sensor.unknown_to_the_registry")
+        assert cf.meter_ownership_warnings(zone, OTHER_ZONES, lambda _e: None) == []
+
+
+class TestAMeteredModeNeedsAMeter:
+    def test_flow_meter_without_a_meter_is_reported(self):
+        """T14: the mode measures volume, so the measuring device is not optional."""
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, meter=None)
+        warnings = cf.meter_ownership_warnings(zone, [], DEVICES.get)
+        assert warnings
+        assert "flow meter" in warnings[0].lower()
+
+    def test_estimated_flow_without_a_meter_is_perfectly_normal(self):
+        """The mode whose contract is 'I measure nothing' must stay silent."""
+        zone = _zone("Giardino Melograno", MELOGRANO_VALVE, meter=None, mode=DELIVERY_MODE_ESTIMATED_FLOW)
+        assert cf.meter_ownership_warnings(zone, [], DEVICES.get) == []
+
+
+class TestTheCheckDoesNotDependOnNaming:
+    """Ownership is decided by the device registry, never by string matching.
+
+    Verified against the field registry on 2026-09-09: for all four zones the
+    valve entity and its volume counter share one device_id. The clearest case
+    is a zone whose device is named "Vavola Irrigazione Ortensia" (the typo is
+    the user's) while its entities are named "giardino_ortensia_*": the names
+    do not match each other, and the device does. A check that compared names
+    would have missed that zone and every zone named after the plant rather
+    than the hardware.
+
+    So the entities below are deliberately opaque: nothing in them names a zone.
+    """
+
+    def test_another_zones_meter_is_caught_without_any_name_clue(self):
+        zone = _zone("Roses", "switch.0x00124b0022ab", "sensor.0x00124b0099ff_volume")
+        others = [_zone("Lawn", "switch.0x00124b0099ff", "sensor.0x00124b0099ff_volume")]
+        warnings = cf.meter_ownership_warnings(zone, others, OPAQUE_DEVICES.get)
+        assert warnings
+        assert "Lawn" in warnings[0]
+
+    def test_its_own_meter_is_silent_without_any_name_clue(self):
+        zone = _zone("Roses", "switch.0x00124b0022ab", "sensor.0x00124b0022ab_volume")
+        others = [_zone("Lawn", "switch.0x00124b0099ff", "sensor.0x00124b0099ff_volume")]
+        assert cf.meter_ownership_warnings(zone, others, OPAQUE_DEVICES.get) == []
+
+
+class TestTheWarningReachesTheUserAndCanBeOverridden:
+    """The guard joins the existing soft-confirm, it does not add a new gate.
+
+    Two things are being tested at once, and both matter:
+
+    - the warning actually reaches the form. A pure function nobody calls would
+      pass every test above and change nothing for the user;
+    - the user can proceed anyway. Ownership is a strong hint, never proof: two
+      zones fed by one physical valve, or a meter deliberately shared, are the
+      user's business. A guard that cannot be overridden would make a legitimate
+      installation impossible to configure, which is worse than the mistake it
+      prevents.
+    """
+
+    @pytest.fixture
+    def _flow(self, hass_mock, monkeypatch, _flow_env):
+        monkeypatch.setattr(cf, "_device_resolver", lambda _hass: OPAQUE_DEVICES.get)
+        flow = cf.NeverDryConfigFlow()
+        flow.hass = hass_mock
+        flow._zones = [_zone("Lawn", "switch.0x00124b0099ff", "sensor.0x00124b0099ff_volume")]
+        return flow
+
+    @pytest.mark.asyncio
+    async def test_it_routes_to_the_confirmation_step(self, _flow):
+        result = await _flow.async_step_zone(
+            {
+                CONF_ZONE_NAME: "Roses",
+                CONF_ZONE_VALVE: "switch.0x00124b0022ab",
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.0x00124b0099ff_volume",
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_AREA: 15.0,
+                CONF_ZONE_FLOW_RATE: 264.0,
+            },
+        )
+        assert result["step_id"] == "confirm_zone"
+        assert any("Lawn" in w for w in _flow._pending_warnings)
+        assert len(_flow._zones) == 1, "nothing saved until the user answers"
+
+    @pytest.mark.asyncio
+    async def test_confirming_saves_the_zone_anyway(self, _flow):
+        await _flow.async_step_zone(
+            {
+                CONF_ZONE_NAME: "Roses",
+                CONF_ZONE_VALVE: "switch.0x00124b0022ab",
+                CONF_ZONE_FLOW_METER_SENSOR: "sensor.0x00124b0099ff_volume",
+                CONF_ZONE_DELIVERY_MODE: DELIVERY_MODE_FLOW_METER,
+                CONF_ZONE_AREA: 15.0,
+                CONF_ZONE_FLOW_RATE: 264.0,
+            },
+        )
+
+        await _flow.async_step_confirm_zone({"confirm": True})
+
+        assert [z[CONF_ZONE_NAME] for z in _flow._zones] == ["Lawn", "Roses"]

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -99,11 +99,26 @@ def _driver(hass) -> ZoneDriver:
     )
 
 
+@pytest.fixture
+def meter_answers_at_once(monkeypatch):
+    """Skip the wait for the meter's closing publication.
+
+    The read blocks until the counter publishes, which is the whole point of
+    it; these tests are about what the sample is made of, not about when it is
+    taken, so they let the wait return and get on with it.
+    """
+
+    async def _immediate(awaitable, timeout):
+        awaitable.close()
+        return True
+
+    monkeypatch.setattr("never_dry.driver.asyncio.wait_for", _immediate)
+
+
 class TestTheSampleComesFromTheMeterAndTheClock:
     @pytest.mark.asyncio
-    async def test_it_divides_the_counter_difference_by_the_session(self, monkeypatch):
+    async def test_it_divides_the_counter_difference_by_the_session(self, meter_answers_at_once):
         """100 L over 10 minutes is 10 L/min, whatever the zone was configured at."""
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", AsyncMock())
         hass = _hass_with_meter([1100.0])
         driver = _driver(hass)
 
@@ -114,21 +129,26 @@ class TestTheSampleComesFromTheMeterAndTheClock:
         assert driver._session_flow.window._samples[0] == pytest.approx(10.0)
 
     @pytest.mark.asyncio
-    async def test_it_waits_before_reading_so_late_ticks_still_count(self, monkeypatch):
-        """The last tick of a session routinely lands after the valve is shut."""
-        sleeper = AsyncMock()
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", sleeper)
+    async def test_it_waits_for_the_closing_tick_instead_of_guessing_when(self):
+        """The last tick of a session routinely lands after the valve is shut.
+
+        How long after is the meter's business, and it announces it. Reading on
+        a timer instead threw away a healthy sample on both field zones.
+        """
         hass = _hass_with_meter([1050.0])
         driver = _driver(hass)
 
-        await driver._record_flow_sample("sensor.meter", baseline=1000.0, session_s=600.0)
+        pending = asyncio.ensure_future(driver._record_flow_sample("sensor.meter", baseline=1000.0, session_s=600.0))
+        await asyncio.sleep(0)
+        assert driver._session_flow.window.sample_count == 0, "read before the meter spoke"
 
-        sleeper.assert_awaited_once()
-        assert sleeper.await_args.args[0] > 0
+        driver._note_meter_publication()
+        await asyncio.wait_for(pending, timeout=1.0)
+
+        assert driver._session_flow.window.sample_count == 1
 
     @pytest.mark.asyncio
-    async def test_a_counter_that_did_not_move_yields_no_sample(self, monkeypatch):
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", AsyncMock())
+    async def test_a_counter_that_did_not_move_yields_no_sample(self, meter_answers_at_once):
         hass = _hass_with_meter([1000.0])
         driver = _driver(hass)
 
@@ -137,9 +157,8 @@ class TestTheSampleComesFromTheMeterAndTheClock:
         assert driver._session_flow.window.sample_count == 0
 
     @pytest.mark.asyncio
-    async def test_a_counter_that_reset_yields_no_sample(self, monkeypatch):
+    async def test_a_counter_that_reset_yields_no_sample(self, meter_answers_at_once):
         """A reset makes the difference negative; a guess would be worse than a gap."""
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", AsyncMock())
         hass = _hass_with_meter([5.0])
         driver = _driver(hass)
 
@@ -148,8 +167,7 @@ class TestTheSampleComesFromTheMeterAndTheClock:
         assert driver._session_flow.window.sample_count == 0
 
     @pytest.mark.asyncio
-    async def test_an_unreadable_meter_yields_no_sample(self, monkeypatch):
-        monkeypatch.setattr("never_dry.driver.asyncio.sleep", AsyncMock())
+    async def test_an_unreadable_meter_yields_no_sample(self, meter_answers_at_once):
         hass = _hass_with_meter(["unavailable"])
         driver = _driver(hass)
 

--- a/tests/test_session_flow.py
+++ b/tests/test_session_flow.py
@@ -231,7 +231,7 @@ class TestTheFlowVerificationWindowComesFromTheZone:
     window has to be resolution over flow rate, not a constant.
     """
 
-    def _driver_with(self, resolution=None, lpm=6.0):
+    def _driver_with(self, resolution=None, lpm=6.0, cadence=None):
         from never_dry.driver import FLOW_VERIFY_MARGIN  # noqa: F401
 
         hass = _hass_with_meter([0.0])
@@ -239,30 +239,44 @@ class TestTheFlowVerificationWindowComesFromTheZone:
         driver._flow_rate_lpm = lpm
         if resolution:
             driver._session_flow.resolution_l = resolution
+        if cadence:
+            driver._session_flow.refresh_cadence_s = cadence
         return driver
 
-    def test_without_a_known_resolution_it_is_conservative_not_strict(self):
-        """The old constant is what closed working valves; absence must not be strict."""
-        from never_dry.driver import FLOW_VERIFY_UNKNOWN_RESOLUTION_S
+    def test_without_a_known_cadence_the_guard_stands_down(self):
+        """Absence of the defining quantity must disarm, not soften.
 
+        This test used to assert ``verdict is None`` here, with a 90 s constant:
+        conservative in duration, unchanged in power. It kept the right to close
+        the valve while admitting it did not know how long to wait, and that is
+        the branch that closed a healthy zone seven times out of ten in the
+        field (2026-09-08). Waiting longer was never the fix; not judging was.
+        """
         window, verdict = self._driver_with().flow_verify_window()
-        assert window == FLOW_VERIFY_UNKNOWN_RESOLUTION_S
+        assert verdict is not None
+        assert "not applicable" in verdict
         assert window > 10.0
-        assert verdict is None
 
     def test_the_reported_case_gets_a_window_that_can_pass(self):
-        """1 L at 1.2 L/min → ~50 s to first tick, so the window must exceed it."""
-        driver = self._driver_with(resolution=1.0, lpm=1.2)
+        """GH #173: a meter that needs ~50 s to move must not be judged at 10 s.
+
+        The quantity is now the observed cadence rather than
+        ``resolution / rate``: same protection, measured on the device instead
+        of predicted from it. ``time_to_first_tick_s`` is kept as diagnostics
+        and still answers, but no longer sizes the window.
+        """
+        driver = self._driver_with(resolution=1.0, lpm=1.2, cadence=50.0)
         assert driver.time_to_first_tick_s() == pytest.approx(50.0)
         window, verdict = driver.flow_verify_window()
         assert window > 50.0
         assert verdict is None
 
     def test_a_fast_zone_keeps_a_tight_window(self):
-        """A meter that ticks immediately must not buy a lax guard."""
+        """A meter that reports promptly must not buy a lax guard."""
         from never_dry.driver import FLOW_VERIFY_MIN_S
 
-        window, verdict = self._driver_with(resolution=0.1, lpm=20.0).flow_verify_window()
+        driver = self._driver_with(resolution=0.1, lpm=20.0, cadence=2.0)
+        window, verdict = driver.flow_verify_window()
         assert window == FLOW_VERIFY_MIN_S
         assert verdict is None
 

--- a/tests/test_valve_compatibility_table.py
+++ b/tests/test_valve_compatibility_table.py
@@ -59,6 +59,8 @@ def test_every_row_declares_the_columns_the_verdict_rule_reads():
         "history",
         "needs_config",
         "caveat",
+        "meter_update_s",
+        "meter_update_kind",
         "reported_by",
     }
     rows = list(csv.DictReader(_CSV.open(encoding="utf-8")))
@@ -95,3 +97,39 @@ def test_a_row_with_no_measurement_is_timer_only_not_bad():
     tier, reason = module._verdict(barebones)
     assert tier == "timer-only"
     assert "clock" in reason or "delivered" in reason
+
+
+def test_a_meter_that_speaks_on_a_clock_cannot_be_top_tier():
+    """The row that caused the field failure of 2026-09-08 must not read "good".
+
+    A SONOFF SWV-ZFE reports every 300 s whatever the flow. Everything else about it
+    looks excellent on this table -- a session counter, an hourly total -- and on those
+    columns alone the old rule rated it top tier. Someone choosing hardware from that
+    row would buy a valve NeverDry cannot supervise, which is the failure this page
+    exists to prevent.
+    """
+    module = _builder()
+    on_a_clock = {
+        "flow_rate": "no",
+        "volume_session": "yes",
+        "volume_aggregate": "hourly",
+        "history": "on_request",
+        "needs_config": "history",
+        "caveat": "",
+        "meter_update_s": "300",
+        "meter_update_kind": "periodic",
+    }
+    tier, reason = module._verdict(on_a_clock)
+    assert tier == "partial"
+    assert "300" in reason, "the reason must name the cadence that caused it"
+
+    prompt = {**on_a_clock, "meter_update_s": "14", "meter_update_kind": "volume"}
+    assert module._verdict(prompt)[0] == "good", "a prompt meter must not be dragged down with it"
+
+
+def test_an_unmeasured_cadence_is_not_read_as_a_fast_one():
+    """Unknown is not a synonym for fine, and it must not silently become one."""
+    module = _builder()
+    assert module._guards_openings({"meter_update_s": ""}) is None
+    assert module._guards_openings({"meter_update_s": "300"}) is False
+    assert module._guards_openings({"meter_update_s": "14"}) is True

--- a/tests/test_valve_fsm.py
+++ b/tests/test_valve_fsm.py
@@ -129,6 +129,30 @@ def test_open_timeout(fsm_no_flow):
     assert fsm_no_flow.last_failure == FailureKind.OPEN_FAILED
 
 
+def test_an_unverifiable_flow_lets_the_run_proceed(fsm_with_flow):
+    """The transition that separates the field defect from its fix.
+
+    ``TIMEOUT_FLOW`` and ``FLOW_UNVERIFIABLE`` reach the FSM from the same
+    timer, in the same state, and mean opposite things: the first is "the pipe
+    is dry", the second is "we could not tell, because this meter's cadence is
+    longer than any window worth waiting". Only the first may close the valve.
+
+    Untested until now, which meant the whole fix could be reverted at this
+    line and the suite would stay green -- the driver would still decline to
+    arm the guard, the FSM would still close the valve, and the field failure
+    of 2026-09-08 would come back with every one of its tests passing.
+    """
+    _drive_to(fsm_with_flow, ValveEvent.CMD_OPEN, ValveEvent.OBS_SWITCH_ON)
+    assert fsm_with_flow.state == ValveState.OPEN
+
+    r = fsm_with_flow.dispatch(ValveEvent.FLOW_UNVERIFIABLE)
+
+    assert r.to_state == ValveState.OPEN_VERIFIED, "the session must go on watering"
+    assert r.failure is None, "an inconclusive check of ours is not the valve's failure"
+    assert SendSwitchOff() not in r.actions
+    assert fsm_with_flow.failure_count == 0
+
+
 def test_actuation_failure_sends_switch_off(fsm_with_flow):
     """TIMEOUT_FLOW from OPEN emits SendSwitchOff as belt-and-suspenders."""
     _drive_to(fsm_with_flow, ValveEvent.CMD_OPEN, ValveEvent.OBS_SWITCH_ON)

--- a/tests/test_volume_duration.py
+++ b/tests/test_volume_duration.py
@@ -136,8 +136,8 @@ class TestResetDeficitAccounting:
 
         assert zone._zone_deficit == 0.0
         assert zone._last_volume_delivered == needed
-        assert zone._session_water_delivered == needed
         assert zone._total_water_delivered == needed
+        assert zone._session_water_delivered == 0.0
 
     def test_credits_explicit_delivered_volume(self, di_sensor):
         """Flow-metered full delivery: credit the measured volume, not the
@@ -151,8 +151,8 @@ class TestResetDeficitAccounting:
 
         assert zone._zone_deficit == 0.0
         assert zone._last_volume_delivered == pytest.approx(measured, abs=0.1)
-        assert zone._session_water_delivered == pytest.approx(measured, abs=0.1)
         assert zone._total_water_delivered == pytest.approx(measured, abs=0.1)
+        assert zone._session_water_delivered == 0.0
 
 
 class TestNativeValue:

--- a/tests/test_zone_deficit_sensor.py
+++ b/tests/test_zone_deficit_sensor.py
@@ -18,6 +18,7 @@ from never_dry.sensor import (
     IrrigationZoneSensor,
     ZoneDeficitSensor,
     ZoneRainSensor,
+    ZoneSessionWaterSensor,
     ZoneYearlyWaterSensor,
 )
 
@@ -40,6 +41,54 @@ def _make_zone(di_sensor, name="Orto", area=20.0, efficiency=0.90):
         CONF_ZONE_THRESHOLD: 15.0,
     }
     return IrrigationZoneSensor(_make_hass(), zone_config, di_sensor)
+
+
+class TestTheCardIsToldWhenASessionEnds:
+    """Refreshing on the periodic broadcast alone is refreshing too late.
+
+    The deficit is settled and the session tally cleared the instant a run
+    closes, but a sensor that only listens to the dryness tick keeps showing
+    the previous state until the next one. The minutes right after a run are
+    exactly when somebody looks: on the field install the deficit read 0.34 mm
+    for three minutes after the model had settled it to zero (pino,
+    2026-09-10), which reads as the irrigation having achieved nothing.
+    """
+
+    @staticmethod
+    def _sensor_that_records_writes(cls, zone):
+        sensor = cls(zone)
+        sensor.hass = MagicMock()
+        writes = []
+        sensor.async_write_ha_state = lambda: writes.append(True)
+        return sensor, writes
+
+    def test_the_deficit_refreshes_when_the_session_closes(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        _sensor, writes = self._sensor_that_records_writes(ZoneDeficitSensor, zone)
+
+        zone.notify_session_listeners()
+
+        assert writes, "the deficit waited for the next tick to show a settled run"
+
+    def test_the_session_tally_refreshes_when_the_session_closes(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        _sensor, writes = self._sensor_that_records_writes(ZoneSessionWaterSensor, zone)
+
+        zone.notify_session_listeners()
+
+        assert writes, "the zero written at the close would not be seen until the next tick"
+
+    def test_a_closed_session_leaves_its_water_in_last_volume_not_in_the_tally(self, di_sensor):
+        """Where the delivered figure lives after the run, and where it does not."""
+        zone = _make_zone(di_sensor)
+        zone._zone_deficit = 10.0
+        # As a flow-metered run leaves it: the tally has been rising live.
+        zone._session_water_delivered = 12.0
+
+        zone.settle_cycle(20.0, source="automatic", at=datetime(2026, 9, 10, 8, 46), duration_s=82)
+
+        assert zone._last_volume_delivered == pytest.approx(20.0)
+        assert zone._session_water_delivered == 0.0, "a running total outlived the run"
 
 
 class TestZoneDeficitSensorProperties:

--- a/tests/test_zone_deficit_sensor.py
+++ b/tests/test_zone_deficit_sensor.py
@@ -17,6 +17,7 @@ from never_dry.const import (
 from never_dry.sensor import (
     IrrigationZoneSensor,
     ZoneDeficitSensor,
+    ZoneDurationSensor,
     ZoneRainSensor,
     ZoneSessionWaterSensor,
     ZoneYearlyWaterSensor,
@@ -89,6 +90,41 @@ class TestTheCardIsToldWhenASessionEnds:
 
         assert zone._last_volume_delivered == pytest.approx(20.0)
         assert zone._session_water_delivered == 0.0, "a running total outlived the run"
+
+
+class TestACompletedRunTellsTheCardToo:
+    """The branch a successful delivery takes was the silent one.
+
+    ``_settle_irrigated_zones`` splits: a partial run settles through the zone
+    and notifies, a full one resets the deficit and did not. So the figures
+    that change at a close refreshed on every interrupted irrigation and on no
+    completed one, which is the case that happens every day.
+    """
+
+    def test_a_full_delivery_notifies_the_session_channel(self, di_sensor):
+        zone = _make_zone(di_sensor)
+        zone._zone_deficit = 10.0
+        fired = []
+        zone.register_session_listener(lambda: fired.append(True))
+
+        zone.reset_deficit("automatic", delivered_liters=222.0, duration_s=82)
+
+        assert fired, "a completed irrigation left the card showing the deficit it had just paid"
+
+    def test_the_expected_duration_reads_zero_once_the_zone_is_full(self, di_sensor):
+        """What the user sees, not merely what the model holds."""
+        zone = _make_zone(di_sensor)
+        zone._zone_deficit = 10.0
+        sensor = ZoneDurationSensor(zone)
+        sensor.hass = MagicMock()
+        written = []
+        sensor.async_write_ha_state = lambda: written.append(sensor.native_value)
+
+        assert sensor.native_value > 0
+        zone.reset_deficit("automatic", delivered_liters=222.0, duration_s=82)
+
+        assert sensor.native_value == 0
+        assert written and written[-1] == 0, "the zero was reached but never written out"
 
 
 class TestZoneDeficitSensorProperties:

--- a/tests/test_zone_domain.py
+++ b/tests/test_zone_domain.py
@@ -194,9 +194,21 @@ class TestWaterCounters:
         counters = WaterCounters()
         counters.credit(120.0, year=2026)
         assert counters.last_volume_l == 120.0
-        assert counters.session_water_l == 120.0
         assert counters.total_water_l == 120.0
         assert counters.yearly_water_l == 120.0
+        assert counters.session_water_l == 0.0, "crediting is not what makes a session's running total"
+
+    def test_ending_a_session_clears_only_its_running_total(self):
+        """What the run delivered survives in ``last_volume_l``; the tally does not."""
+        counters = WaterCounters()
+        counters.session_water_l = 18.0
+        counters.credit(120.0, year=2026)
+
+        counters.end_session()
+
+        assert counters.session_water_l == 0.0
+        assert counters.last_volume_l == 120.0
+        assert counters.total_water_l == 120.0
 
     def test_lifetime_accumulates_while_last_is_replaced(self):
         counters = WaterCounters()

--- a/tests/test_zone_settle_wiring.py
+++ b/tests/test_zone_settle_wiring.py
@@ -68,8 +68,8 @@ class TestPartialDeliverySettlesThroughTheZone:
         _settle_partial(controller, zone, delivered=20.0, target=50.0)
 
         assert zone._last_volume_delivered == 20.0
-        assert zone._session_water_delivered == 20.0
         assert zone._total_water_delivered == 20.0
+        assert zone._session_water_delivered == 0.0, "the run is over, so its running total is too"
         assert zone._yearly_water_delivered == 20.0
         assert zone._last_irrigation_source == "automatic"
         assert zone._last_irrigated is not None
@@ -186,7 +186,8 @@ class TestManualSessionSettlesThroughTheZone:
 
         assert zone._last_irrigation_source == "manual"
         assert zone._total_water_delivered > 0
-        assert zone._session_water_delivered > 0
+        assert zone._last_volume_delivered > 0
+        assert zone._session_water_delivered == 0.0
 
     def test_a_close_never_clears_the_whole_deficit(self, hass_mock, di_sensor):
         """The rule this path exists to keep: only mark_irrigated zeroes it."""

--- a/tools/build_valve_table.py
+++ b/tools/build_valve_table.py
@@ -43,6 +43,44 @@ _TIERS = {
     "timer-only": "no delivery measurement, so NeverDry runs it on a clock",
 }
 
+# The longest window still worth waiting for before a guard stops being a guard, mirroring
+# FLOW_VERIFY_MAX_S in driver.py. A meter may only supervise an opening if a full reporting
+# interval, plus the margin the driver applies, fits inside it.
+_MAX_USEFUL_WINDOW_S = 180.0
+_WINDOW_MARGIN = 1.5
+
+
+def _guards_openings(row: dict[str, str]) -> bool | None:
+    """Whether this meter can tell a dry pipe from a counter that has not spoken yet.
+
+    ``None`` while the cadence is unmeasured, which is not the same as "no": it means
+    the quantity that decides has not been established for this firmware.
+
+    Not a column anyone types. A meter's ability to supervise an opening follows from
+    how often it reports, and a row where the two disagreed would be the hand-written
+    verdict this generator exists to abolish.
+    """
+    raw = (row.get("meter_update_s") or "").strip().lstrip("~")
+    if not raw:
+        return None
+    try:
+        cadence = float(raw)
+    except ValueError:
+        return None
+    return cadence * _WINDOW_MARGIN <= _MAX_USEFUL_WINDOW_S
+
+
+def _reporting(row: dict[str, str]) -> str:
+    """How this meter speaks, as one cell: the cadence and what kind of clock it is."""
+    cadence = (row.get("meter_update_s") or "").strip()
+    kind = (row.get("meter_update_kind") or "").strip()
+    step = (row.get("meter_resolution_l") or "").strip()
+    if kind == "volume":
+        return f"per volume ({step} L steps)" if step else "per volume"
+    if kind == "periodic":
+        return f"on a clock, ~{cadence} s" if cadence else "on a clock"
+    return "-"
+
 
 def _verdict(row: dict[str, str]) -> tuple[str, str]:
     """Return ``(tier, reason)`` for one CSV row."""
@@ -62,13 +100,27 @@ def _verdict(row: dict[str, str]) -> tuple[str, str]:
         evidence.append(f"{row['volume_aggregate']} counter only")
 
     # A caveat that touches the delivery measurement is not a footnote: it is the difference
-    # between a number you can trust and one you cannot. It costs the row its top tier.
+    # between a number you can trust and one you cannot. It costs the row its top tier, and
+    # a row can carry more than one, so they accumulate rather than shadow each other.
+    caveats = []
+    if _guards_openings(row) is False:
+        # A meter reporting on a clock delivers its count late and in coarse jumps, so it can
+        # neither supervise an opening nor stop a dose precisely. That is what the field
+        # failure of 2026-09-08 cost, and a table calling such a row "good" would repeat it.
+        cadence = (row.get("meter_update_s") or "").strip()
+        caveats.append(
+            f"it reports every ~{cadence} s on a clock, too late to supervise an opening, "
+            f"and the dose lands in steps that size"
+        )
     if row["caveat"] == "unit_change":
-        return "partial", f"{', '.join(evidence)}, but the firmware can change its own counter units"
+        caveats.append("the firmware can change its own counter units")
     if not has_session and has_aggregate:
-        return "partial", f"{', '.join(evidence)}, subject to the calendar-reset caveat"
+        caveats.append("it is subject to the calendar-reset caveat")
     if row["needs_config"] not in ("", "none") and row["needs_config"] != "history":
-        return "partial", f"{', '.join(evidence)}, reachable only after a documented step"
+        caveats.append("it is reachable only after a documented step")
+
+    if caveats:
+        return "partial", f"{', '.join(evidence)}, but {'; and '.join(caveats)}"
     return "good", ", ".join(evidence)
 
 
@@ -82,9 +134,9 @@ def _cell(value: str) -> str:
 def render() -> str:
     rows = list(csv.DictReader(_CSV.open(encoding="utf-8")))
     out = [
-        "| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | History | "
-        "Needs config? | Verdict | Why | LoD | By |",
-        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+        "| Vendor / model | Firmware | Via | Valve | Flow rate | Volume counters | Meter reports | "
+        "History | Needs config? | Verdict | Why | LoD | By |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for row in rows:
         tier, reason = _verdict(row)
@@ -100,6 +152,7 @@ def render() -> str:
             f"| {row['via']} | `{row['valve_domain']}.*` "
             f"| {_cell(row['flow_rate'])} "
             f"| {'✅ ' + ' + '.join(counters) if counters else '❌'} "
+            f"| {_reporting(row)} "
             f"| {_cell(row['history'])} | {_cell(row['needs_config'])} "
             f"| **{tier}** | {reason} | {_cell(row['lod'])} | {row['reported_by']} |"
         )


### PR DESCRIPTION
## What this is

A field failure and its fix. On 2026-09-08 a healthy valve was closed mid-session
and the log recorded it as a device fault. The valve was fine: the flow-verification
window was a constant chosen against the wrong quantity.

A SONOFF SWV-ZFE publishes its volume counter on a **fixed 300 s clock**, not once
per litre delivered (measured: mean 300.2 s, sd 1.1 s). The window was derived from
`resolution / flow rate`, which describes the other kind of meter entirely, and in the
unknown-resolution branch it fell back to a 90 s constant. Against a 300 s cadence a
90 s window passes 90/300 of the time, so roughly 7 openings in 10 were refused. Four
of five observed sessions failed, which matches.

The valve was healthy throughout: it reported `actual_irrigation_amount = 6` L itself,
`valve_abnormal_state = normal`, and the counter rose by 8 L three and a half minutes
after the close.

## The rule this restores

`docs/design/flow-rate-provenance.md` already states it, and the code did not follow it:

> a still meter qualifies an action, it never refuses one

## Commits

| | |
|---|---|
| `3fbbdad` | the meter observes the zone, it does not judge it. `flow_guard` separated from `flow_sensor_entity_id`, so a meter can inform without holding a veto; the window derives from the measured cadence; `FLOW_VERIFY_UNKNOWN_RESOLUTION_S = 90.0` removed. No cadence means no threshold, so no guard. |
| `3ebb813` | warn when a zone points at another zone's meter, decided on the device registry rather than on names. |
| `db92266` | the card shows what a zone doses by, which meter it uses and how often that meter speaks. |
| `04ef539` | the post-close wait follows the meter instead of a 30 s constant, so the closing tick is not missed. |
| `e3f65d3` | the other half of the contract: who answers for the water once it has run (T2, T7, T8, T12). |
| `1e6daa9` | a refusal of ours no longer costs the zone its water, and `FLOW_UNVERIFIABLE` gets its first test. |

## Design decisions

**The guard stays a gate, with the device's threshold.** The alternative considered was
a guard that never closes. Protection against a dry pipe survives; the accepted residual
risk is a meter that changes cadence over time.

**A cadence too long to guard steps aside rather than growing.** Stretching the window
to 300 s would make "commanded but dry" take five minutes to notice, and that detection
is the only reason the guard exists.

**Credit never depends on the verification's outcome**, and what is credited is what the
meter finally reports, never an estimate. A genuinely dry pipe therefore credits nothing,
which is what keeps the guard meaningful.

**A meter on another device is a warning, not a refusal.** An inline flow meter on the
supply line is a legitimate installation, and the project consumes Home Assistant
entities without dictating the plumbing.

## Known limits, recorded

- `volume_preset` is not guarded on the live path: the controller bypasses the driver on
  purpose for smart valves that drive their own state. The divergence is written into a
  test rather than left as a belief (AI-346).
- `_deliver_flow_rate` has no cumulative baseline, so the deferred credit does not apply
  to rate-only sensors yet (AI-347).
- Four zones are in a transitional window: the guard stands down on each until that zone
  has measured its meter's cadence, which takes one session.

## Verification

1733 passed, 1 skipped. `ruff check` and `ruff format --check` clean. Every new
assertion was checked against a deliberately broken build first, so none of them passes
by describing the code instead of the contract.

Field confirmation is still pending: the fix is installed on the maintainer's
installation and two sessions are scheduled tonight.

## The design notes, corrected

The notes described a mechanism covering half the cases and stated a rule the code did
not follow in the other half. Four corrected, one written:

- **`flow-rate-provenance.md`** stays Accepted: the decision never changed, its coverage
  was not what the document claimed. The third defect in the "silence is not absence"
  family now sits beside the two it repeated, and a new section separates a counter's
  **resolution** from its **reporting cadence**, which had been read as one quantity.
  That conflation is the whole failure in one line.
- **`valve-state-machine.md`** disagreed with the code in two places and hid a third by
  omission: `FLOW_UNVERIFIABLE` appears now in the diagram and in both tables, where its
  absence left `ACTUATION_FAILED` reading as the only possible outcome of a silent meter.
- **`delivery-contract.md`** is new and **Proposed (RFC)**. It closes with what holds
  today and what does not, because two of its clauses are not implemented.
- **`design_water_balance_reference_model.md`**: its ownership table still said the VWC
  sensor was system-level pending AI-174. A zone binds its own probe today. The row also
  implied `field_capacity` and `root_depth` were system-level parameters; they are not
  parameters at all, being absent from every form and fixed at 0.30 / 0.30.
- **The valve register** rated the SWV-ZFE **good**, which is the device whose 300 s
  reporting clock caused this failure. Everything the table looked at was excellent; it
  was not looking at *when* the counter speaks. The verdict rule now reads the cadence.

## Not translated, and not new

No translation keys are added or changed by these commits. The card strings introduced
with the meter cell are complete in all three languages and guarded by the existing
parity test. The config-flow warning added here is composed in Python as an English
sentence, like every other soft-confirm warning in that file: a pre-existing gap tracked
as AI-315, which this adds one member to rather than creating.
